### PR TITLE
Added box building for stand-alone phar

### DIFF
--- a/bin/versionscan
+++ b/bin/versionscan
@@ -9,8 +9,14 @@ set_time_limit(0);
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
+$version = '@package_version@';
+if (strpos($version, 'package_version') !== false)
+{
+	$version = 'src';
+}
+
 $output = new ConsoleOutput();
-$app = new Application('INI Scan', '0.1');
+$app = new Application('INI Scan', $version);
 $app->addCommands(array(
     new \Psecio\Versionscan\Command\ScanCommand(),
 ));

--- a/box.json
+++ b/box.json
@@ -1,0 +1,28 @@
+{
+	"directories": ["src/"],
+	"finder": [
+		{
+			"name": "*.php",
+			"exclude": [
+				".gitignore",
+				".md",
+				"phpunit",
+				"Tester",
+				"Tests",
+				"tests",
+				"yaml"
+			],
+			"in": "vendor"
+		}
+	],
+	"compactors": [
+		"Herrera\\Box\\Compactor\\Json",
+		"Herrera\\Box\\Compactor\\Php"
+	],
+	"compression": "GZ",
+	"git-version": "package_version",
+	"main": "bin/versionscan",
+	"output": "versionscan.phar",
+	"stub": true,
+	"chmod": "0755"
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "php":">=5.3.1",
         "symfony/console": "~2.1"
     },
+    "require-dev": {
+        "kherge/box": "~2.4"
+    },
     "autoload": {
         "psr-0": {
             "Psecio": "src/"


### PR DESCRIPTION
Since this is quite a self-contained tool, I've added phar construction using http://box-project.org/ as an option.

Feel free to toss if you're not interested (adds a bunch of dev dependencies, unless you grab the box.phar directly).

Builds to a nice compact phar with this command:

$ cd /path/to/project/
$ ./vendor/kherge/box/bin/box build
