### PR TITLE
Output formats

### DIFF
--- a/src/Psecio/Versionscan/Command/Output.php
+++ b/src/Psecio/Versionscan/Command/Output.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Psecio\Versionscan\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+abstract class Output
+{
+    /**
+     * Output object
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    private $output;
+
+    /**
+     * Output options
+     * @var array
+     */
+    private $options;
+
+    /**
+     * Init the object and set output and options (if given)
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Output object
+     * @param array $options Output options
+     */
+    public function __construct(
+        \Symfony\Component\Console\Output\OutputInterface $output,
+        $options = array()
+    ) {
+        $this->setOutput($output);
+        $this->setOptions($options);
+    }
+
+    /**
+     * Set the Output object instance
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Object instance
+     */
+    public function setOutput(\Symfony\Component\Console\Output\OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Get the Output instance
+     *
+     * @return object Output instance
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    /**
+     * Set the output options
+     *
+     * @param array $options Set of options
+     */
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Get the current set of options
+     *
+     * @return array Options set
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Get a single option
+     *
+     * @param string $optionName Name of option to find
+     * @return mixed Either the option value if found or null
+     */
+    public function getOption($optionName)
+    {
+        return (isset($this->options[$optionName]))
+            ? $this->options[$optionName] : null;
+    }
+
+    /**
+     * Render the results of the scan
+     *
+     * @param array $results Set of scan results
+     * @param \Symfony\Component\Console\Command\Command $command
+     */
+    abstract public function render($results, Command $command);
+}

--- a/src/Psecio/Versionscan/Command/ScanCommand.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand.php
@@ -36,8 +36,10 @@ class ScanCommand extends Command
         $phpVersion = $input->getOption('php-version');
         $failOnly = $input->getOption('fail-only');
         $sort = $input->getOption('sort');
-        $format = $input->getOption('format');
         $outputPath = $input->getOption('output');
+
+        $format = $input->getOption('format');
+        $format = $format === null ? 'console' : strtolower($format);
 
         if ($format === 'html' && $outputPath === null) {
             throw new \InvalidArgumentException('Output path must be set for format "HTML"');
@@ -92,7 +94,6 @@ class ScanCommand extends Command
             'outputPath'  => $outputPath,
         );
 
-        $format = $format === null ? 'console' : strtolower($format);
         $formatClass = '\\Psecio\\Versionscan\\Command\\ScanCommand\\Output\\' . ucwords($format);
         if (!class_exists($formatClass)) {
             throw new FormatNotFoundException(sprintf('Output format "%s" not found', $format));

--- a/src/Psecio/Versionscan/Command/ScanCommand.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand.php
@@ -5,6 +5,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Psecio\Versionscan\Exceptions\FormatNotFoundException;
 
 class ScanCommand extends Command
 {
@@ -15,7 +16,9 @@ class ScanCommand extends Command
             ->setDefinition(array(
                 new InputOption('php-version', 'php-version', InputOption::VALUE_OPTIONAL, 'PHP version to check'),
                 new InputOption('fail-only', 'fail-only', InputOption::VALUE_NONE, 'Show only failures'),
-                new InputOption('sort', 'sort', InputOption::VALUE_OPTIONAL, 'Sort Results By Column (cve, risk)')
+                new InputOption('sort', 'sort', InputOption::VALUE_OPTIONAL, 'Sort Results By Column (cve, risk)'),
+                new InputOption('format', 'format', InputOption::VALUE_OPTIONAL, 'Output format'),
+                new InputOption('output', 'output', InputOption::VALUE_OPTIONAL, 'Directory for file output types'),
             ))
             ->setHelp(
                 'Execute the scan on the current PHP version'
@@ -33,75 +36,70 @@ class ScanCommand extends Command
         $phpVersion = $input->getOption('php-version');
         $failOnly = $input->getOption('fail-only');
         $sort = $input->getOption('sort');
+        $format = $input->getOption('format');
+        $outputPath = $input->getOption('output');
+
+        if ($format === 'html' && $outputPath === null) {
+            throw new \InvalidArgumentException('Output path must be set for format "HTML"');
+        }
 
         $scan = new \Psecio\Versionscan\Scan();
         $scan->execute($phpVersion);
 
-        $output->writeLn('Executing against version: '.$scan->getVersion());
-
-        $failedCount = 0;
-
-        $table = $this->getApplication()->getHelperSet()->get('table');
-        $table->setHeaders(array('Status', 'CVE ID', 'Risk', 'Summary'));
-
-        $data = array();
-        $column = 100;
+        $results = array();
+        $failCount = 0;
 
         foreach ($scan->getChecks() as $check) {
             if ($failOnly !== null && $check->getResult() !== true) {
                 continue;
             }
 
-            if ($check->getResult() === true) {
-                $status = '<fg=red>FAIL</fg=red>';
-                $failedCount++;
-            } else {
-                $status = '<fg=green>PASS</fg=green>';
+            $status = $check->getResult() === true ? 'fail' : 'pass';
+            if ($status === 'fail') {
+                $failCount++;
             }
 
-            if ($output->isVerbose() === true) {
-                $summary = trim($check->getSummary());
-            } else {
-                $summary = (strlen($check->getSummary()) > $column
-                    ? substr($check->getSummary(), 0, $column-3) . '...' : $check->getSummary());
-            }
-
-            $data[] = array(
-                $status,
-                $check->getCveId(),
-                $check->getThreat(),
-                $summary,
+            $results[] = array(
+                'status'  => $status,
+                'cve-id'  => $check->getCveId(),
+                'risk'    => $check->getThreat(),
+                'summary' => trim($check->getSummary()),
             );
         }
 
         if ($sort !== false) {
-            usort($data, function($row1, $row2) use ($sort) {
+            usort($results, function($row1, $row2) use ($sort) {
                 $sort = strtolower($sort);
 
                 if ($sort == 'cve') {
-                    $r1 = str_replace(array('CVE', '-'), '', $row1[1]);
-                    $r2 = str_replace(array('CVE', '-'), '', $row2[1]);
+                    $r1 = str_replace(array('CVE', '-'), '', $row1['cve-id']);
+                    $r2 = str_replace(array('CVE', '-'), '', $row2['cve-id']);
 
-                    return ($r1 > $r2) ? -1 : 1;
+                    return $r1 > $r2 ? -1 : 1;
                 } elseif ($sort == 'risk') {
-                    $r1 = (integer)$row1[2];
-                    $r2 = (integer)$row2[2];
+                    $r1 = (integer) $row1['risk'];
+                    $r2 = (integer) $row2['risk'];
 
-                    return ($r1 > $r2) ? -1 : 1;
+                    return $r1 > $r2 ? -1 : 1;
                 }
             });
         }
 
-        $table->setRows($data);
-        $table->render($output);
-
-        $output->writeLn(
-            "\nScan complete\n"
-            .str_repeat('-', 20)."\n"
-            ."Total checks: ".count($scan->getChecks())."\n"
-            ."<fg=red>Failures: ".$failedCount."</fg=red>\n"
+        $options = array(
+            'phpVersion'  => $scan->getVersion(),
+            'checksCount' => count($scan->getChecks()),
+            'failCount'   => $failCount,
+            'outputPath'  => $outputPath,
         );
+
+        $format = $format === null ? 'console' : strtolower($format);
+        $formatClass = '\\Psecio\\Versionscan\\Command\\ScanCommand\\Output\\' . ucwords($format);
+        if (!class_exists($formatClass)) {
+            throw new FormatNotFoundException(sprintf('Output format "%s" not found', $format));
+        }
+
+        $outputHandler = new $formatClass($output, $options);
+
+        return $outputHandler->render($results, $this);
     }
 }
-
-?>

--- a/src/Psecio/Versionscan/Command/ScanCommand/Output/Console.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand/Output/Console.php
@@ -19,13 +19,12 @@ class Console extends Output
         $table = $command->getHelper('table');
         $table->setHeaders(array('Status', 'CVE ID', 'Risk', 'Summary'));
 
-        $rows = array();
-        $column = 100;
+        $columnSize = 100;
 
         for ($i = 0, $length = count($results); $i < $length; $i++) {
             $results[$i]['status'] = 'fail' ? '<fg=red>FAIL</fg=red>' : '<fg=green>PASS</fg=green>';
-            $results[$i]['summary'] = !$output->isVerbose() && strlen($results[$i]['summary']) > $column
-                ? substr($results[$i]['summary'], 0, $column - 3) . '...'
+            $results[$i]['summary'] = !$output->isVerbose() && strlen($results[$i]['summary']) > $columnSize
+                ? substr($results[$i]['summary'], 0, $columnSize - 3) . '...'
                 : $results[$i]['summary'];
         }
 

--- a/src/Psecio/Versionscan/Command/ScanCommand/Output/Console.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand/Output/Console.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Psecio\Versionscan\Command\ScanCommand\Output;
+
+use Psecio\Versionscan\Command\Output;
+use Symfony\Component\Console\Command\Command;
+
+class Console extends Output
+{
+    public function render($results, Command $command)
+    {
+        $phpVersion = $this->getOption('phpVersion');
+        $checksCount = $this->getOption('checksCount');
+        $failCount = $this->getOption('failCount');
+        $output = $this->getOutput();
+
+        $output->writeLn('Executing against version: ' . $phpVersion);
+
+        $table = $command->getHelper('table');
+        $table->setHeaders(array('Status', 'CVE ID', 'Risk', 'Summary'));
+
+        $rows = array();
+        $column = 100;
+
+        for ($i = 0, $length = count($results); $i < $length; $i++) {
+            $results[$i]['status'] = 'fail' ? '<fg=red>FAIL</fg=red>' : '<fg=green>PASS</fg=green>';
+            $results[$i]['summary'] = !$output->isVerbose() && strlen($results[$i]['summary']) > $column
+                ? substr($results[$i]['summary'], 0, $column - 3) . '...'
+                : $results[$i]['summary'];
+        }
+
+        $table->setRows($results);
+        $table->render($output);
+
+        $output->writeLn(sprintf(
+            "\nScan complete\n%s\nTotal checks: %s\n<fg=red>Failures: %s</fg=red>\n",
+            str_repeat('-', 20),
+            $checksCount,
+            $failCount
+        ));
+    }
+}

--- a/src/Psecio/Versionscan/Command/ScanCommand/Output/Html.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand/Output/Html.php
@@ -1,0 +1,49 @@
+<?php
+namespace Psecio\Versionscan\Command\ScanCommand\Output;
+
+use Psecio\Versionscan\Command\Output;
+use Symfony\Component\Console\Command\Command;
+
+class Html extends Output
+{
+    public function render($results, Command $command)
+    {
+        $output = $this->getOption('outputPath');
+
+        if (!is_writable($output)) {
+            throw new \RuntimeException(sprintf('Ouput path "%s" is not writable', $output));
+        }
+
+        $values = array(
+            'date' => date('m.d.Y H:i:s'),
+            'results' => ''
+        );
+
+        foreach ($results as $result) {
+            $values['results'] .=  sprintf(
+                '<div class="result %1$s">
+                    <table cellpadding="2" cellspacing="0" border="0" class="result">
+                        <tr>
+                            <td class="key"><a href="http://www.cvedetails.com/cve/%2$s/">%2$s</a></td>
+                            <td class="risk">%3$s</td>
+                            <td>%4$s</td>
+                        </tr>
+                    </table>
+                </div>
+                <br/>',
+                $result['status'],
+                $result['cve-id'],
+                $result['risk'],
+                $result['summary']
+            );
+        }
+
+        $template = file_get_contents(__DIR__ . '/../Templates/html.html');
+        foreach ($values as $key => $value) {
+            $template = str_replace('{{' . $key . '}}', $value, $template);
+        }
+
+        $output = sprintf('%s/versionscan-output-%s.html', rtrim($output, '/'), date('Ymd'));
+        file_put_contents($output, $template);
+    }
+}

--- a/src/Psecio/Versionscan/Command/ScanCommand/Output/Json.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand/Output/Json.php
@@ -1,0 +1,15 @@
+<?php
+namespace Psecio\Versionscan\Command\ScanCommand\Output;
+
+use Psecio\Versionscan\Command\Output;
+use Symfony\Component\Console\Command\Command;
+
+class Json extends Output
+{
+    public function render($results, Command $command)
+    {
+        $output = $this->getOutput();
+
+        $output->writeLn(json_encode(array('results' => $results)));
+    }
+}

--- a/src/Psecio/Versionscan/Command/ScanCommand/Output/Xml.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand/Output/Xml.php
@@ -1,0 +1,34 @@
+<?php
+namespace Psecio\Versionscan\Command\ScanCommand\Output;
+
+use Psecio\Versionscan\Command\Output;
+use Symfony\Component\Console\Command\Command;
+
+class Xml extends Output
+{
+    public function render($results, Command $command)
+    {
+        $output = $this->getOutput();
+
+        $resultValues = $results;
+
+        $dom = new \DomDocument('1.0', 'UTF-8');
+
+        $results = $dom->createElement('results');
+
+        foreach ($resultValues as $result) {
+            $resultXml = $dom->createElement('result');
+
+            foreach ($result as $name => $value) {
+                $property = $dom->createElement($name, $value);
+                $resultXml->appendChild($property);
+            }
+
+            $results->appendChild($resultXml);
+        }
+
+        $dom->appendChild($results);
+
+        $output->writeLn($dom->saveXML());
+    }
+}

--- a/src/Psecio/Versionscan/Command/ScanCommand/Templates/html.html
+++ b/src/Psecio/Versionscan/Command/ScanCommand/Templates/html.html
@@ -1,0 +1,60 @@
+<html>
+    <head>
+        <title>VersionScan Results - {{date}}</title>
+        <style>
+            body {
+                font-family: verdana, arial;
+                font-size: 12px;
+                background-color: #EEEEEE;
+            }
+            .container {
+                text-align: center;
+            }
+            .result {
+                width: 500px;
+            }
+            .result tr td {
+                border: 0px solid #000000;
+                color: #FFFFFF;
+                padding: 7px;
+                font-size: 11px;
+                vertical-align: top;
+            }
+            .result tr td.key {
+                width: 90px;
+            }
+            .result tr td.key a,
+            .result tr td.key a:hover,
+            .result tr td.key a:active {
+                color: #FFFFFF;
+            }
+            .result tr td.risk {
+                width: 20px;
+            }
+            .header tr td {
+                background-color: #838383;
+            }
+            .fail {
+                background-color: #830000;
+            }
+            .pass {
+                background-color: #1E8A00;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <center>
+                <h2>VersionScan Results - {{date}}</h2>
+                <table class="result header">
+                    <tr>
+                        <td class="key">CVE ID</td>
+                        <td class="risk">Risk</td>
+                        <td>Summary</td>
+                    </tr>
+                </table>
+                {{results}}
+            </center>
+        </div>
+    </body>
+</html>

--- a/src/Psecio/Versionscan/Exceptions/FormatNotFoundException.php
+++ b/src/Psecio/Versionscan/Exceptions/FormatNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Psecio\Versionscan\Exceptions;
+
+class FormatNotFoundException extends \Exception
+{
+    protected $message = 'The format given is either incorrect or not found';
+}


### PR DESCRIPTION
Feature on issue #16 

# Implementation

Using psecio/iniscan as example I've added output formatting: `console`, `html` (same constraints as iniscan), `json` and `xml`

Default format is `console`

# Additionally

once this is merged I'll update [grunt-versionscan](https://www.npmjs.com/package/grunt-versionscan) grunt plugin to use this output formats