### PR TITLE
More changes

### DIFF
--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -1042,6 +1042,16 @@
             }
         },
         {
+            "threat": "2.1",
+            "cveid": "CVE-2006-7204",
+            "summary": "The imap_body function in PHP before 4.4.4 does not implement safemode or open_basedir checks, which allows local users to read arbitrary files or list arbitrary directory contents.",
+            "fixVersions": {
+                "base": [
+                    "4.4.4"
+                ]
+            }
+        },
+        {
             "threat": "5.0",
             "cveid": "CVE-2006-7243",
             "summary": "PHP before 5.3.4 accepts the \\0 character in a pathname, which might allow context-dependent attackers to bypass intended access restrictions by placing a safe file extension after this character, as demonstrated by .php\\0.jpg at the end of the argument to the file_exists function.",
@@ -1060,6 +1070,145 @@
             }
         },
         {
+            "threat": "10.0",
+            "cveid": "CVE-2007-0448",
+            "summary": "The fopen function in PHP 5.2.0 does not properly handle invalid URI handlers, which allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files via a file path specified with an invalid URI, as demonstrated via the srpath URI.",
+            "fixVersions": {
+                "base": [
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-0905",
+            "summary": "PHP before 5.2.1 allows attackers to bypass safe_mode and open_basedir restrictions via unspecified vectors in the session extension.  NOTE: it is possible that this issue is a duplicate of CVE-2006-6383.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-0906",
+            "summary": "Multiple buffer overflows in PHP before 5.2.1 allow attackers to cause a denial of service and possibly execute arbitrary code via unspecified vectors in the (1) session, (2) zip, (3) imap, and (4) sqlite extensions; (5) stream filters; and the (6) str_replace, (7) mail, (8) ibase_delete_user, (9) ibase_add_user, and (10) ibase_modify_user functions.  NOTE: vector 6 might actually be an integer overflow (CVE-2007-1885).  NOTE: as of 20070411, vector (3) might involve the imap_mail_compose function (CVE-2007-1825).",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-0907",
+            "summary": "Buffer underflow in PHP before 5.2.1 allows attackers to cause a denial of service via unspecified vectors involving the sapi_header_op function.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-0908",
+            "summary": "The WDDX deserializer in the wddx extension in PHP 5 before 5.2.1 and PHP 4 before 4.4.5 does not properly initialize the key_length variable for a numerical key, which allows context-dependent attackers to read stack memory via a wddxPacket element that contains a variable with a string name before a numerical variable.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.4",
+                    "4.2.5",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-0909",
+            "summary": "Multiple format string vulnerabilities in PHP before 5.2.1 might allow attackers to execute arbitrary code via format string specifiers to (1) all of the *print functions on 64-bit systems, and (2) the odbc_result_all function.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "10.0",
+            "cveid": "CVE-2007-0910",
+            "summary": "Unspecified vulnerability in PHP before 5.2.1 allows attackers to \"clobber\" certain super-global variables via unspecified vectors.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.8",
+            "cveid": "CVE-2007-0911",
+            "summary": "Off-by-one error in the str_ireplace function in PHP 5.2.1 might allow context-dependent attackers to cause a denial of service (crash).",
+            "fixVersions": {
+                "base": [
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "4.3",
+            "cveid": "CVE-2007-0988",
+            "summary": "The zend_hash_init function in PHP 5 before 5.2.1 and PHP 4 before 4.4.5, when running on a 64-bit platform, allows context-dependent attackers to cause a denial of service (infinite loop) by unserializing certain integer expressions, which only cause 32-bit arguments to be used after the check for a negative value, as demonstrated by an \"a:2147483649:{\" argument.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.4",
+                    "4.2.5",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
             "threat": "6.8",
             "cveid": "CVE-2007-1001",
             "summary": "Multiple integer overflows in the (1) createwbmp and (2) readwbmp functions in wbmp.c in the GD library (libgd) in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allow context-dependent attackers to execute arbitrary code via Wireless Bitmap (WBMP) images with large width or height values.",
@@ -1073,6 +1222,683 @@
                     "5.0.6",
                     "5.1.7",
                     "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-1285",
+            "summary": "The Zend Engine in PHP 4.x before 4.4.7, and 5.x before 5.2.2, allows remote attackers to cause a denial of service (stack exhaustion and PHP crash) via deeply nested arrays, which trigger deep recursion in the variable destruction routines.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1286",
+            "summary": "Integer overflow in PHP 4.4.4 and earlier allows remote context-dependent attackers to execute arbitrary code via a long string to the unserialize function, which triggers the overflow in the ZVAL reference counter.",
+            "fixVersions": {
+                "base": [
+                    "4.4.5"
+                ]
+            }
+        },
+        {
+            "threat": "4.3",
+            "cveid": "CVE-2007-1287",
+            "summary": "A regression error in the phpinfo function in PHP 4.4.3 to 4.4.6, and PHP 6.0 in CVS, allows remote attackers to conduct cross-site scripting (XSS) attacks via GET, POST, or COOKIE array values, which are not escaped in the phpinfo output, as originally fixed for CVE-2005-3388.",
+            "fixVersions": {
+                "base": [
+                    "4.4.7"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-1375",
+            "summary": "Integer overflow in the substr_compare function in PHP 5.2.1 and earlier allows context-dependent attackers to read sensitive memory via a large value in the length argument, a different vulnerability than CVE-2006-1991.",
+            "fixVersions": {
+                "base": [
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1376",
+            "summary": "The shmop functions in PHP before 4.4.5, and before 5.2.1 in the 5.x series, do not verify that their arguments correspond to a shmop resource, which allows context-dependent attackers to read and write arbitrary memory locations via arguments associated with an inappropriate resource, as demonstrated by a GD Image resource.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.6",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "5.1",
+            "cveid": "CVE-2007-1378",
+            "summary": "The ovrimos_longreadlen function in the Ovrimos extension for PHP before 4.4.5 allows context-dependent attackers to write to arbitrary memory locations via the result_id and length arguments.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5"
+                ]
+            }
+        },
+        {
+            "threat": "5.1",
+            "cveid": "CVE-2007-1379",
+            "summary": "The ovrimos_close function in the Ovrimos extension for PHP before 4.4.5 can trigger efree of an arbitrary address, which might allow context-dependent attackers to execute arbitrary code.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-1380",
+            "summary": "The php_binary serialization handler in the session extension in PHP before 4.4.5, and 5.x before 5.2.1, allows context-dependent attackers to obtain sensitive information (memory contents) via a serialized variable entry with a large length value, which triggers a buffer over-read.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.6",
+            "cveid": "CVE-2007-1381",
+            "summary": "The wddx_deserialize function in wddx.c 1.119.2.10.2.12 and 1.119.2.10.2.13 in PHP 5, as modified in CVS on 20070224 and fixed on 20070304, calls strlcpy where strlcat was intended and uses improper arguments, which allows context-dependent attackers to execute arbitrary code via a WDDX packet with a malformed overlap of a STRING element, which triggers a buffer overflow.",
+            "fixVersions": {
+                "base": [
+                    "5.0.1"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1396",
+            "summary": "The import_request_variables function in PHP 4.0.7 through 4.4.6, and 5.x before 5.2.2, when called without a prefix, does not prevent the (1) GET, (2) POST, (3) COOKIE, (4) FILES, (5) SERVER, (6) SESSION, and other superglobals from being overwritten, which allows remote attackers to spoof source IP address and Referer data, and have other unspecified impact.  NOTE: it could be argued that this is a design limitation of PHP and that only the misuse of this feature, i.e. implementation bugs in applications, should be included in CVE. However, it has been fixed by the vendor.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "10.0",
+            "cveid": "CVE-2007-1399",
+            "summary": "Stack-based buffer overflow in the zip:\/\/ URL wrapper in PECL ZIP 1.8.3 and earlier, as bundled with PHP 5.2.0 and 5.2.1, allows remote attackers to execute arbitrary code via a long zip:\/\/ URL, as demonstrated by actively triggering URL access from a remote PHP interpreter via avatar upload or blog pingback.",
+            "fixVersions": {
+                "base": [
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.9",
+            "cveid": "CVE-2007-1401",
+            "summary": "Buffer overflow in the crack extension (CrackLib), as bundled with PHP 4.4.6 and other versions before 5.0.0, might allow local users to gain privileges via a long argument to the crack_opendict function.",
+            "fixVersions": {
+                "base": [
+                    "4.4.7"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1411",
+            "summary": "Buffer overflow in PHP 4.4.6 and earlier, and unspecified PHP 5 versions, allows local and possibly remote attackers to execute arbitrary code via long server name arguments to the (1) mssql_connect and (2) mssql_pconnect functions.",
+            "fixVersions": {
+                "base": [
+                    "4.4.7",
+                    "5.4.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.8",
+            "cveid": "CVE-2007-1412",
+            "summary": "The cpdf_open function in the ClibPDF (cpdf) extension in PHP 4.4.6 allows context-dependent attackers to obtain sensitive information (script source code) via a long string in the second argument.",
+            "fixVersions": {
+                "base": [
+                    "4.4.7"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1413",
+            "summary": "Buffer overflow in the snmpget function in the snmp extension in PHP 5.2.3 and earlier, including PHP 4.4.6 and probably other PHP 4 versions, allows context-dependent attackers to execute arbitrary code via a long value in the third argument (object id).",
+            "fixVersions": {
+                "base": [
+                    "4.4.7",
+                    "5.2.4"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-1452",
+            "summary": "The FDF support (ext\/fdf) in PHP 5.2.0 and earlier does not implement the input filtering hooks for ext\/filter, which allows remote attackers to bypass web site filters via an application\/vnd.fdf formatted POST.",
+            "fixVersions": {
+                "base": [
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1453",
+            "summary": "Buffer underflow in the PHP_FILTER_TRIM_DEFAULT macro in the filtering extension (ext\/filter) in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by calling filter_var with certain modes such as FILTER_VALIDATE_INT, which causes filter to write a null byte in whitespace that precedes the buffer.",
+            "fixVersions": {
+                "base": [
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "4.3",
+            "cveid": "CVE-2007-1454",
+            "summary": "ext\/filter in PHP 5.2.0, when FILTER_SANITIZE_STRING is used with the FILTER_FLAG_STRIP_LOW flag, does not properly strip HTML tags, which allows remote attackers to conduct cross-site scripting (XSS) attacks via HTML with a '<' character followed by certain whitespace characters, which passes one filter but is collapsed into a valid tag, as demonstrated using %0b.",
+            "fixVersions": {
+                "base": [
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-1460",
+            "summary": "The zip:\/\/ URL wrapper provided by the PECL zip extension in PHP before 4.4.7, and 5.2.0 and 5.2.1, does not implement safemode or open_basedir checks, which allows remote attackers to read ZIP archives located outside of the intended directories.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.8",
+            "cveid": "CVE-2007-1461",
+            "summary": "The compress.bzip2:\/\/ URL wrapper provided by the bz2 extension in PHP before 4.4.7, and 5.x before 5.2.2, does not implement safemode or open_basedir checks, which allows remote attackers to read bzip2 archives located outside of the intended directories.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "5.4",
+            "cveid": "CVE-2007-1475",
+            "summary": "Multiple buffer overflows in the (1) ibase_connect and (2) ibase_pconnect functions in the interbase extension in PHP 4.4.6 and earlier allow context-dependent attackers to execute arbitrary code via a long argument.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7"
+                ]
+            }
+        },
+        {
+            "threat": "4.6",
+            "cveid": "CVE-2007-1484",
+            "summary": "The array_user_key_compare function in PHP 4.4.6 and earlier, and 5.x up to 5.2.1, makes erroneous calls to zval_dtor, which triggers memory corruption and allows local users to bypass safe_mode and execute arbitrary code via a certain unset operation after array_user_key_compare has been called.",
+            "fixVersions": {
+                "base": [
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1521",
+            "summary": "Double free vulnerability in PHP before 4.4.7, and 5.x before 5.2.2, allows context-dependent attackers to execute arbitrary code by interrupting the session_regenerate_id function, as demonstrated by calling a userspace error handler or triggering a memory limit violation.",
+            "fixVersions": {
+                "base": [
+                    "4.4.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1522",
+            "summary": "Double free vulnerability in the session extension in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to execute arbitrary code via illegal characters in a session identifier, which is rejected by an internal session storage module, which calls the session identifier generator with an improper environment, leading to code execution when the generator is interrupted, as demonstrated by triggering a memory limit violation or certain PHP errors.",
+            "fixVersions": {
+                "base": [
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "9.3",
+            "cveid": "CVE-2007-1581",
+            "summary": "The resource system in PHP 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting the hash_update_file function via a userspace (1) error or (2) stream handler, which can then be used to destroy and modify internal resources.  NOTE: it was later reported that PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 are also affected.",
+            "fixVersions": {
+                "base": [
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.14",
+                    "5.3.3"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1582",
+            "summary": "The resource system in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting certain functions in the GD (ext\/gd) extension and unspecified other extensions via a userspace error handler, which can be used to destroy and modify internal resources.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1583",
+            "summary": "The mb_parse_str function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 sets the internal register_globals flag and does not disable it in certain cases when a script terminates, which allows remote attackers to invoke available PHP scripts with register_globals functionality that is not detectable by these scripts, as demonstrated by forcing a memory_limit violation.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1584",
+            "summary": "Buffer underflow in the header function in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by passing an all-whitespace string to this function, which causes it to write '\\0' characters in whitespace that precedes the string.",
+            "fixVersions": {
+                "base": [
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.8",
+            "cveid": "CVE-2007-1649",
+            "summary": "PHP 5.2.1 allows context-dependent attackers to read portions of heap memory by executing certain scripts with a serialized data input string beginning with S:, which does not properly track the number of input bytes being processed.",
+            "fixVersions": {
+                "base": [
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1700",
+            "summary": "The session extension in PHP 4 before 4.4.5, and PHP 5 before 5.2.1, calculates the reference count for the session variables without considering the internal pointer from the session globals, which allows context-dependent attackers to execute arbitrary code via a crafted string in the session_register after unsetting HTTP_SESSION_VARS and _SESSION, which destroys the session data Hashtable.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1701",
+            "summary": "PHP 4 before 4.4.5, and PHP 5 before 5.2.1, when register_globals is enabled, allows context-dependent attackers to execute arbitrary code via deserialization of session data, which overwrites arbitrary global variables, as demonstrated by calling session_decode on a string beginning with \"_SESSION|s:39:\".",
+            "fixVersions": {
+                "base": [
+                    "4.4.5",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "4.3",
+            "cveid": "CVE-2007-1709",
+            "summary": "Buffer overflow in the confirm_phpdoc_compiled function in the phpDOC extension (PECL phpDOC) in PHP 5.2.1 allows context-dependent attackers to execute arbitrary code via a long argument string.",
+            "fixVersions": {
+                "base": [
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "4.3",
+            "cveid": "CVE-2007-1710",
+            "summary": "The readfile function in PHP 4.4.4, 5.1.6, and 5.2.1 allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files by referring to local files with a certain URL syntax instead of a pathname syntax, as demonstrated by a filename preceded a \"php:\/\/..\/..\/\" sequence.",
+            "fixVersions": {
+                "base": [
+                    "4.4.5",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1711",
+            "summary": "Double free vulnerability in the unserializer in PHP 4.4.5 and 4.4.6 allows context-dependent attackers to execute arbitrary code by overwriting variables pointing to (1) the GLOBALS array or (2) the session data in _SESSION.  NOTE: this issue was introduced when attempting to patch CVE-2007-1701 (MOPB-31-2007).",
+            "fixVersions": {
+                "base": [
+                    "4.4.7"
+                ]
+            }
+        },
+        {
+            "threat": "7.8",
+            "cveid": "CVE-2007-1717",
+            "summary": "The mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 truncates e-mail messages at the first ASCIIZ ('\\0') byte, which might allow context-dependent attackers to prevent intended information from being delivered in e-mail messages.  NOTE: this issue might be security-relevant in cases when the trailing contents of e-mail messages are important, such as logging information or if the message is expected to be well-formed.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.8",
+            "cveid": "CVE-2007-1718",
+            "summary": "CRLF injection vulnerability in the mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows remote attackers to inject arbitrary e-mail headers and possibly conduct spam attacks via a control character immediately following folding of the (1) Subject or (2) To parameter, as demonstrated by a parameter containing a \"\\r\\n\\t\\n\" sequence, related to an increment bug in the SKIP_LONG_HEADER_SEP macro.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1777",
+            "summary": "Integer overflow in the zip_read_entry function in PHP 4 before 4.4.5 allows remote attackers to execute arbitrary code via a ZIP archive that contains an entry with a length value of 0xffffffff, which is incremented before use in an emalloc call, triggering a heap overflow.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5"
+                ]
+            }
+        },
+        {
+            "threat": "5.1",
+            "cveid": "CVE-2007-1824",
+            "summary": "Buffer overflow in the php_stream_filter_create function in PHP 5 before 5.2.1 allows remote attackers to cause a denial of service (application crash) via a php:\/\/filter\/ URL that has a name ending in the '.' character.",
+            "fixVersions": {
+                "base": [
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1825",
+            "summary": "Buffer overflow in the imap_mail_compose function in PHP 5 before 5.2.1, and PHP 4 before 4.4.5, allows remote attackers to execute arbitrary code via a long boundary string in a type.parameters field. NOTE: as of 20070411, it appears that this issue might be subsumed by CVE-2007-0906.3.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "4.6",
+            "cveid": "CVE-2007-1835",
+            "summary": "PHP 4 before 4.4.5 and PHP 5 before 5.2.1, when using an empty session save path (session.save_path), uses the TMPDIR default after checking the restrictions, which allows local users to bypass open_basedir restrictions.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1864",
+            "summary": "Buffer overflow in the bundled libxmlrpc library in PHP before 4.4.7, and 5.x before 5.2.2, has unknown impact and remote attack vectors.",
+            "fixVersions": {
+                "base": [
+                    "4.4.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.8",
+            "cveid": "CVE-2007-1883",
+            "summary": "PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to read arbitrary memory locations via an interruption that triggers a user space error handler that changes a parameter to an arbitrary pointer, as demonstrated via the iptcembed function, which calls certain convert_to_* functions with its input parameters.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1884",
+            "summary": "Multiple integer signedness errors in the printf function family in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 on 64 bit machines allow context-dependent attackers to execute arbitrary code via (1) certain negative argument numbers that arise in the php_formatted_print function because of 64 to 32 bit truncation, and bypass a check for the maximum allowable value; and (2) a width and precision of -1, which make it possible for the php_sprintf_appendstring function to place an internal buffer at an arbitrary memory location.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1885",
+            "summary": "Integer overflow in the str_replace function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via a single character search string in conjunction with a long replacement string, which overflows a 32 bit length counter.  NOTE: this is probably the same issue as CVE-2007-0906.6.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2007-1886",
+            "summary": "Integer overflow in the str_replace function in PHP 4.4.5 and PHP 5.2.1 allows context-dependent attackers to have an unknown impact via a single character search string in conjunction with a single character replacement string, which causes an \"off by one overflow.\"",
+            "fixVersions": {
+                "base": [
+                    "4.4.6",
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1887",
+            "summary": "Buffer overflow in the sqlite_decode_binary function in the bundled sqlite library in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter, as demonstrated by calling the sqlite_udf_decode_binary function with a 0x01 character.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1888",
+            "summary": "Buffer overflow in the sqlite_decode_binary function in src\/encode.c in SQLite 2, as used by PHP 4.x through 5.x and other applications, allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter.  NOTE: some PHP installations use a bundled version of sqlite without this vulnerability.  The SQLite developer has argued that this issue could be due to a misuse of the sqlite_decode_binary() API.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.2",
+                    "5.4.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1889",
+            "summary": "Integer signedness error in the _zend_mm_alloc_int function in the Zend Memory Manager in PHP 5.2.0 allows remote attackers to execute arbitrary code via a large emalloc request, related to an incorrect signed long cast, as demonstrated via the HTTP SOAP client in PHP, and via a call to msg_receive with the largest positive integer value of maxsize.",
+            "fixVersions": {
+                "base": [
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2007-1890",
+            "summary": "Integer overflow in the msg_receive function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1, on FreeBSD and possibly other platforms, allows context-dependent attackers to execute arbitrary code via certain maxsize values, as demonstrated by 0xffffffff.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.5",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.1"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-1900",
+            "summary": "CRLF injection vulnerability in the FILTER_VALIDATE_EMAIL filter in ext\/filter in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to inject arbitrary e-mail headers via an e-mail address with a '\\n' character, which causes a regular expression to ignore the subsequent part of the address string.",
+            "fixVersions": {
+                "base": [
+                    "5.2.2"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2007-2369",
+            "summary": "Directory traversal vulnerability in picture.php in WebSPELL 4.01.02 and earlier, when PHP before 4.3.0 is used, allows remote attackers to read arbitrary files via a .. (dot dot) in the id parameter.",
+            "fixVersions": {
+                "base": [
+                    "4.01.3",
+                    "4.2.4"
                 ]
             }
         },
@@ -3571,6 +4397,16 @@
             }
         },
         {
+            "threat": "4.6",
+            "cveid": "CVE-2013-6501",
+            "summary": "The default soap.wsdl_cache_dir setting in (1) php.ini-production and (2) php.ini-development in PHP through 5.6.7 specifies the \/tmp directory, which makes it easier for local users to conduct WSDL injection attacks by creating a file under \/tmp with a predictable filename that is used by the get_sdl function in ext\/soap\/php_sdl.c.",
+            "fixVersions": {
+                "base": [
+                    "5.6.8"
+                ]
+            }
+        },
+        {
             "threat": "5.0",
             "cveid": "CVE-2013-6712",
             "summary": "The scan function in ext\/date\/lib\/parse_iso_intervals.c in PHP through 5.5.6 does not properly restrict creation of DateInterval objects, which might allow remote attackers to cause a denial of service (heap-based buffer over-read) via a crafted interval specification.",
@@ -3908,6 +4744,27 @@
             }
         },
         {
+            "threat": "3.6",
+            "cveid": "CVE-2014-5459",
+            "summary": "The PEAR_REST class in REST.php in PEAR in PHP through 5.6.0 allows local users to write to arbitrary files via a symlink attack on a (1) rest.cachefile or (2) rest.cacheid file in \/tmp\/pear\/cache\/, related to the retrieveCacheFirst and useLocalCache functions.",
+            "fixVersions": {
+                "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.10",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.18",
+                    "5.3.29",
+                    "5.4.31",
+                    "5.5.15",
+                    "5.6.1"
+                ]
+            }
+        },
+        {
             "threat": "7.5",
             "cveid": "CVE-2014-8142",
             "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019.",
@@ -3916,6 +4773,16 @@
                     "5.4.36",
                     "5.5.20",
                     "5.6.5"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2014-8626",
+            "summary": "Stack-based buffer overflow in the date_from_ISO8601 function in ext\/xmlrpc\/libxmlrpc\/xmlrpc.c in PHP before 5.2.7 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code by including a timezone field in a date, leading to improper XML-RPC encoding.",
+            "fixVersions": {
+                "base": [
+                    "5.2.7"
                 ]
             }
         },
@@ -3957,6 +4824,30 @@
                     "5.1.7",
                     "5.2.18",
                     "5.3.29",
+                    "5.4.37",
+                    "5.5.21",
+                    "5.6.5"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2014-9652",
+            "summary": "The mconvert function in softmagic.c in file before 5.21, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not properly handle a certain string-length field during a copy of a truncated version of a Pascal string, which might allow remote attackers to cause a denial of service (out-of-bounds memory access and application crash) via a crafted file.",
+            "fixVersions": {
+                "base": [
+                    "5.4.37",
+                    "5.5.21",
+                    "5.6.5"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2014-9653",
+            "summary": "readelf.c in file before 5.22, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not consider that pread calls sometimes read only a subset of the available data, which allows remote attackers to cause a denial of service (uninitialized memory access) or possibly have unspecified other impact via a crafted ELF file.",
+            "fixVersions": {
+                "base": [
                     "5.4.37",
                     "5.5.21",
                     "5.6.5"
@@ -4132,6 +5023,18 @@
         },
         {
             "threat": "7.5",
+            "cveid": "CVE-2015-3307",
+            "summary": "The phar_parse_metadata function in ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (heap metadata corruption) or possibly have unspecified other impact via a crafted tar archive.",
+            "fixVersions": {
+                "base": [
+                    "5.4.40",
+                    "5.5.24",
+                    "5.6.8"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
             "cveid": "CVE-2015-3329",
             "summary": "Multiple stack-based buffer overflows in the phar_set_inode function in phar_internal.h in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allow remote attackers to execute arbitrary code via a crafted length value in a (1) tar, (2) phar, or (3) ZIP archive.",
             "fixVersions": {
@@ -4156,8 +5059,56 @@
         },
         {
             "threat": "5.0",
+            "cveid": "CVE-2015-4021",
+            "summary": "The phar_parse_tarfile function in ext\/phar\/tar.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 does not verify that the first character of a filename is different from the \\0 character, which allows remote attackers to cause a denial of service (integer underflow and memory corruption) via a crafted entry in a tar archive.",
+            "fixVersions": {
+                "base": [
+                    "5.4.41",
+                    "5.5.25",
+                    "5.6.9"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-4022",
+            "summary": "Integer overflow in the ftp_genlist function in ext\/ftp\/ftp.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote FTP servers to execute arbitrary code via a long reply to a LIST command, leading to a heap-based buffer overflow.",
+            "fixVersions": {
+                "base": [
+                    "5.4.41",
+                    "5.5.25",
+                    "5.6.9"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
             "cveid": "CVE-2015-4024",
             "summary": "Algorithmic complexity vulnerability in the multipart_buffer_headers function in main\/rfc1867.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote attackers to cause a denial of service (CPU consumption) via crafted form data that triggers an improper order-of-growth outcome.",
+            "fixVersions": {
+                "base": [
+                    "5.4.41",
+                    "5.5.25",
+                    "5.6.9"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-4025",
+            "summary": "PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character in certain situations, which allows remote attackers to bypass intended extension restrictions and access files or directories with unexpected names via a crafted argument to (1) set_include_path, (2) tempnam, (3) rmdir, or (4) readlink.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
+            "fixVersions": {
+                "base": [
+                    "5.4.41",
+                    "5.5.25",
+                    "5.6.9"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-4026",
+            "summary": "The pcntl_exec implementation in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character, which might allow remote attackers to bypass intended extension restrictions and execute files with unexpected names via a crafted first argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -4187,6 +5138,140 @@
                     "5.4.39",
                     "5.5.23",
                     "5.6.7"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-5590",
+            "summary": "Stack-based buffer overflow in the phar_fix_filepath function in ext\/phar\/phar.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large length value, as demonstrated by mishandling of an e-mail attachment by the imap PHP extension.",
+            "fixVersions": {
+                "base": [
+                    "5.4.43",
+                    "5.5.27",
+                    "5.6.11"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-6527",
+            "summary": "The php_str_replace_in_subject function in ext\/standard\/string.c in PHP 7.x before 7.0.0 allows remote attackers to execute arbitrary code via a crafted value in the third argument to the str_ireplace function.",
+            "fixVersions": {
+                "base": [
+                    "7.0.1"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-6831",
+            "summary": "Multiple use-after-free vulnerabilities in SPL in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allow remote attackers to execute arbitrary code via vectors involving (1) ArrayObject, (2) SplObjectStorage, and (3) SplDoublyLinkedList, which are mishandled during unserialization.",
+            "fixVersions": {
+                "base": [
+                    "5.4.44",
+                    "5.5.28",
+                    "5.6.12"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-6832",
+            "summary": "Use-after-free vulnerability in the SPL unserialize implementation in ext\/spl\/spl_array.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to execute arbitrary code via crafted serialized data that triggers misuse of an array field.",
+            "fixVersions": {
+                "base": [
+                    "5.4.44",
+                    "5.5.28",
+                    "5.6.12"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
+            "cveid": "CVE-2015-6833",
+            "summary": "Directory traversal vulnerability in the PharData class in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to write to arbitrary files via a .. (dot dot) in a ZIP archive entry that is mishandled during an extractTo call.",
+            "fixVersions": {
+                "base": [
+                    "5.4.44",
+                    "5.5.28",
+                    "5.6.12"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-6836",
+            "summary": "The SoapClient __call method in ext\/soap\/soap.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 does not properly manage headers, which allows remote attackers to execute arbitrary code via crafted serialized data that triggers a \"type confusion\" in the serialize_function_call function.",
+            "fixVersions": {
+                "base": [
+                    "5.4.45",
+                    "5.5.29",
+                    "5.6.13"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2015-7803",
+            "summary": "The phar_get_entry_data function in ext\/phar\/util.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a .phar file with a crafted TAR archive entry in which the Link indicator references a file that does not exist.",
+            "fixVersions": {
+                "base": [
+                    "5.5.30",
+                    "5.6.14"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2015-7804",
+            "summary": "Off-by-one error in the phar_parse_zipfile function in ext\/phar\/zip.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (uninitialized pointer dereference and application crash) by including the \/ filename in a .zip PHAR archive.",
+            "fixVersions": {
+                "base": [
+                    "5.5.30",
+                    "5.6.14"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-8616",
+            "summary": "Use-after-free vulnerability in the Collator::sortWithSortKeys function in ext\/intl\/collator\/collator_sort.c in PHP 7.x before 7.0.1 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact by leveraging the relationships between a key buffer and a destroyed array.",
+            "fixVersions": {
+                "base": [
+                    "7.0.1"
+                ]
+            }
+        },
+        {
+            "threat": "10.0",
+            "cveid": "CVE-2015-8617",
+            "summary": "Format string vulnerability in the zend_throw_or_error function in Zend\/zend_execute_API.c in PHP 7.x before 7.0.1 allows remote attackers to execute arbitrary code via format string specifiers in a string that is misused as a class name, leading to incorrect error handling.",
+            "fixVersions": {
+                "base": [
+                    "7.0.2"
+                ]
+            }
+        },
+        {
+            "threat": "6.4",
+            "cveid": "CVE-2016-1903",
+            "summary": "The gdImageRotateInterpolated function in ext\/gd\/libgd\/gd_interpolation.c in PHP before 5.5.31, 5.6.x before 5.6.17, and 7.x before 7.0.2 allows remote attackers to obtain sensitive information or cause a denial of service (out-of-bounds read and application crash) via a large bgd_color argument to the imagerotate function.",
+            "fixVersions": {
+                "base": [
+                    "5.5.31",
+                    "5.6.17",
+                    "7.0.2"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2016-1904",
+            "summary": "Multiple integer overflows in ext\/standard\/exec.c in PHP 7.x before 7.0.2 allow remote attackers to cause a denial of service or possibly have unspecified other impact via a long string to the (1) php_escape_shell_cmd or (2) php_escape_shell_arg function, leading to a heap-based buffer overflow.",
+            "fixVersions": {
+                "base": [
+                    "7.0.2"
                 ]
             }
         }

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -680,7 +680,7 @@
             "fixVersions": {
                 "base": [
                     "4.0.1",
-                    "4.2.1",
+                    "4.2.0",
                     "4.3.12",
                     "4.4.2",
                     "5.0.6",
@@ -1065,6 +1065,13 @@
             "summary": "Multiple integer overflows in the (1) createwbmp and (2) readwbmp functions in wbmp.c in the GD library (libgd) in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allow context-dependent attackers to execute arbitrary code via Wireless Bitmap (WBMP) images with large width or height values.",
             "fixVersions": {
                 "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.7",
+                    "5.0.6",
+                    "5.1.7",
                     "5.2.2"
                 ]
             }
@@ -1295,6 +1302,7 @@
             "summary": "Buffer overflow in the intT1_EnvGetCompletePath function in lib\/t1lib\/t1env.c in t1lib 5.1.1 allows context-dependent attackers to execute arbitrary code via a long FileName parameter.  NOTE: this issue was originally reported to be in the imagepsloadfont function in php_gd2.dll in the gd (PHP_GD2) extension in PHP 5.2.3.",
             "fixVersions": {
                 "base": [
+                    "5.1.2",
                     "5.2.4"
                 ]
             }
@@ -3907,7 +3915,7 @@
                 "base": [
                     "5.4.36",
                     "5.5.20",
-                    "5.6.4"
+                    "5.6.5"
                 ]
             }
         },
@@ -3940,6 +3948,15 @@
             "summary": "sapi\/cgi\/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping.",
             "fixVersions": {
                 "base": [
+                    "4.0.8",
+                    "4.1.3",
+                    "4.2.4",
+                    "4.3.12",
+                    "4.4.10",
+                    "5.0.6",
+                    "5.1.7",
+                    "5.2.18",
+                    "5.3.29",
                     "5.4.37",
                     "5.5.21",
                     "5.6.5"

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -23,7 +23,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2001-0108",
-            "summary": "PHP Apache module 4.0.4 and earlier allows remote attackers to bypass .htaccess access restrictions via a malformed HTTP request on an unrestricted page that causes PHP to use those access controls on the next page that is requested.",
+            "summary": "PHP Apache module 4.0.4 and earlier allows remote attackers to bypass .htaccess access restrictions via a malformed HTTP request on an unrestricted page that causes PHP to use those access controls on the next page that is requested. \n Publish Date : 2001-03-12 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.5"
@@ -33,7 +33,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2001-1246",
-            "summary": "PHP 4.0.5 through 4.1.0 in safe mode does not properly cleanse the 5th parameter to the mail() function, which allows local users and possibly remote attackers to execute arbitrary commands via shell metacharacters.",
+            "summary": "PHP 4.0.5 through 4.1.0 in safe mode does not properly cleanse the 5th parameter to the mail() function, which allows local users and possibly remote attackers to execute arbitrary commands via shell metacharacters. \n Publish Date : 2001-06-30 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.6"
@@ -43,7 +43,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2001-1247",
-            "summary": "PHP 4.0.4pl1 and 4.0.5 in safe mode allows remote attackers to read and write files owned by the web server UID by uploading a PHP script that uses the error_log function to access the files.",
+            "summary": "PHP 4.0.4pl1 and 4.0.5 in safe mode allows remote attackers to read and write files owned by the web server UID by uploading a PHP script that uses the error_log function to access the files. \n Publish Date : 2001-12-06 Last Update Date : 2012-06-25",
             "fixVersions": {
                 "base": [
                     "4.0.6"
@@ -53,7 +53,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2001-1385",
-            "summary": "The Apache module for PHP 4.0.0 through PHP 4.0.4, when disabled with the 'engine = off' option for a virtual host, may disable PHP for other virtual hosts, which could cause Apache to serve the source code of PHP scripts.",
+            "summary": "The Apache module for PHP 4.0.0 through PHP 4.0.4, when disabled with the 'engine = off' option for a virtual host, may disable PHP for other virtual hosts, which could cause Apache to serve the source code of PHP scripts. \n Publish Date : 2001-01-12 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.5"
@@ -63,7 +63,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0081",
-            "summary": "Buffer overflows in (1) php_mime_split in PHP 4.1.0, 4.1.1, and 4.0.6 and earlier, and (2) php3_mime_split in PHP 3.0.x allows remote attackers to execute arbitrary code via a multipart\/form-data HTTP POST request when file_uploads is enabled.",
+            "summary": "Buffer overflows in (1) php_mime_split in PHP 4.1.0, 4.1.1, and 4.0.6 and earlier, and (2) php3_mime_split in PHP 3.0.x allows remote attackers to execute arbitrary code via a multipart\/form-data HTTP POST request when file_uploads is enabled. \n Publish Date : 2002-03-08 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -74,7 +74,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2002-0121",
-            "summary": "PHP 4.0 through 4.1.1 stores session IDs in temporary files whose name contains the session ID, which allows local users to hijack web connections.",
+            "summary": "PHP 4.0 through 4.1.1 stores session IDs in temporary files whose name contains the session ID, which allows local users to hijack web connections. \n Publish Date : 2002-03-25 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -85,7 +85,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0229",
-            "summary": "Safe Mode feature (safe_mode) in PHP 3.0 through 4.1.0 allows attackers with access to the MySQL database to bypass Safe Mode access restrictions and read arbitrary files using \"LOAD DATA INFILE LOCAL\" SQL statements.",
+            "summary": "Safe Mode feature (safe_mode) in PHP 3.0 through 4.1.0 allows attackers with access to the MySQL database to bypass Safe Mode access restrictions and read arbitrary files using \"LOAD DATA INFILE LOCAL\" SQL statements. \n Publish Date : 2002-05-16 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -96,7 +96,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-0253",
-            "summary": "PHP, when not configured with the \"display_errors = Off\" setting in php.ini, allows remote attackers to obtain the physical path for an include file via a trailing slash in a request to a directly accessible PHP program, which modifies the base path, causes the include directive to fail, and produces an error message that contains the path.",
+            "summary": "PHP, when not configured with the \"display_errors = Off\" setting in php.ini, allows remote attackers to obtain the physical path for an include file via a trailing slash in a request to a directly accessible PHP program, which modifies the base path, causes the include directive to fail, and produces an error message that contains the path. \n Publish Date : 2002-05-29 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -107,7 +107,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-0484",
-            "summary": "move_uploaded_file in PHP does not does not check for the base directory (open_basedir), which could allow remote attackers to upload files to unintended locations on the system.",
+            "summary": "move_uploaded_file in PHP does not does not check for the base directory (open_basedir), which could allow remote attackers to upload files to unintended locations on the system. \n Publish Date : 2002-08-12 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -118,7 +118,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0717",
-            "summary": "PHP 4.2.0 and 4.2.1 allows remote attackers to cause a denial of service and possibly execute arbitrary code via an HTTP POST request with certain arguments in a multipart\/form-data form, which generates an error condition that is not properly handled and causes improper memory to be freed.",
+            "summary": "PHP 4.2.0 and 4.2.1 allows remote attackers to cause a denial of service and possibly execute arbitrary code via an HTTP POST request with certain arguments in a multipart\/form-data form, which generates an error condition that is not properly handled and causes improper memory to be freed. \n Publish Date : 2002-07-26 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.2.2"
@@ -128,7 +128,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0985",
-            "summary": "Argument injection vulnerability in the mail function for PHP 4.x to 4.2.2 may allow attackers to bypass safe mode restrictions and modify command line arguments to the MTA (e.g. sendmail) in the 5th argument to mail(), altering MTA behavior and possibly executing commands.",
+            "summary": "Argument injection vulnerability in the mail function for PHP 4.x to 4.2.2 may allow attackers to bypass safe mode restrictions and modify command line arguments to the MTA (e.g. sendmail) in the 5th argument to mail(), altering MTA behavior and possibly executing commands. \n Publish Date : 2002-09-24 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -140,7 +140,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-0986",
-            "summary": "The mail function in PHP 4.x to 4.2.2 does not filter ASCII control characters from its arguments, which could allow remote attackers to modify mail message content, including mail headers, and possibly use PHP as a \"spam proxy.\"",
+            "summary": "The mail function in PHP 4.x to 4.2.2 does not filter ASCII control characters from its arguments, which could allow remote attackers to modify mail message content, including mail headers, and possibly use PHP as a \"spam proxy.\" \n Publish Date : 2002-09-24 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -152,7 +152,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-1396",
-            "summary": "Heap-based buffer overflow in the wordwrap function in PHP after 4.1.2 and before 4.3.0 may allow attackers to cause a denial of service or execute arbitrary code.",
+            "summary": "Heap-based buffer overflow in the wordwrap function in PHP after 4.1.2 and before 4.3.0 may allow attackers to cause a denial of service or execute arbitrary code. \n Publish Date : 2003-01-17 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.1.3",
@@ -163,7 +163,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-1783",
-            "summary": "CRLF injection vulnerability in PHP 4.2.1 through 4.2.3, when allow_url_fopen is enabled, allows remote attackers to modify HTTP headers for outgoing requests by causing CRLF sequences to be injected into arguments that are passed to the (1) fopen or (2) file functions.",
+            "summary": "CRLF injection vulnerability in PHP 4.2.1 through 4.2.3, when allow_url_fopen is enabled, allows remote attackers to modify HTTP headers for outgoing requests by causing CRLF sequences to be injected into arguments that are passed to the (1) fopen or (2) file functions. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -175,7 +175,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2002-1954",
-            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.2.3 allows remote attackers to inject arbitrary web script or HTML via the query string argument, as demonstrated using soinfo.php.",
+            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.2.3 allows remote attackers to inject arbitrary web script or HTML via the query string argument, as demonstrated using soinfo.php. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.2.4"
@@ -185,7 +185,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-2214",
-            "summary": "The php_if_imap_mime_header_decode function in the IMAP functionality in PHP before 4.2.2 allows remote attackers to cause a denial of service (crash) via an e-mail header with a long \"To\" header.",
+            "summary": "The php_if_imap_mime_header_decode function in the IMAP functionality in PHP before 4.2.2 allows remote attackers to cause a denial of service (crash) via an e-mail header with a long \"To\" header. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.2.2"
@@ -195,7 +195,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-2215",
-            "summary": "The imap_header function in the IMAP functionality for PHP before 4.3.0 allows remote attackers to cause a denial of service via an e-mail message with a large number of \"To\" addresses, which triggers an error in the rfc822_write_address function.",
+            "summary": "The imap_header function in the IMAP functionality for PHP before 4.3.0 allows remote attackers to cause a denial of service via an e-mail message with a large number of \"To\" addresses, which triggers an error in the rfc822_write_address function. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -207,7 +207,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2002-2309",
-            "summary": "php.exe in PHP 3.0 through 4.2.2, when running on Apache, does not terminate properly, which allows remote attackers to cause a denial of service via a direct request without arguments.",
+            "summary": "php.exe in PHP 3.0 through 4.2.2, when running on Apache, does not terminate properly, which allows remote attackers to cause a denial of service via a direct request without arguments. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -229,7 +229,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0166",
-            "summary": "Integer signedness error in emalloc() function for PHP before 4.3.2 allow remote attackers to cause a denial of service (memory consumption) and possibly execute arbitrary code via negative arguments to functions such as (1) socket_recv, (2) socket_recvfrom, and possibly other functions.",
+            "summary": "Integer signedness error in emalloc() function for PHP before 4.3.2 allow remote attackers to cause a denial of service (memory consumption) and possibly execute arbitrary code via negative arguments to functions such as (1) socket_recv, (2) socket_recvfrom, and possibly other functions. \n Publish Date : 2003-04-02 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -242,7 +242,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0172",
-            "summary": "Buffer overflow in openlog function for PHP 4.3.1 on Windows operating system, and possibly other OSes, allows remote attackers to cause a crash and possibly execute arbitrary code via a long filename argument.",
+            "summary": "Buffer overflow in openlog function for PHP 4.3.1 on Windows operating system, and possibly other OSes, allows remote attackers to cause a crash and possibly execute arbitrary code via a long filename argument. \n Publish Date : 2003-04-02 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.3.2"
@@ -252,7 +252,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0249",
-            "summary": "** DISPUTED **  PHP treats unknown methods such as \"PoSt\" as a GET request, which could allow attackers to intended access restrictions if PHP is running on a server that passes on all methods, such as Apache httpd 2.0, as demonstrated using a Limit directive.  NOTE: this issue has been disputed by the Apache security team, saying \"It is by design that PHP allows scripts to process any request method.  A script which does not explicitly verify the request method will hence be processed as normal for arbitrary methods.  It is therefore expected behaviour that one cannot implement per-method access control using the Apache configuration alone, which is the assumption made in this report.\"",
+            "summary": "** DISPUTED **  PHP treats unknown methods such as \"PoSt\" as a GET request, which could allow attackers to intended access restrictions if PHP is running on a server that passes on all methods, such as Apache httpd 2.0, as demonstrated using a Limit directive.  NOTE: this issue has been disputed by the Apache security team, saying \"It is by design that PHP allows scripts to process any request method.  A script which does not explicitly verify the request method will hence be processed as normal for arbitrary methods.  It is therefore expected behaviour that one cannot implement per-method access control using the Apache configuration alone, which is the assumption made in this report.\" \n Publish Date : 2003-12-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -262,7 +262,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2003-0442",
-            "summary": "Cross-site scripting (XSS) vulnerability in the transparent SID support capability for PHP before 4.3.2 (session.use_trans_sid) allows remote attackers to insert arbitrary script via the PHPSESSID parameter.",
+            "summary": "Cross-site scripting (XSS) vulnerability in the transparent SID support capability for PHP before 4.3.2 (session.use_trans_sid) allows remote attackers to insert arbitrary script via the PHPSESSID parameter. \n Publish Date : 2003-07-24 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.3.2"
@@ -272,7 +272,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2003-0860",
-            "summary": "Buffer overflows in PHP before 4.3.3 have unknown impact and unknown attack vectors.",
+            "summary": "Buffer overflows in PHP before 4.3.3 have unknown impact and unknown attack vectors. \n Publish Date : 2003-11-17 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -285,7 +285,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2003-0861",
-            "summary": "Integer overflows in (1) base64_encode and (2) the GD library for PHP before 4.3.3 have unknown impact and unknown attack vectors.",
+            "summary": "Integer overflows in (1) base64_encode and (2) the GD library for PHP before 4.3.3 have unknown impact and unknown attack vectors. \n Publish Date : 2003-11-17 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -298,7 +298,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0863",
-            "summary": "The php_check_safe_mode_include_dir function in fopen_wrappers.c of PHP 4.3.x returns a success value (0) when the safe_mode_include_dir variable is not specified in configuration, which differs from the previous failure value and may allow remote attackers to exploit file include vulnerabilities in PHP applications.",
+            "summary": "The php_check_safe_mode_include_dir function in fopen_wrappers.c of PHP 4.3.x returns a success value (0) when the safe_mode_include_dir variable is not specified in configuration, which differs from the previous failure value and may allow remote attackers to exploit file include vulnerabilities in PHP applications. \n Publish Date : 2003-11-17 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.3.3"
@@ -308,7 +308,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2003-1302",
-            "summary": "The IMAP functionality in PHP before 4.3.1 allows remote attackers to cause a denial of service via an e-mail message with a (1) To or (2) From header with an address that contains a large number of \"\\\" (backslash) characters.",
+            "summary": "The IMAP functionality in PHP before 4.3.1 allows remote attackers to cause a denial of service via an e-mail message with a (1) To or (2) From header with an address that contains a large number of \"\\\" (backslash) characters. \n Publish Date : 2003-12-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.2.4",
@@ -319,7 +319,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2003-1303",
-            "summary": "Buffer overflow in the imap_fetch_overview function in the IMAP functionality (php_imap.c) in PHP before 4.3.3 allows remote attackers to cause a denial of service (segmentation fault) and possibly execute arbitrary code via a long e-mail address in a (1) To or (2) From header.",
+            "summary": "Buffer overflow in the imap_fetch_overview function in the IMAP functionality (php_imap.c) in PHP before 4.3.3 allows remote attackers to cause a denial of service (segmentation fault) and possibly execute arbitrary code via a long e-mail address in a (1) To or (2) From header. \n Publish Date : 2003-12-31 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.3.3"
@@ -329,7 +329,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2004-0542",
-            "summary": "PHP before 4.3.7 on Win32 platforms does not properly filter all shell metacharacters, which allows local or remote attackers to execute arbitrary code, overwrite files, and access internal environment variables via (1) the \"%\", \"|\", or \">\" characters to the escapeshellcmd function, or (2) the \"%\" character to the escapeshellarg function.",
+            "summary": "PHP before 4.3.7 on Win32 platforms does not properly filter all shell metacharacters, which allows local or remote attackers to execute arbitrary code, overwrite files, and access internal environment variables via (1) the \"%\", \"|\", or \">\" characters to the escapeshellcmd function, or (2) the \"%\" character to the escapeshellarg function. \n Publish Date : 2004-08-06 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -367,7 +367,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2004-0958",
-            "summary": "php_variables.c in PHP before 5.0.2 allows remote attackers to read sensitive memory contents via (1) GET, (2) POST, or (3) COOKIE GPC variables that end in an open bracket character, which causes PHP to calculate an incorrect string length.",
+            "summary": "php_variables.c in PHP before 5.0.2 allows remote attackers to read sensitive memory contents via (1) GET, (2) POST, or (3) COOKIE GPC variables that end in an open bracket character, which causes PHP to calculate an incorrect string length. \n Publish Date : 2004-11-03 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.0.3"
@@ -377,7 +377,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2004-0959",
-            "summary": "rfc1867.c in PHP before 5.0.2 allows local users to upload files to arbitrary locations via a PHP script with a certain MIME header that causes the \"$_FILES\" array to be modified.",
+            "summary": "rfc1867.c in PHP before 5.0.2 allows local users to upload files to arbitrary locations via a PHP script with a certain MIME header that causes the \"$_FILES\" array to be modified. \n Publish Date : 2004-11-03 Last Update Date : 2013-09-11",
             "fixVersions": {
                 "base": [
                     "5.0.3"
@@ -401,7 +401,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2004-1020",
-            "summary": "The addslashes function in PHP 4.3.9 does not properly escape a NULL (\/0) character, which may allow remote attackers to read arbitrary files in PHP applications that contain a directory traversal vulnerability in require or include statements, but are otherwise protected by the magic_quotes_gpc mechanism.  NOTE: this issue was originally REJECTed by its CNA before publication, but that decision is in active dispute.  This candidate may change significantly in the future as a result of further discussion.",
+            "summary": "The addslashes function in PHP 4.3.9 does not properly escape a NULL (\/0) character, which may allow remote attackers to read arbitrary files in PHP applications that contain a directory traversal vulnerability in require or include statements, but are otherwise protected by the magic_quotes_gpc mechanism.  NOTE: this issue was originally REJECTed by its CNA before publication, but that decision is in active dispute.  This candidate may change significantly in the future as a result of further discussion. \n Publish Date : 2005-01-10 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "4.3.10",
@@ -426,7 +426,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2004-1392",
-            "summary": "PHP 4.0 with cURL functions allows remote attackers to bypass the open_basedir setting and read arbitrary files via a file: URL argument to the curl_init function.",
+            "summary": "PHP 4.0 with cURL functions allows remote attackers to bypass the open_basedir setting and read arbitrary files via a file: URL argument to the curl_init function. \n Publish Date : 2004-12-31 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8"
@@ -436,7 +436,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-0524",
-            "summary": "The php_handle_iff function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a -8 size value.",
+            "summary": "The php_handle_iff function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a -8 size value. \n Publish Date : 2005-05-02 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.2.3",
@@ -448,7 +448,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-0525",
-            "summary": "The php_next_marker function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a JPEG image with an invalid marker value, which causes a negative length value to be passed to php_stream_seek.",
+            "summary": "The php_next_marker function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a JPEG image with an invalid marker value, which causes a negative length value to be passed to php_stream_seek. \n Publish Date : 2005-05-02 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.2.3",
@@ -470,7 +470,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-1042",
-            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in PHP before 4.3.11 may allow remote attackers to execute arbitrary code via an IFD tag that leads to a negative byte count.",
+            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in PHP before 4.3.11 may allow remote attackers to execute arbitrary code via an IFD tag that leads to a negative byte count. \n Publish Date : 2005-05-02 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.3.11"
@@ -490,7 +490,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2005-3054",
-            "summary": "fopen_wrappers.c in PHP 4.4.0, and possibly other versions, does not properly restrict access to other directories when the open_basedir directive includes a trailing slash, which allows PHP scripts in one directory to access files in other directories whose names are substrings of the original directory.",
+            "summary": "fopen_wrappers.c in PHP 4.4.0, and possibly other versions, does not properly restrict access to other directories when the open_basedir directive includes a trailing slash, which allows PHP scripts in one directory to access files in other directories whose names are substrings of the original directory. \n Publish Date : 2005-09-26 Last Update Date : 2010-04-02",
             "fixVersions": {
                 "base": [
                     "4.4.1"
@@ -500,7 +500,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2005-3319",
-            "summary": "The apache2handler SAPI (sapi_apache2.c) in the Apache module (mod_php) for PHP 5.x before 5.1.0 final and 4.4 before 4.4.1 final allows attackers to cause a denial of service (segmentation fault) via the session.save_path option in a .htaccess file or VirtualHost.",
+            "summary": "The apache2handler SAPI (sapi_apache2.c) in the Apache module (mod_php) for PHP 5.x before 5.1.0 final and 4.4 before 4.4.1 final allows attackers to cause a denial of service (segmentation fault) via the session.save_path option in a .htaccess file or VirtualHost. \n Publish Date : 2005-10-27 Last Update Date : 2010-04-02",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -515,7 +515,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-3353",
-            "summary": "The exif_read_data function in the Exif module in PHP before 4.4.1 allows remote attackers to cause a denial of service (infinite loop) via a malformed JPEG image.",
+            "summary": "The exif_read_data function in the Exif module in PHP before 4.4.1 allows remote attackers to cause a denial of service (infinite loop) via a malformed JPEG image. \n Publish Date : 2005-11-18 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -529,7 +529,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2005-3388",
-            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5 allows remote attackers to inject arbitrary web script or HTML via a crafted URL with a \"stacked array assignment.\"",
+            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5 allows remote attackers to inject arbitrary web script or HTML via a crafted URL with a \"stacked array assignment.\" \n Publish Date : 2005-11-01 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -544,7 +544,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-3389",
-            "summary": "The parse_str function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when called with only one parameter, allows remote attackers to enable the register_globals directive via inputs that cause a request to be terminated due to the memory_limit setting, which causes PHP to set an internal flag that enables register_globals and allows attackers to exploit vulnerabilities in PHP applications that would otherwise be protected.",
+            "summary": "The parse_str function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when called with only one parameter, allows remote attackers to enable the register_globals directive via inputs that cause a request to be terminated due to the memory_limit setting, which causes PHP to set an internal flag that enables register_globals and allows attackers to exploit vulnerabilities in PHP applications that would otherwise be protected. \n Publish Date : 2005-11-01 Last Update Date : 2013-07-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -559,7 +559,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-3390",
-            "summary": "The RFC1867 file upload feature in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when register_globals is enabled, allows remote attackers to modify the GLOBALS array and bypass security protections of PHP applications via a multipart\/form-data POST request with a \"GLOBALS\" fileupload field.",
+            "summary": "The RFC1867 file upload feature in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when register_globals is enabled, allows remote attackers to modify the GLOBALS array and bypass security protections of PHP applications via a multipart\/form-data POST request with a \"GLOBALS\" fileupload field. \n Publish Date : 2005-11-01 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -574,7 +574,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-3391",
-            "summary": "Multiple vulnerabilities in PHP before 4.4.1 allow remote attackers to bypass safe_mode and open_basedir restrictions via unknown attack vectors in (1) ext\/curl and (2) ext\/gd.",
+            "summary": "Multiple vulnerabilities in PHP before 4.4.1 allow remote attackers to bypass safe_mode and open_basedir restrictions via unknown attack vectors in (1) ext\/curl and (2) ext\/gd. \n Publish Date : 2005-11-01 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -588,7 +588,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-3392",
-            "summary": "Unspecified vulnerability in PHP before 4.4.1, when using the virtual function on Apache 2, allows remote attackers to bypass safe_mode and open_basedir directives.",
+            "summary": "Unspecified vulnerability in PHP before 4.4.1, when using the virtual function on Apache 2, allows remote attackers to bypass safe_mode and open_basedir directives. \n Publish Date : 2005-11-01 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -602,7 +602,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-3883",
-            "summary": "CRLF injection vulnerability in the mb_send_mail function in PHP before 5.1.0 might allow remote attackers to inject arbitrary e-mail headers via line feeds (LF) in the \"To\" address argument.",
+            "summary": "CRLF injection vulnerability in the mb_send_mail function in PHP before 5.1.0 might allow remote attackers to inject arbitrary e-mail headers via line feeds (LF) in the \"To\" address argument. \n Publish Date : 2005-11-29 Last Update Date : 2013-08-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -617,7 +617,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2006-0097",
-            "summary": "Stack-based buffer overflow in the create_named_pipe function in libmysql.c in PHP 4.3.10 and 4.4.x before 4.4.3 for Windows allows attackers to execute arbitrary code via a long (1) arg_host or (2) arg_unix_socket argument, as demonstrated by a long named pipe variable in the host argument to the mysql_connect function.",
+            "summary": "Stack-based buffer overflow in the create_named_pipe function in libmysql.c in PHP 4.3.10 and 4.4.x before 4.4.3 for Windows allows attackers to execute arbitrary code via a long (1) arg_host or (2) arg_unix_socket argument, as demonstrated by a long named pipe variable in the host argument to the mysql_connect function. \n Publish Date : 2006-01-06 Last Update Date : 2011-08-01",
             "fixVersions": {
                 "base": [
                     "4.3.11",
@@ -628,7 +628,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-0200",
-            "summary": "Format string vulnerability in the error-reporting feature in the mysqli extension in PHP 5.1.0 and 5.1.1 might allow remote attackers to execute arbitrary code via format string specifiers in MySQL error messages.",
+            "summary": "Format string vulnerability in the error-reporting feature in the mysqli extension in PHP 5.1.0 and 5.1.1 might allow remote attackers to execute arbitrary code via format string specifiers in MySQL error messages. \n Publish Date : 2006-01-13 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.1.2"
@@ -638,7 +638,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-0207",
-            "summary": "Multiple HTTP response splitting vulnerabilities in PHP 5.1.1 allow remote attackers to inject arbitrary HTTP headers via a crafted Set-Cookie header, related to the (1) session extension (aka ext\/session) and the (2) header function.",
+            "summary": "Multiple HTTP response splitting vulnerabilities in PHP 5.1.1 allow remote attackers to inject arbitrary HTTP headers via a crafted Set-Cookie header, related to the (1) session extension (aka ext\/session) and the (2) header function. \n Publish Date : 2006-01-13 Last Update Date : 2011-09-09",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -649,7 +649,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-0208",
-            "summary": "Multiple cross-site scripting (XSS) vulnerabilities in PHP 4.4.1 and 5.1.1, when display_errors and html_errors are on, allow remote attackers to inject arbitrary web script or HTML via inputs to PHP applications that are not filtered when they are included in the resulting error message.",
+            "summary": "Multiple cross-site scripting (XSS) vulnerabilities in PHP 4.4.1 and 5.1.1, when display_errors and html_errors are on, allow remote attackers to inject arbitrary web script or HTML via inputs to PHP applications that are not filtered when they are included in the resulting error message. \n Publish Date : 2006-01-13 Last Update Date : 2011-09-13",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -665,7 +665,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2006-0996",
-            "summary": "Cross-site scripting (XSS) vulnerability in phpinfo (info.c) in PHP 5.1.2 and 4.4.2 allows remote attackers to inject arbitrary web script or HTML via long array variables, including (1) a large number of dimensions or (2) long values, which prevents HTML tags from being removed.",
+            "summary": "Cross-site scripting (XSS) vulnerability in phpinfo (info.c) in PHP 5.1.2 and 4.4.2 allows remote attackers to inject arbitrary web script or HTML via long array variables, including (1) a large number of dimensions or (2) long values, which prevents HTML tags from being removed. \n Publish Date : 2006-04-10 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -676,7 +676,7 @@
         {
             "threat": "3.2",
             "cveid": "CVE-2006-1014",
-            "summary": "Argument injection vulnerability in certain PHP 4.x and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mb_send_mail function, allows context-dependent attackers to read and create arbitrary files by providing extra -C and -X arguments to sendmail.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE.",
+            "summary": "Argument injection vulnerability in certain PHP 4.x and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mb_send_mail function, allows context-dependent attackers to read and create arbitrary files by providing extra -C and -X arguments to sendmail.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE. \n Publish Date : 2006-03-06 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -691,7 +691,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2006-1015",
-            "summary": "Argument injection vulnerability in certain PHP 3.x, 4.x, and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mail function, allows remote attackers to read and create arbitrary files via the sendmail -C and -X arguments.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE.",
+            "summary": "Argument injection vulnerability in certain PHP 3.x, 4.x, and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mail function, allows remote attackers to read and create arbitrary files via the sendmail -C and -X arguments.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE. \n Publish Date : 2006-03-06 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -707,7 +707,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-1017",
-            "summary": "The c-client library 2000, 2001, or 2004 for PHP before 4.4.4 and 5.x before 5.1.5 do not check the (1) safe_mode or (2) open_basedir functions, and when used in applications that accept user-controlled input for the mailbox argument to the imap_open function, allow remote attackers to obtain access to an IMAP stream data structure and conduct unauthorized IMAP actions.",
+            "summary": "The c-client library 2000, 2001, or 2004 for PHP before 4.4.4 and 5.x before 5.1.5 do not check the (1) safe_mode or (2) open_basedir functions, and when used in applications that accept user-controlled input for the mailbox argument to the imap_open function, allow remote attackers to obtain access to an IMAP stream data structure and conduct unauthorized IMAP actions. \n Publish Date : 2006-03-06 Last Update Date : 2011-07-14",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -723,7 +723,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-1490",
-            "summary": "PHP before 5.1.3-RC1 might allow remote attackers to obtain portions of memory via crafted binary data sent to a script that processes user input in the html_entity_decode function and sends the encoded results back to the client, aka a \"binary safety\" issue.  NOTE: this issue has been referred to as a \"memory leak,\" but it is an information leak that discloses memory contents.",
+            "summary": "PHP before 5.1.3-RC1 might allow remote attackers to obtain portions of memory via crafted binary data sent to a script that processes user input in the html_entity_decode function and sends the encoded results back to the client, aka a \"binary safety\" issue.  NOTE: this issue has been referred to as a \"memory leak,\" but it is an information leak that discloses memory contents. \n Publish Date : 2006-03-29 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -739,7 +739,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-1494",
-            "summary": "Directory traversal vulnerability in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass open_basedir restrictions allows remote attackers to create files in arbitrary directories via the tempnam function.",
+            "summary": "Directory traversal vulnerability in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass open_basedir restrictions allows remote attackers to create files in arbitrary directories via the tempnam function. \n Publish Date : 2006-04-10 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -755,7 +755,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-1549",
-            "summary": "PHP 4.4.2 and 5.1.2 allows local users to cause a crash (segmentation fault) by defining and executing a recursive function.  NOTE: it has been reported by a reliable third party that some later versions are also affected.",
+            "summary": "PHP 4.4.2 and 5.1.2 allows local users to cause a crash (segmentation fault) by defining and executing a recursive function.  NOTE: it has been reported by a reliable third party that some later versions are also affected. \n Publish Date : 2006-04-10 Last Update Date : 2011-08-23",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -766,7 +766,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-1608",
-            "summary": "The copy function in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass safe mode and read arbitrary files via a source argument containing a compress.zlib:\/\/ URI.",
+            "summary": "The copy function in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass safe mode and read arbitrary files via a source argument containing a compress.zlib:\/\/ URI. \n Publish Date : 2006-04-10 Last Update Date : 2010-04-02",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -782,7 +782,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-1990",
-            "summary": "Integer overflow in the wordwrap function in string.c in PHP 4.4.2 and 5.1.2 might allow context-dependent attackers to execute arbitrary code via certain long arguments that cause a small buffer to be allocated, which triggers a heap-based buffer overflow in a memcpy function call, a different vulnerability than CVE-2002-1396.",
+            "summary": "Integer overflow in the wordwrap function in string.c in PHP 4.4.2 and 5.1.2 might allow context-dependent attackers to execute arbitrary code via certain long arguments that cause a small buffer to be allocated, which triggers a heap-based buffer overflow in a memcpy function call, a different vulnerability than CVE-2002-1396. \n Publish Date : 2006-04-24 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -793,7 +793,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2006-1991",
-            "summary": "The substr_compare function in string.c in PHP 5.1.2 allows context-dependent attackers to cause a denial of service (memory access violation) via an out-of-bounds offset argument.",
+            "summary": "The substr_compare function in string.c in PHP 5.1.2 allows context-dependent attackers to cause a denial of service (memory access violation) via an out-of-bounds offset argument. \n Publish Date : 2006-04-24 Last Update Date : 2011-06-13",
             "fixVersions": {
                 "base": [
                     "5.1.3"
@@ -803,7 +803,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-2563",
-            "summary": "The cURL library (libcurl) in PHP 4.4.2 and 5.1.4 allows attackers to bypass safe mode and read files via a file:\/\/ request containing null characters.",
+            "summary": "The cURL library (libcurl) in PHP 4.4.2 and 5.1.4 allows attackers to bypass safe mode and read files via a file:\/\/ request containing null characters. \n Publish Date : 2006-05-29 Last Update Date : 2010-04-02",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -814,7 +814,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-2660",
-            "summary": "Buffer consumption vulnerability in the tempnam function in PHP 5.1.4 and 4.x before 4.4.3 allows local users to bypass restrictions and create PHP files with fixed names in other directories via a pathname argument longer than MAXPATHLEN, which prevents a unique string from being appended to the filename.",
+            "summary": "Buffer consumption vulnerability in the tempnam function in PHP 5.1.4 and 4.x before 4.4.3 allows local users to bypass restrictions and create PHP files with fixed names in other directories via a pathname argument longer than MAXPATHLEN, which prevents a unique string from being appended to the filename. \n Publish Date : 2006-06-13 Last Update Date : 2010-04-02",
             "fixVersions": {
                 "base": [
                     "4.0.6",
@@ -829,7 +829,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2006-3011",
-            "summary": "The error_log function in basic_functions.c in PHP before 4.4.4 and 5.x before 5.1.5 allows local users to bypass safe mode and open_basedir restrictions via a \"php:\/\/\" or other scheme in the third argument, which disables safe mode.",
+            "summary": "The error_log function in basic_functions.c in PHP before 4.4.4 and 5.x before 5.1.5 allows local users to bypass safe mode and open_basedir restrictions via a \"php:\/\/\" or other scheme in the third argument, which disables safe mode. \n Publish Date : 2006-06-26 Last Update Date : 2011-07-11",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -861,7 +861,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2006-4020",
-            "summary": "scanf.c in PHP 5.1.4 and earlier, and 4.4.3 and earlier, allows context-dependent attackers to execute arbitrary code via a sscanf PHP function call that performs argument swapping, which increments an index past the end of an array and triggers a buffer over-read.",
+            "summary": "scanf.c in PHP 5.1.4 and earlier, and 4.4.3 and earlier, allows context-dependent attackers to execute arbitrary code via a sscanf PHP function call that performs argument swapping, which increments an index past the end of an array and triggers a buffer over-read. \n Publish Date : 2006-08-08 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -877,7 +877,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-4023",
-            "summary": "The ip2long function in PHP 5.1.4 and earlier may incorrectly validate an arbitrary string and return a valid network IP address, which allows remote attackers to obtain network information and facilitate other attacks, as demonstrated using SQL injection in the X-FORWARDED-FOR Header in index.php in MiniBB 2.0.  NOTE: it could be argued that the ip2long behavior represents a risk for security-relevant issues in a way that is similar to strcpy's role in buffer overflows, in which case this would be a class of implementation bugs that would require separate CVE items for each PHP application that uses ip2long in a security-relevant manner.",
+            "summary": "The ip2long function in PHP 5.1.4 and earlier may incorrectly validate an arbitrary string and return a valid network IP address, which allows remote attackers to obtain network information and facilitate other attacks, as demonstrated using SQL injection in the X-FORWARDED-FOR Header in index.php in MiniBB 2.0.  NOTE: it could be argued that the ip2long behavior represents a risk for security-relevant issues in a way that is similar to strcpy's role in buffer overflows, in which case this would be a class of implementation bugs that would require separate CVE items for each PHP application that uses ip2long in a security-relevant manner. \n Publish Date : 2006-08-08 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.3.4",
@@ -889,7 +889,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2006-4433",
-            "summary": "PHP before 4.4.3 and 5.x before 5.1.4 does not limit the character set of the session identifier (PHPSESSID) for third party session handlers, which might make it easier for remote attackers to exploit other vulnerabilities by inserting PHP code into the PHPSESSID, which is stored in the session file.  NOTE: it could be argued that this not a vulnerability in PHP itself, rather a design limitation that enables certain attacks against session handlers that do not account for this limitation.",
+            "summary": "PHP before 4.4.3 and 5.x before 5.1.4 does not limit the character set of the session identifier (PHPSESSID) for third party session handlers, which might make it easier for remote attackers to exploit other vulnerabilities by inserting PHP code into the PHPSESSID, which is stored in the session file.  NOTE: it could be argued that this not a vulnerability in PHP itself, rather a design limitation that enables certain attacks against session handlers that do not account for this limitation. \n Publish Date : 2006-08-28 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -905,7 +905,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2006-4481",
-            "summary": "The (1) file_exists and (2) imap_reopen functions in PHP before 5.1.5 do not check for the safe_mode and open_basedir settings, which allows local users to bypass the settings.  NOTE: the error_log function is covered by CVE-2006-3011, and the imap_open function is covered by CVE-2006-1017.",
+            "summary": "The (1) file_exists and (2) imap_reopen functions in PHP before 5.1.5 do not check for the safe_mode and open_basedir settings, which allows local users to bypass the settings.  NOTE: the error_log function is covered by CVE-2006-3011, and the imap_open function is covered by CVE-2006-1017. \n Publish Date : 2006-08-31 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -915,7 +915,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-4482",
-            "summary": "Multiple heap-based buffer overflows in the (1) str_repeat and (2) wordwrap functions in ext\/standard\/string.c in PHP before 5.1.5, when used on a 64-bit system, have unspecified impact and attack vectors, a different vulnerability than CVE-2006-1990.",
+            "summary": "Multiple heap-based buffer overflows in the (1) str_repeat and (2) wordwrap functions in ext\/standard\/string.c in PHP before 5.1.5, when used on a 64-bit system, have unspecified impact and attack vectors, a different vulnerability than CVE-2006-1990. \n Publish Date : 2006-08-31 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -925,7 +925,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-4483",
-            "summary": "The cURL extension files (1) ext\/curl\/interface.c and (2) ext\/curl\/streams.c in PHP before 5.1.5 permit the CURLOPT_FOLLOWLOCATION option when open_basedir or safe_mode is enabled, which allows attackers to perform unauthorized actions, possibly related to the realpath cache.",
+            "summary": "The cURL extension files (1) ext\/curl\/interface.c and (2) ext\/curl\/streams.c in PHP before 5.1.5 permit the CURLOPT_FOLLOWLOCATION option when open_basedir or safe_mode is enabled, which allows attackers to perform unauthorized actions, possibly related to the realpath cache. \n Publish Date : 2006-08-31 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -935,7 +935,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-4484",
-            "summary": "Buffer overflow in the LWZReadByte_ function in ext\/gd\/libgd\/gd_gif_in.c in the GD extension in PHP before 5.1.5 allows remote attackers to have an unknown impact via a GIF file with input_code_size greater than MAX_LWZ_BITS, which triggers an overflow when initializing the table array.",
+            "summary": "Buffer overflow in the LWZReadByte_ function in ext\/gd\/libgd\/gd_gif_in.c in the GD extension in PHP before 5.1.5 allows remote attackers to have an unknown impact via a GIF file with input_code_size greater than MAX_LWZ_BITS, which triggers an overflow when initializing the table array. \n Publish Date : 2006-08-31 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -945,7 +945,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2006-4485",
-            "summary": "The stripos function in PHP before 5.1.5 has unknown impact and attack vectors related to an out-of-bounds read.",
+            "summary": "The stripos function in PHP before 5.1.5 has unknown impact and attack vectors related to an out-of-bounds read. \n Publish Date : 2006-08-31 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -955,7 +955,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-4486",
-            "summary": "Integer overflow in memory allocation routines in PHP before 5.1.6, when running on a 64-bit system, allows context-dependent attackers to bypass the memory_limit restriction.",
+            "summary": "Integer overflow in memory allocation routines in PHP before 5.1.6, when running on a 64-bit system, allows context-dependent attackers to bypass the memory_limit restriction. \n Publish Date : 2006-08-31 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.1.6"
@@ -965,7 +965,7 @@
         {
             "threat": "3.6",
             "cveid": "CVE-2006-4625",
-            "summary": "PHP 4.x up to 4.4.4 and PHP 5 up to 5.1.6 allows local users to bypass certain Apache HTTP Server httpd.conf options, such as safe_mode and open_basedir, via the ini_restore function, which resets the values to their php.ini (Master Value) defaults.",
+            "summary": "PHP 4.x up to 4.4.4 and PHP 5 up to 5.1.6 allows local users to bypass certain Apache HTTP Server httpd.conf options, such as safe_mode and open_basedir, via the ini_restore function, which resets the values to their php.ini (Master Value) defaults. \n Publish Date : 2006-09-12 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -981,7 +981,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2006-4812",
-            "summary": "Integer overflow in PHP 5 up to 5.1.6 and 4 before 4.3.0 allows remote attackers to execute arbitrary code via an argument to the unserialize PHP function with a large value for the number of array elements, which triggers the overflow in the Zend Engine ecalloc function (Zend\/zend_alloc.c).",
+            "summary": "Integer overflow in PHP 5 up to 5.1.6 and 4 before 4.3.0 allows remote attackers to execute arbitrary code via an argument to the unserialize PHP function with a large value for the number of array elements, which triggers the overflow in the Zend Engine ecalloc function (Zend\/zend_alloc.c). \n Publish Date : 2006-10-10 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -995,7 +995,7 @@
         {
             "threat": "6.2",
             "cveid": "CVE-2006-5178",
-            "summary": "Race condition in the symlink function in PHP 5.1.6 and earlier allows local users to bypass the open_basedir restriction by using a combination of symlink, mkdir, and unlink functions to change the file path after the open_basedir check and before the file is opened by the underlying system, as demonstrated by symlinking a symlink into a subdirectory, to point to a parent directory via .. (dot dot) sequences, and then unlinking the resulting symlink.",
+            "summary": "Race condition in the symlink function in PHP 5.1.6 and earlier allows local users to bypass the open_basedir restriction by using a combination of symlink, mkdir, and unlink functions to change the file path after the open_basedir check and before the file is opened by the underlying system, as demonstrated by symlinking a symlink into a subdirectory, to point to a parent directory via .. (dot dot) sequences, and then unlinking the resulting symlink. \n Publish Date : 2006-10-10 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1011,7 +1011,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2006-5465",
-            "summary": "Buffer overflow in PHP before 5.2.0 allows remote attackers to execute arbitrary code via crafted UTF-8 inputs to the (1) htmlentities or (2) htmlspecialchars functions.",
+            "summary": "Buffer overflow in PHP before 5.2.0 allows remote attackers to execute arbitrary code via crafted UTF-8 inputs to the (1) htmlentities or (2) htmlspecialchars functions. \n Publish Date : 2006-11-03 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1022,7 +1022,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2006-5706",
-            "summary": "Unspecified vulnerabilities in PHP, probably before 5.2.0, allow local users to bypass open_basedir restrictions and perform unspecified actions via unspecified vectors involving the (1) chdir and (2) tempnam functions.  NOTE: the tempnam vector might overlap CVE-2006-1494.",
+            "summary": "Unspecified vulnerabilities in PHP, probably before 5.2.0, allow local users to bypass open_basedir restrictions and perform unspecified actions via unspecified vectors involving the (1) chdir and (2) tempnam functions.  NOTE: the tempnam vector might overlap CVE-2006-1494. \n Publish Date : 2006-11-03 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1033,7 +1033,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2006-6383",
-            "summary": "PHP 5.2.0 and 4.4 allows local users to bypass safe_mode and open_basedir restrictions via a malicious path and a null byte before a \";\" in a session_save_path argument, followed by an allowed path, which causes a parsing inconsistency in which PHP validates the allowed path but sets session.save_path to the malicious path.",
+            "summary": "PHP 5.2.0 and 4.4 allows local users to bypass safe_mode and open_basedir restrictions via a malicious path and a null byte before a \";\" in a session_save_path argument, followed by an allowed path, which causes a parsing inconsistency in which PHP validates the allowed path but sets session.save_path to the malicious path. \n Publish Date : 2006-12-10 Last Update Date : 2008-11-15",
             "fixVersions": {
                 "base": [
                     "5.2.1",
@@ -1044,7 +1044,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-7204",
-            "summary": "The imap_body function in PHP before 4.4.4 does not implement safemode or open_basedir checks, which allows local users to read arbitrary files or list arbitrary directory contents.",
+            "summary": "The imap_body function in PHP before 4.4.4 does not implement safemode or open_basedir checks, which allows local users to read arbitrary files or list arbitrary directory contents. \n Publish Date : 2007-05-22 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.4"
@@ -1054,7 +1054,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-7243",
-            "summary": "PHP before 5.3.4 accepts the \\0 character in a pathname, which might allow context-dependent attackers to bypass intended access restrictions by placing a safe file extension after this character, as demonstrated by .php\\0.jpg at the end of the argument to the file_exists function.",
+            "summary": "PHP before 5.3.4 accepts the \\0 character in a pathname, which might allow context-dependent attackers to bypass intended access restrictions by placing a safe file extension after this character, as demonstrated by .php\\0.jpg at the end of the argument to the file_exists function. \n Publish Date : 2011-01-18 Last Update Date : 2014-03-25",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1072,7 +1072,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2007-0448",
-            "summary": "The fopen function in PHP 5.2.0 does not properly handle invalid URI handlers, which allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files via a file path specified with an invalid URI, as demonstrated via the srpath URI.",
+            "summary": "The fopen function in PHP 5.2.0 does not properly handle invalid URI handlers, which allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files via a file path specified with an invalid URI, as demonstrated via the srpath URI. \n Publish Date : 2007-05-24 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1082,7 +1082,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-0905",
-            "summary": "PHP before 5.2.1 allows attackers to bypass safe_mode and open_basedir restrictions via unspecified vectors in the session extension.  NOTE: it is possible that this issue is a duplicate of CVE-2006-6383.",
+            "summary": "PHP before 5.2.1 allows attackers to bypass safe_mode and open_basedir restrictions via unspecified vectors in the session extension.  NOTE: it is possible that this issue is a duplicate of CVE-2006-6383. \n Publish Date : 2007-02-13 Last Update Date : 2008-11-15",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1099,7 +1099,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-0906",
-            "summary": "Multiple buffer overflows in PHP before 5.2.1 allow attackers to cause a denial of service and possibly execute arbitrary code via unspecified vectors in the (1) session, (2) zip, (3) imap, and (4) sqlite extensions; (5) stream filters; and the (6) str_replace, (7) mail, (8) ibase_delete_user, (9) ibase_add_user, and (10) ibase_modify_user functions.  NOTE: vector 6 might actually be an integer overflow (CVE-2007-1885).  NOTE: as of 20070411, vector (3) might involve the imap_mail_compose function (CVE-2007-1825).",
+            "summary": "Multiple buffer overflows in PHP before 5.2.1 allow attackers to cause a denial of service and possibly execute arbitrary code via unspecified vectors in the (1) session, (2) zip, (3) imap, and (4) sqlite extensions; (5) stream filters; and the (6) str_replace, (7) mail, (8) ibase_delete_user, (9) ibase_add_user, and (10) ibase_modify_user functions.  NOTE: vector 6 might actually be an integer overflow (CVE-2007-1885).  NOTE: as of 20070411, vector (3) might involve the imap_mail_compose function (CVE-2007-1825). \n Publish Date : 2007-02-13 Last Update Date : 2011-09-20",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1116,7 +1116,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-0907",
-            "summary": "Buffer underflow in PHP before 5.2.1 allows attackers to cause a denial of service via unspecified vectors involving the sapi_header_op function.",
+            "summary": "Buffer underflow in PHP before 5.2.1 allows attackers to cause a denial of service via unspecified vectors involving the sapi_header_op function. \n Publish Date : 2007-02-13 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1133,7 +1133,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-0908",
-            "summary": "The WDDX deserializer in the wddx extension in PHP 5 before 5.2.1 and PHP 4 before 4.4.5 does not properly initialize the key_length variable for a numerical key, which allows context-dependent attackers to read stack memory via a wddxPacket element that contains a variable with a string name before a numerical variable.",
+            "summary": "The WDDX deserializer in the wddx extension in PHP 5 before 5.2.1 and PHP 4 before 4.4.5 does not properly initialize the key_length variable for a numerical key, which allows context-dependent attackers to read stack memory via a wddxPacket element that contains a variable with a string name before a numerical variable. \n Publish Date : 2007-02-13 Last Update Date : 2011-06-06",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1150,7 +1150,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-0909",
-            "summary": "Multiple format string vulnerabilities in PHP before 5.2.1 might allow attackers to execute arbitrary code via format string specifiers to (1) all of the *print functions on 64-bit systems, and (2) the odbc_result_all function.",
+            "summary": "Multiple format string vulnerabilities in PHP before 5.2.1 might allow attackers to execute arbitrary code via format string specifiers to (1) all of the *print functions on 64-bit systems, and (2) the odbc_result_all function. \n Publish Date : 2007-02-13 Last Update Date : 2010-09-15",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1167,7 +1167,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2007-0910",
-            "summary": "Unspecified vulnerability in PHP before 5.2.1 allows attackers to \"clobber\" certain super-global variables via unspecified vectors.",
+            "summary": "Unspecified vulnerability in PHP before 5.2.1 allows attackers to \"clobber\" certain super-global variables via unspecified vectors. \n Publish Date : 2007-02-13 Last Update Date : 2011-03-10",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1184,7 +1184,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2007-0911",
-            "summary": "Off-by-one error in the str_ireplace function in PHP 5.2.1 might allow context-dependent attackers to cause a denial of service (crash).",
+            "summary": "Off-by-one error in the str_ireplace function in PHP 5.2.1 might allow context-dependent attackers to cause a denial of service (crash). \n Publish Date : 2007-02-13 Last Update Date : 2008-11-15",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1194,7 +1194,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-0988",
-            "summary": "The zend_hash_init function in PHP 5 before 5.2.1 and PHP 4 before 4.4.5, when running on a 64-bit platform, allows context-dependent attackers to cause a denial of service (infinite loop) by unserializing certain integer expressions, which only cause 32-bit arguments to be used after the check for a negative value, as demonstrated by an \"a:2147483649:{\" argument.",
+            "summary": "The zend_hash_init function in PHP 5 before 5.2.1 and PHP 4 before 4.4.5, when running on a 64-bit platform, allows context-dependent attackers to cause a denial of service (infinite loop) by unserializing certain integer expressions, which only cause 32-bit arguments to be used after the check for a negative value, as demonstrated by an \"a:2147483649:{\" argument. \n Publish Date : 2007-02-20 Last Update Date : 2011-05-25",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1211,7 +1211,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1001",
-            "summary": "Multiple integer overflows in the (1) createwbmp and (2) readwbmp functions in wbmp.c in the GD library (libgd) in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allow context-dependent attackers to execute arbitrary code via Wireless Bitmap (WBMP) images with large width or height values.",
+            "summary": "Multiple integer overflows in the (1) createwbmp and (2) readwbmp functions in wbmp.c in the GD library (libgd) in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allow context-dependent attackers to execute arbitrary code via Wireless Bitmap (WBMP) images with large width or height values. \n Publish Date : 2007-04-05 Last Update Date : 2011-09-08",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1228,7 +1228,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-1285",
-            "summary": "The Zend Engine in PHP 4.x before 4.4.7, and 5.x before 5.2.2, allows remote attackers to cause a denial of service (stack exhaustion and PHP crash) via deeply nested arrays, which trigger deep recursion in the variable destruction routines.",
+            "summary": "The Zend Engine in PHP 4.x before 4.4.7, and 5.x before 5.2.2, allows remote attackers to cause a denial of service (stack exhaustion and PHP crash) via deeply nested arrays, which trigger deep recursion in the variable destruction routines. \n Publish Date : 2007-03-06 Last Update Date : 2010-11-30",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1245,7 +1245,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1286",
-            "summary": "Integer overflow in PHP 4.4.4 and earlier allows remote context-dependent attackers to execute arbitrary code via a long string to the unserialize function, which triggers the overflow in the ZVAL reference counter.",
+            "summary": "Integer overflow in PHP 4.4.4 and earlier allows remote context-dependent attackers to execute arbitrary code via a long string to the unserialize function, which triggers the overflow in the ZVAL reference counter. \n Publish Date : 2007-03-06 Last Update Date : 2010-11-30",
             "fixVersions": {
                 "base": [
                     "4.4.5"
@@ -1255,7 +1255,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-1287",
-            "summary": "A regression error in the phpinfo function in PHP 4.4.3 to 4.4.6, and PHP 6.0 in CVS, allows remote attackers to conduct cross-site scripting (XSS) attacks via GET, POST, or COOKIE array values, which are not escaped in the phpinfo output, as originally fixed for CVE-2005-3388.",
+            "summary": "A regression error in the phpinfo function in PHP 4.4.3 to 4.4.6, and PHP 6.0 in CVS, allows remote attackers to conduct cross-site scripting (XSS) attacks via GET, POST, or COOKIE array values, which are not escaped in the phpinfo output, as originally fixed for CVE-2005-3388. \n Publish Date : 2007-03-06 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1265,7 +1265,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-1375",
-            "summary": "Integer overflow in the substr_compare function in PHP 5.2.1 and earlier allows context-dependent attackers to read sensitive memory via a large value in the length argument, a different vulnerability than CVE-2006-1991.",
+            "summary": "Integer overflow in the substr_compare function in PHP 5.2.1 and earlier allows context-dependent attackers to read sensitive memory via a large value in the length argument, a different vulnerability than CVE-2006-1991. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1275,7 +1275,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1376",
-            "summary": "The shmop functions in PHP before 4.4.5, and before 5.2.1 in the 5.x series, do not verify that their arguments correspond to a shmop resource, which allows context-dependent attackers to read and write arbitrary memory locations via arguments associated with an inappropriate resource, as demonstrated by a GD Image resource.",
+            "summary": "The shmop functions in PHP before 4.4.5, and before 5.2.1 in the 5.x series, do not verify that their arguments correspond to a shmop resource, which allows context-dependent attackers to read and write arbitrary memory locations via arguments associated with an inappropriate resource, as demonstrated by a GD Image resource. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1292,7 +1292,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2007-1378",
-            "summary": "The ovrimos_longreadlen function in the Ovrimos extension for PHP before 4.4.5 allows context-dependent attackers to write to arbitrary memory locations via the result_id and length arguments.",
+            "summary": "The ovrimos_longreadlen function in the Ovrimos extension for PHP before 4.4.5 allows context-dependent attackers to write to arbitrary memory locations via the result_id and length arguments. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1306,7 +1306,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2007-1379",
-            "summary": "The ovrimos_close function in the Ovrimos extension for PHP before 4.4.5 can trigger efree of an arbitrary address, which might allow context-dependent attackers to execute arbitrary code.",
+            "summary": "The ovrimos_close function in the Ovrimos extension for PHP before 4.4.5 can trigger efree of an arbitrary address, which might allow context-dependent attackers to execute arbitrary code. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1320,7 +1320,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-1380",
-            "summary": "The php_binary serialization handler in the session extension in PHP before 4.4.5, and 5.x before 5.2.1, allows context-dependent attackers to obtain sensitive information (memory contents) via a serialized variable entry with a large length value, which triggers a buffer over-read.",
+            "summary": "The php_binary serialization handler in the session extension in PHP before 4.4.5, and 5.x before 5.2.1, allows context-dependent attackers to obtain sensitive information (memory contents) via a serialized variable entry with a large length value, which triggers a buffer over-read. \n Publish Date : 2007-03-09 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1337,7 +1337,7 @@
         {
             "threat": "7.6",
             "cveid": "CVE-2007-1381",
-            "summary": "The wddx_deserialize function in wddx.c 1.119.2.10.2.12 and 1.119.2.10.2.13 in PHP 5, as modified in CVS on 20070224 and fixed on 20070304, calls strlcpy where strlcat was intended and uses improper arguments, which allows context-dependent attackers to execute arbitrary code via a WDDX packet with a malformed overlap of a STRING element, which triggers a buffer overflow.",
+            "summary": "The wddx_deserialize function in wddx.c 1.119.2.10.2.12 and 1.119.2.10.2.13 in PHP 5, as modified in CVS on 20070224 and fixed on 20070304, calls strlcpy where strlcat was intended and uses improper arguments, which allows context-dependent attackers to execute arbitrary code via a WDDX packet with a malformed overlap of a STRING element, which triggers a buffer overflow. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.0.1"
@@ -1347,7 +1347,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1396",
-            "summary": "The import_request_variables function in PHP 4.0.7 through 4.4.6, and 5.x before 5.2.2, when called without a prefix, does not prevent the (1) GET, (2) POST, (3) COOKIE, (4) FILES, (5) SERVER, (6) SESSION, and other superglobals from being overwritten, which allows remote attackers to spoof source IP address and Referer data, and have other unspecified impact.  NOTE: it could be argued that this is a design limitation of PHP and that only the misuse of this feature, i.e. implementation bugs in applications, should be included in CVE. However, it has been fixed by the vendor.",
+            "summary": "The import_request_variables function in PHP 4.0.7 through 4.4.6, and 5.x before 5.2.2, when called without a prefix, does not prevent the (1) GET, (2) POST, (3) COOKIE, (4) FILES, (5) SERVER, (6) SESSION, and other superglobals from being overwritten, which allows remote attackers to spoof source IP address and Referer data, and have other unspecified impact.  NOTE: it could be argued that this is a design limitation of PHP and that only the misuse of this feature, i.e. implementation bugs in applications, should be included in CVE. However, it has been fixed by the vendor. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1364,7 +1364,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2007-1399",
-            "summary": "Stack-based buffer overflow in the zip:\/\/ URL wrapper in PECL ZIP 1.8.3 and earlier, as bundled with PHP 5.2.0 and 5.2.1, allows remote attackers to execute arbitrary code via a long zip:\/\/ URL, as demonstrated by actively triggering URL access from a remote PHP interpreter via avatar upload or blog pingback.",
+            "summary": "Stack-based buffer overflow in the zip:\/\/ URL wrapper in PECL ZIP 1.8.3 and earlier, as bundled with PHP 5.2.0 and 5.2.1, allows remote attackers to execute arbitrary code via a long zip:\/\/ URL, as demonstrated by actively triggering URL access from a remote PHP interpreter via avatar upload or blog pingback. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1374,7 +1374,7 @@
         {
             "threat": "6.9",
             "cveid": "CVE-2007-1401",
-            "summary": "Buffer overflow in the crack extension (CrackLib), as bundled with PHP 4.4.6 and other versions before 5.0.0, might allow local users to gain privileges via a long argument to the crack_opendict function.",
+            "summary": "Buffer overflow in the crack extension (CrackLib), as bundled with PHP 4.4.6 and other versions before 5.0.0, might allow local users to gain privileges via a long argument to the crack_opendict function. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1384,7 +1384,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1411",
-            "summary": "Buffer overflow in PHP 4.4.6 and earlier, and unspecified PHP 5 versions, allows local and possibly remote attackers to execute arbitrary code via long server name arguments to the (1) mssql_connect and (2) mssql_pconnect functions.",
+            "summary": "Buffer overflow in PHP 4.4.6 and earlier, and unspecified PHP 5 versions, allows local and possibly remote attackers to execute arbitrary code via long server name arguments to the (1) mssql_connect and (2) mssql_pconnect functions. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1395,7 +1395,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2007-1412",
-            "summary": "The cpdf_open function in the ClibPDF (cpdf) extension in PHP 4.4.6 allows context-dependent attackers to obtain sensitive information (script source code) via a long string in the second argument.",
+            "summary": "The cpdf_open function in the ClibPDF (cpdf) extension in PHP 4.4.6 allows context-dependent attackers to obtain sensitive information (script source code) via a long string in the second argument. \n Publish Date : 2007-03-12 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1405,7 +1405,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1413",
-            "summary": "Buffer overflow in the snmpget function in the snmp extension in PHP 5.2.3 and earlier, including PHP 4.4.6 and probably other PHP 4 versions, allows context-dependent attackers to execute arbitrary code via a long value in the third argument (object id).",
+            "summary": "Buffer overflow in the snmpget function in the snmp extension in PHP 5.2.3 and earlier, including PHP 4.4.6 and probably other PHP 4 versions, allows context-dependent attackers to execute arbitrary code via a long value in the third argument (object id). \n Publish Date : 2007-03-12 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1416,7 +1416,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-1452",
-            "summary": "The FDF support (ext\/fdf) in PHP 5.2.0 and earlier does not implement the input filtering hooks for ext\/filter, which allows remote attackers to bypass web site filters via an application\/vnd.fdf formatted POST.",
+            "summary": "The FDF support (ext\/fdf) in PHP 5.2.0 and earlier does not implement the input filtering hooks for ext\/filter, which allows remote attackers to bypass web site filters via an application\/vnd.fdf formatted POST. \n Publish Date : 2007-03-14 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1428,7 +1428,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1453",
-            "summary": "Buffer underflow in the PHP_FILTER_TRIM_DEFAULT macro in the filtering extension (ext\/filter) in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by calling filter_var with certain modes such as FILTER_VALIDATE_INT, which causes filter to write a null byte in whitespace that precedes the buffer.",
+            "summary": "Buffer underflow in the PHP_FILTER_TRIM_DEFAULT macro in the filtering extension (ext\/filter) in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by calling filter_var with certain modes such as FILTER_VALIDATE_INT, which causes filter to write a null byte in whitespace that precedes the buffer. \n Publish Date : 2007-03-14 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1438,7 +1438,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-1454",
-            "summary": "ext\/filter in PHP 5.2.0, when FILTER_SANITIZE_STRING is used with the FILTER_FLAG_STRIP_LOW flag, does not properly strip HTML tags, which allows remote attackers to conduct cross-site scripting (XSS) attacks via HTML with a '<' character followed by certain whitespace characters, which passes one filter but is collapsed into a valid tag, as demonstrated using %0b.",
+            "summary": "ext\/filter in PHP 5.2.0, when FILTER_SANITIZE_STRING is used with the FILTER_FLAG_STRIP_LOW flag, does not properly strip HTML tags, which allows remote attackers to conduct cross-site scripting (XSS) attacks via HTML with a '<' character followed by certain whitespace characters, which passes one filter but is collapsed into a valid tag, as demonstrated using %0b. \n Publish Date : 2007-03-14 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1448,7 +1448,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-1460",
-            "summary": "The zip:\/\/ URL wrapper provided by the PECL zip extension in PHP before 4.4.7, and 5.2.0 and 5.2.1, does not implement safemode or open_basedir checks, which allows remote attackers to read ZIP archives located outside of the intended directories.",
+            "summary": "The zip:\/\/ URL wrapper provided by the PECL zip extension in PHP before 4.4.7, and 5.2.0 and 5.2.1, does not implement safemode or open_basedir checks, which allows remote attackers to read ZIP archives located outside of the intended directories. \n Publish Date : 2007-03-14 Last Update Date : 2011-05-24",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1463,7 +1463,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2007-1461",
-            "summary": "The compress.bzip2:\/\/ URL wrapper provided by the bz2 extension in PHP before 4.4.7, and 5.x before 5.2.2, does not implement safemode or open_basedir checks, which allows remote attackers to read bzip2 archives located outside of the intended directories.",
+            "summary": "The compress.bzip2:\/\/ URL wrapper provided by the bz2 extension in PHP before 4.4.7, and 5.x before 5.2.2, does not implement safemode or open_basedir checks, which allows remote attackers to read bzip2 archives located outside of the intended directories. \n Publish Date : 2007-03-14 Last Update Date : 2011-07-13",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1480,7 +1480,7 @@
         {
             "threat": "5.4",
             "cveid": "CVE-2007-1475",
-            "summary": "Multiple buffer overflows in the (1) ibase_connect and (2) ibase_pconnect functions in the interbase extension in PHP 4.4.6 and earlier allow context-dependent attackers to execute arbitrary code via a long argument.",
+            "summary": "Multiple buffer overflows in the (1) ibase_connect and (2) ibase_pconnect functions in the interbase extension in PHP 4.4.6 and earlier allow context-dependent attackers to execute arbitrary code via a long argument. \n Publish Date : 2007-03-16 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1494,7 +1494,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2007-1484",
-            "summary": "The array_user_key_compare function in PHP 4.4.6 and earlier, and 5.x up to 5.2.1, makes erroneous calls to zval_dtor, which triggers memory corruption and allows local users to bypass safe_mode and execute arbitrary code via a certain unset operation after array_user_key_compare has been called.",
+            "summary": "The array_user_key_compare function in PHP 4.4.6 and earlier, and 5.x up to 5.2.1, makes erroneous calls to zval_dtor, which triggers memory corruption and allows local users to bypass safe_mode and execute arbitrary code via a certain unset operation after array_user_key_compare has been called. \n Publish Date : 2007-03-16 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1507,7 +1507,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1521",
-            "summary": "Double free vulnerability in PHP before 4.4.7, and 5.x before 5.2.2, allows context-dependent attackers to execute arbitrary code by interrupting the session_regenerate_id function, as demonstrated by calling a userspace error handler or triggering a memory limit violation.",
+            "summary": "Double free vulnerability in PHP before 4.4.7, and 5.x before 5.2.2, allows context-dependent attackers to execute arbitrary code by interrupting the session_regenerate_id function, as demonstrated by calling a userspace error handler or triggering a memory limit violation. \n Publish Date : 2007-03-20 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1518,7 +1518,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1522",
-            "summary": "Double free vulnerability in the session extension in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to execute arbitrary code via illegal characters in a session identifier, which is rejected by an internal session storage module, which calls the session identifier generator with an improper environment, leading to code execution when the generator is interrupted, as demonstrated by triggering a memory limit violation or certain PHP errors.",
+            "summary": "Double free vulnerability in the session extension in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to execute arbitrary code via illegal characters in a session identifier, which is rejected by an internal session storage module, which calls the session identifier generator with an improper environment, leading to code execution when the generator is interrupted, as demonstrated by triggering a memory limit violation or certain PHP errors. \n Publish Date : 2007-03-20 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1528,7 +1528,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2007-1581",
-            "summary": "The resource system in PHP 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting the hash_update_file function via a userspace (1) error or (2) stream handler, which can then be used to destroy and modify internal resources.  NOTE: it was later reported that PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 are also affected.",
+            "summary": "The resource system in PHP 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting the hash_update_file function via a userspace (1) error or (2) stream handler, which can then be used to destroy and modify internal resources.  NOTE: it was later reported that PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 are also affected. \n Publish Date : 2007-03-21 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1541,7 +1541,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1582",
-            "summary": "The resource system in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting certain functions in the GD (ext\/gd) extension and unspecified other extensions via a userspace error handler, which can be used to destroy and modify internal resources.",
+            "summary": "The resource system in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting certain functions in the GD (ext\/gd) extension and unspecified other extensions via a userspace error handler, which can be used to destroy and modify internal resources. \n Publish Date : 2007-03-21 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1558,7 +1558,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1583",
-            "summary": "The mb_parse_str function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 sets the internal register_globals flag and does not disable it in certain cases when a script terminates, which allows remote attackers to invoke available PHP scripts with register_globals functionality that is not detectable by these scripts, as demonstrated by forcing a memory_limit violation.",
+            "summary": "The mb_parse_str function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 sets the internal register_globals flag and does not disable it in certain cases when a script terminates, which allows remote attackers to invoke available PHP scripts with register_globals functionality that is not detectable by these scripts, as demonstrated by forcing a memory_limit violation. \n Publish Date : 2007-03-21 Last Update Date : 2010-11-30",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1575,7 +1575,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1584",
-            "summary": "Buffer underflow in the header function in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by passing an all-whitespace string to this function, which causes it to write '\\0' characters in whitespace that precedes the string.",
+            "summary": "Buffer underflow in the header function in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by passing an all-whitespace string to this function, which causes it to write '\\0' characters in whitespace that precedes the string. \n Publish Date : 2007-03-21 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1585,7 +1585,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2007-1649",
-            "summary": "PHP 5.2.1 allows context-dependent attackers to read portions of heap memory by executing certain scripts with a serialized data input string beginning with S:, which does not properly track the number of input bytes being processed.",
+            "summary": "PHP 5.2.1 allows context-dependent attackers to read portions of heap memory by executing certain scripts with a serialized data input string beginning with S:, which does not properly track the number of input bytes being processed. \n Publish Date : 2007-03-23 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1595,7 +1595,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1700",
-            "summary": "The session extension in PHP 4 before 4.4.5, and PHP 5 before 5.2.1, calculates the reference count for the session variables without considering the internal pointer from the session globals, which allows context-dependent attackers to execute arbitrary code via a crafted string in the session_register after unsetting HTTP_SESSION_VARS and _SESSION, which destroys the session data Hashtable.",
+            "summary": "The session extension in PHP 4 before 4.4.5, and PHP 5 before 5.2.1, calculates the reference count for the session variables without considering the internal pointer from the session globals, which allows context-dependent attackers to execute arbitrary code via a crafted string in the session_register after unsetting HTTP_SESSION_VARS and _SESSION, which destroys the session data Hashtable. \n Publish Date : 2007-03-26 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1612,7 +1612,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1701",
-            "summary": "PHP 4 before 4.4.5, and PHP 5 before 5.2.1, when register_globals is enabled, allows context-dependent attackers to execute arbitrary code via deserialization of session data, which overwrites arbitrary global variables, as demonstrated by calling session_decode on a string beginning with \"_SESSION|s:39:\".",
+            "summary": "PHP 4 before 4.4.5, and PHP 5 before 5.2.1, when register_globals is enabled, allows context-dependent attackers to execute arbitrary code via deserialization of session data, which overwrites arbitrary global variables, as demonstrated by calling session_decode on a string beginning with \"_SESSION|s:39:\". \n Publish Date : 2007-03-26 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.4.5",
@@ -1623,7 +1623,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-1709",
-            "summary": "Buffer overflow in the confirm_phpdoc_compiled function in the phpDOC extension (PECL phpDOC) in PHP 5.2.1 allows context-dependent attackers to execute arbitrary code via a long argument string.",
+            "summary": "Buffer overflow in the confirm_phpdoc_compiled function in the phpDOC extension (PECL phpDOC) in PHP 5.2.1 allows context-dependent attackers to execute arbitrary code via a long argument string. \n Publish Date : 2007-03-26 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1633,7 +1633,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-1710",
-            "summary": "The readfile function in PHP 4.4.4, 5.1.6, and 5.2.1 allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files by referring to local files with a certain URL syntax instead of a pathname syntax, as demonstrated by a filename preceded a \"php:\/\/..\/..\/\" sequence.",
+            "summary": "The readfile function in PHP 4.4.4, 5.1.6, and 5.2.1 allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files by referring to local files with a certain URL syntax instead of a pathname syntax, as demonstrated by a filename preceded a \"php:\/\/..\/..\/\" sequence. \n Publish Date : 2007-03-26 Last Update Date : 2013-08-03",
             "fixVersions": {
                 "base": [
                     "4.4.5",
@@ -1645,7 +1645,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1711",
-            "summary": "Double free vulnerability in the unserializer in PHP 4.4.5 and 4.4.6 allows context-dependent attackers to execute arbitrary code by overwriting variables pointing to (1) the GLOBALS array or (2) the session data in _SESSION.  NOTE: this issue was introduced when attempting to patch CVE-2007-1701 (MOPB-31-2007).",
+            "summary": "Double free vulnerability in the unserializer in PHP 4.4.5 and 4.4.6 allows context-dependent attackers to execute arbitrary code by overwriting variables pointing to (1) the GLOBALS array or (2) the session data in _SESSION.  NOTE: this issue was introduced when attempting to patch CVE-2007-1701 (MOPB-31-2007). \n Publish Date : 2007-03-26 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1655,7 +1655,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2007-1717",
-            "summary": "The mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 truncates e-mail messages at the first ASCIIZ ('\\0') byte, which might allow context-dependent attackers to prevent intended information from being delivered in e-mail messages.  NOTE: this issue might be security-relevant in cases when the trailing contents of e-mail messages are important, such as logging information or if the message is expected to be well-formed.",
+            "summary": "The mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 truncates e-mail messages at the first ASCIIZ ('\\0') byte, which might allow context-dependent attackers to prevent intended information from being delivered in e-mail messages.  NOTE: this issue might be security-relevant in cases when the trailing contents of e-mail messages are important, such as logging information or if the message is expected to be well-formed. \n Publish Date : 2007-03-27 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1672,7 +1672,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2007-1718",
-            "summary": "CRLF injection vulnerability in the mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows remote attackers to inject arbitrary e-mail headers and possibly conduct spam attacks via a control character immediately following folding of the (1) Subject or (2) To parameter, as demonstrated by a parameter containing a \"\\r\\n\\t\\n\" sequence, related to an increment bug in the SKIP_LONG_HEADER_SEP macro.",
+            "summary": "CRLF injection vulnerability in the mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows remote attackers to inject arbitrary e-mail headers and possibly conduct spam attacks via a control character immediately following folding of the (1) Subject or (2) To parameter, as demonstrated by a parameter containing a \"\\r\\n\\t\\n\" sequence, related to an increment bug in the SKIP_LONG_HEADER_SEP macro. \n Publish Date : 2007-03-27 Last Update Date : 2013-08-13",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1689,7 +1689,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1777",
-            "summary": "Integer overflow in the zip_read_entry function in PHP 4 before 4.4.5 allows remote attackers to execute arbitrary code via a ZIP archive that contains an entry with a length value of 0xffffffff, which is incremented before use in an emalloc call, triggering a heap overflow.",
+            "summary": "Integer overflow in the zip_read_entry function in PHP 4 before 4.4.5 allows remote attackers to execute arbitrary code via a ZIP archive that contains an entry with a length value of 0xffffffff, which is incremented before use in an emalloc call, triggering a heap overflow. \n Publish Date : 2007-03-29 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1703,7 +1703,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2007-1824",
-            "summary": "Buffer overflow in the php_stream_filter_create function in PHP 5 before 5.2.1 allows remote attackers to cause a denial of service (application crash) via a php:\/\/filter\/ URL that has a name ending in the '.' character.",
+            "summary": "Buffer overflow in the php_stream_filter_create function in PHP 5 before 5.2.1 allows remote attackers to cause a denial of service (application crash) via a php:\/\/filter\/ URL that has a name ending in the '.' character. \n Publish Date : 2007-04-02 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1715,7 +1715,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1825",
-            "summary": "Buffer overflow in the imap_mail_compose function in PHP 5 before 5.2.1, and PHP 4 before 4.4.5, allows remote attackers to execute arbitrary code via a long boundary string in a type.parameters field. NOTE: as of 20070411, it appears that this issue might be subsumed by CVE-2007-0906.3.",
+            "summary": "Buffer overflow in the imap_mail_compose function in PHP 5 before 5.2.1, and PHP 4 before 4.4.5, allows remote attackers to execute arbitrary code via a long boundary string in a type.parameters field. NOTE: as of 20070411, it appears that this issue might be subsumed by CVE-2007-0906.3. \n Publish Date : 2007-04-02 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1732,7 +1732,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2007-1835",
-            "summary": "PHP 4 before 4.4.5 and PHP 5 before 5.2.1, when using an empty session save path (session.save_path), uses the TMPDIR default after checking the restrictions, which allows local users to bypass open_basedir restrictions.",
+            "summary": "PHP 4 before 4.4.5 and PHP 5 before 5.2.1, when using an empty session save path (session.save_path), uses the TMPDIR default after checking the restrictions, which allows local users to bypass open_basedir restrictions. \n Publish Date : 2007-04-02 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1749,7 +1749,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1864",
-            "summary": "Buffer overflow in the bundled libxmlrpc library in PHP before 4.4.7, and 5.x before 5.2.2, has unknown impact and remote attack vectors.",
+            "summary": "Buffer overflow in the bundled libxmlrpc library in PHP before 4.4.7, and 5.x before 5.2.2, has unknown impact and remote attack vectors. \n Publish Date : 2007-05-08 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1760,7 +1760,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2007-1883",
-            "summary": "PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to read arbitrary memory locations via an interruption that triggers a user space error handler that changes a parameter to an arbitrary pointer, as demonstrated via the iptcembed function, which calls certain convert_to_* functions with its input parameters.",
+            "summary": "PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to read arbitrary memory locations via an interruption that triggers a user space error handler that changes a parameter to an arbitrary pointer, as demonstrated via the iptcembed function, which calls certain convert_to_* functions with its input parameters. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1777,7 +1777,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1884",
-            "summary": "Multiple integer signedness errors in the printf function family in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 on 64 bit machines allow context-dependent attackers to execute arbitrary code via (1) certain negative argument numbers that arise in the php_formatted_print function because of 64 to 32 bit truncation, and bypass a check for the maximum allowable value; and (2) a width and precision of -1, which make it possible for the php_sprintf_appendstring function to place an internal buffer at an arbitrary memory location.",
+            "summary": "Multiple integer signedness errors in the printf function family in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 on 64 bit machines allow context-dependent attackers to execute arbitrary code via (1) certain negative argument numbers that arise in the php_formatted_print function because of 64 to 32 bit truncation, and bypass a check for the maximum allowable value; and (2) a width and precision of -1, which make it possible for the php_sprintf_appendstring function to place an internal buffer at an arbitrary memory location. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1794,7 +1794,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1885",
-            "summary": "Integer overflow in the str_replace function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via a single character search string in conjunction with a long replacement string, which overflows a 32 bit length counter.  NOTE: this is probably the same issue as CVE-2007-0906.6.",
+            "summary": "Integer overflow in the str_replace function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via a single character search string in conjunction with a long replacement string, which overflows a 32 bit length counter.  NOTE: this is probably the same issue as CVE-2007-0906.6. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1811,7 +1811,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-1886",
-            "summary": "Integer overflow in the str_replace function in PHP 4.4.5 and PHP 5.2.1 allows context-dependent attackers to have an unknown impact via a single character search string in conjunction with a single character replacement string, which causes an \"off by one overflow.\"",
+            "summary": "Integer overflow in the str_replace function in PHP 4.4.5 and PHP 5.2.1 allows context-dependent attackers to have an unknown impact via a single character search string in conjunction with a single character replacement string, which causes an \"off by one overflow.\" \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.4.6",
@@ -1822,7 +1822,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1887",
-            "summary": "Buffer overflow in the sqlite_decode_binary function in the bundled sqlite library in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter, as demonstrated by calling the sqlite_udf_decode_binary function with a 0x01 character.",
+            "summary": "Buffer overflow in the sqlite_decode_binary function in the bundled sqlite library in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter, as demonstrated by calling the sqlite_udf_decode_binary function with a 0x01 character. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1839,7 +1839,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1888",
-            "summary": "Buffer overflow in the sqlite_decode_binary function in src\/encode.c in SQLite 2, as used by PHP 4.x through 5.x and other applications, allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter.  NOTE: some PHP installations use a bundled version of sqlite without this vulnerability.  The SQLite developer has argued that this issue could be due to a misuse of the sqlite_decode_binary() API.",
+            "summary": "Buffer overflow in the sqlite_decode_binary function in src\/encode.c in SQLite 2, as used by PHP 4.x through 5.x and other applications, allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter.  NOTE: some PHP installations use a bundled version of sqlite without this vulnerability.  The SQLite developer has argued that this issue could be due to a misuse of the sqlite_decode_binary() API. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1857,7 +1857,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1889",
-            "summary": "Integer signedness error in the _zend_mm_alloc_int function in the Zend Memory Manager in PHP 5.2.0 allows remote attackers to execute arbitrary code via a large emalloc request, related to an incorrect signed long cast, as demonstrated via the HTTP SOAP client in PHP, and via a call to msg_receive with the largest positive integer value of maxsize.",
+            "summary": "Integer signedness error in the _zend_mm_alloc_int function in the Zend Memory Manager in PHP 5.2.0 allows remote attackers to execute arbitrary code via a large emalloc request, related to an incorrect signed long cast, as demonstrated via the HTTP SOAP client in PHP, and via a call to msg_receive with the largest positive integer value of maxsize. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1867,7 +1867,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-1890",
-            "summary": "Integer overflow in the msg_receive function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1, on FreeBSD and possibly other platforms, allows context-dependent attackers to execute arbitrary code via certain maxsize values, as demonstrated by 0xffffffff.",
+            "summary": "Integer overflow in the msg_receive function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1, on FreeBSD and possibly other platforms, allows context-dependent attackers to execute arbitrary code via certain maxsize values, as demonstrated by 0xffffffff. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1884,7 +1884,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-1900",
-            "summary": "CRLF injection vulnerability in the FILTER_VALIDATE_EMAIL filter in ext\/filter in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to inject arbitrary e-mail headers via an e-mail address with a '\\n' character, which causes a regular expression to ignore the subsequent part of the address string.",
+            "summary": "CRLF injection vulnerability in the FILTER_VALIDATE_EMAIL filter in ext\/filter in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to inject arbitrary e-mail headers via an e-mail address with a '\\n' character, which causes a regular expression to ignore the subsequent part of the address string. \n Publish Date : 2007-04-10 Last Update Date : 2009-03-04",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1894,7 +1894,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-2369",
-            "summary": "Directory traversal vulnerability in picture.php in WebSPELL 4.01.02 and earlier, when PHP before 4.3.0 is used, allows remote attackers to read arbitrary files via a .. (dot dot) in the id parameter.",
+            "summary": "Directory traversal vulnerability in picture.php in WebSPELL 4.01.02 and earlier, when PHP before 4.3.0 is used, allows remote attackers to read arbitrary files via a .. (dot dot) in the id parameter. \n Publish Date : 2007-04-30 Last Update Date : 2008-11-15",
             "fixVersions": {
                 "base": [
                     "4.01.3",
@@ -1905,7 +1905,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2007-2509",
-            "summary": "CRLF injection vulnerability in the ftp_putcmd function in PHP before 4.4.7, and 5.x before 5.2.2 allows remote attackers to inject arbitrary FTP commands via CRLF sequences in the parameters to earlier FTP commands.",
+            "summary": "CRLF injection vulnerability in the ftp_putcmd function in PHP before 4.4.7, and 5.x before 5.2.2 allows remote attackers to inject arbitrary FTP commands via CRLF sequences in the parameters to earlier FTP commands. \n Publish Date : 2007-05-08 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1922,7 +1922,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2007-2510",
-            "summary": "Buffer overflow in the make_http_soap_request function in PHP before 5.2.2 has unknown impact and remote attack vectors, possibly related to \"\/\" (slash) characters.",
+            "summary": "Buffer overflow in the make_http_soap_request function in PHP before 5.2.2 has unknown impact and remote attack vectors, possibly related to \"\/\" (slash) characters. \n Publish Date : 2007-05-08 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1939,7 +1939,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2007-2511",
-            "summary": "Buffer overflow in the user_filter_factory_create function in PHP before 5.2.2 has unknown impact and local attack vectors.",
+            "summary": "Buffer overflow in the user_filter_factory_create function in PHP before 5.2.2 has unknown impact and local attack vectors. \n Publish Date : 2007-05-08 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1954,7 +1954,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2007-2727",
-            "summary": "The mcrypt_create_iv function in ext\/mcrypt\/mcrypt.c in PHP before 4.4.7, 5.2.1, and possibly 5.0.x and other PHP 5 versions, calls php_rand_r with an uninitialized seed variable and therefore always generates the same initialization vector (IV), which might allow context-dependent attackers to decrypt certain data more easily because of the guessable encryption keys.",
+            "summary": "The mcrypt_create_iv function in ext\/mcrypt\/mcrypt.c in PHP before 4.4.7, 5.2.1, and possibly 5.0.x and other PHP 5 versions, calls php_rand_r with an uninitialized seed variable and therefore always generates the same initialization vector (IV), which might allow context-dependent attackers to decrypt certain data more easily because of the guessable encryption keys. \n Publish Date : 2007-05-16 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1971,7 +1971,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-2748",
-            "summary": "The substr_count function in PHP 5.2.1 and earlier allows context-dependent attackers to obtain sensitive information via unspecified vectors, a different affected function than CVE-2007-1375.",
+            "summary": "The substr_count function in PHP 5.2.1 and earlier allows context-dependent attackers to obtain sensitive information via unspecified vectors, a different affected function than CVE-2007-1375. \n Publish Date : 2007-05-17 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1983,7 +1983,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2007-2844",
-            "summary": "PHP 4.x and 5.x before 5.2.1, when running on multi-threaded systems, does not ensure thread safety for libc crypt function calls using protection schemes such as a mutex, which creates race conditions that allow remote attackers to overwrite internal program memory and gain system access.",
+            "summary": "PHP 4.x and 5.x before 5.2.1, when running on multi-threaded systems, does not ensure thread safety for libc crypt function calls using protection schemes such as a mutex, which creates race conditions that allow remote attackers to overwrite internal program memory and gain system access. \n Publish Date : 2007-05-24 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2000,7 +2000,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-2872",
-            "summary": "Multiple integer overflows in the chunk_split function in PHP 5 before 5.2.3 and PHP 4 before 4.4.8 allow remote attackers to cause a denial of service (crash) or execute arbitrary code via the (1) chunks, (2) srclen, and (3) chunklen arguments.",
+            "summary": "Multiple integer overflows in the chunk_split function in PHP 5 before 5.2.3 and PHP 4 before 4.4.8 allow remote attackers to cause a denial of service (crash) or execute arbitrary code via the (1) chunks, (2) srclen, and (3) chunklen arguments. \n Publish Date : 2007-06-04 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2013,7 +2013,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-3007",
-            "summary": "PHP 5 before 5.2.3 does not enforce the open_basedir or safe_mode restriction in certain cases, which allows context-dependent attackers to determine the existence of arbitrary files by checking if the readfile function returns a string.  NOTE: this issue might also involve the realpath function.",
+            "summary": "PHP 5 before 5.2.3 does not enforce the open_basedir or safe_mode restriction in certain cases, which allows context-dependent attackers to determine the existence of arbitrary files by checking if the readfile function returns a string.  NOTE: this issue might also involve the realpath function. \n Publish Date : 2007-06-04 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2025,7 +2025,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-3294",
-            "summary": "Multiple buffer overflows in libtidy, as used in the Tidy extension for PHP 5.2.3 and possibly other products, allow context-dependent attackers to execute arbitrary code via (1) a long second argument to the tidy_parse_string function or (2) an unspecified vector to the tidy_repair_string function.  NOTE: this might only be an issue in environments where vsnprintf is implemented as a wrapper for vsprintf.",
+            "summary": "Multiple buffer overflows in libtidy, as used in the Tidy extension for PHP 5.2.3 and possibly other products, allow context-dependent attackers to execute arbitrary code via (1) a long second argument to the tidy_parse_string function or (2) an unspecified vector to the tidy_repair_string function.  NOTE: this might only be an issue in environments where vsnprintf is implemented as a wrapper for vsprintf. \n Publish Date : 2007-06-20 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2035,7 +2035,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-3378",
-            "summary": "The (1) session_save_path, (2) ini_set, and (3) error_log functions in PHP 4.4.7 and earlier, and PHP 5 5.2.3 and earlier, when invoked from a .htaccess file, allow remote attackers to bypass safe_mode and open_basedir restrictions and possibly execute arbitrary commands, as demonstrated using (a) php_value, (b) php_flag, and (c) directives in .htaccess.",
+            "summary": "The (1) session_save_path, (2) ini_set, and (3) error_log functions in PHP 4.4.7 and earlier, and PHP 5 5.2.3 and earlier, when invoked from a .htaccess file, allow remote attackers to bypass safe_mode and open_basedir restrictions and possibly execute arbitrary commands, as demonstrated using (a) php_value, (b) php_flag, and (c) directives in .htaccess. \n Publish Date : 2007-06-29 Last Update Date : 2010-11-22",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2046,7 +2046,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2007-3790",
-            "summary": "The com_print_typeinfo function in the bz2 extension in PHP 5.2.3 allows context-dependent attackers to cause a denial of service via a long argument.",
+            "summary": "The com_print_typeinfo function in the bz2 extension in PHP 5.2.3 allows context-dependent attackers to cause a denial of service via a long argument. \n Publish Date : 2007-07-15 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2056,7 +2056,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-3799",
-            "summary": "The session_start function in ext\/session in PHP 4.x up to 4.4.7 and 5.x up to 5.2.3 allows remote attackers to insert arbitrary attributes into the session cookie via special characters in a cookie that is obtained from (1) PATH_INFO, (2) the session_id function, and (3) the session_start function, which are not encoded or filtered when the new session cookie is generated, a related issue to CVE-2006-0207.",
+            "summary": "The session_start function in ext\/session in PHP 4.x up to 4.4.7 and 5.x up to 5.2.3 allows remote attackers to insert arbitrary attributes into the session cookie via special characters in a cookie that is obtained from (1) PATH_INFO, (2) the session_id function, and (3) the session_start function, which are not encoded or filtered when the new session cookie is generated, a related issue to CVE-2006-0207. \n Publish Date : 2007-07-16 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2073,7 +2073,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-3806",
-            "summary": "The glob function in PHP 5.2.3 allows context-dependent attackers to cause a denial of service and possibly execute arbitrary code via an invalid value of the flags parameter, probably related to memory corruption or an invalid read on win32 platforms, and possibly related to lack of initialization for a glob structure.",
+            "summary": "The glob function in PHP 5.2.3 allows context-dependent attackers to cause a denial of service and possibly execute arbitrary code via an invalid value of the flags parameter, probably related to memory corruption or an invalid read on win32 platforms, and possibly related to lack of initialization for a glob structure. \n Publish Date : 2007-07-16 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2083,7 +2083,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-3996",
-            "summary": "Multiple integer overflows in libgd in PHP before 5.2.4 allow remote attackers to cause a denial of service (application crash) and possibly execute arbitrary code via a large (1) srcW or (2) srcH value to the (a) gdImageCopyResized function, or a large (3) sy (height) or (4) sx (width) value to the (b) gdImageCreate or the (c) gdImageCreateTrueColor function.",
+            "summary": "Multiple integer overflows in libgd in PHP before 5.2.4 allow remote attackers to cause a denial of service (application crash) and possibly execute arbitrary code via a large (1) srcW or (2) srcH value to the (a) gdImageCopyResized function, or a large (3) sy (height) or (4) sx (width) value to the (b) gdImageCreate or the (c) gdImageCreateTrueColor function. \n Publish Date : 2007-09-04 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2093,7 +2093,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-3997",
-            "summary": "The (1) MySQL and (2) MySQLi extensions in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to bypass safe_mode and open_basedir restrictions via MySQL LOCAL INFILE operations, as demonstrated by a query with LOAD DATA LOCAL INFILE.",
+            "summary": "The (1) MySQL and (2) MySQLi extensions in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to bypass safe_mode and open_basedir restrictions via MySQL LOCAL INFILE operations, as demonstrated by a query with LOAD DATA LOCAL INFILE. \n Publish Date : 2007-09-04 Last Update Date : 2009-09-16",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2104,7 +2104,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-3998",
-            "summary": "The wordwrap function in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, does not properly use the breakcharlen variable, which allows remote attackers to cause a denial of service (divide-by-zero error and application crash, or infinite loop) via certain arguments, as demonstrated by a 'chr(0), 0, \"\"' argument set.",
+            "summary": "The wordwrap function in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, does not properly use the breakcharlen variable, which allows remote attackers to cause a denial of service (divide-by-zero error and application crash, or infinite loop) via certain arguments, as demonstrated by a 'chr(0), 0, \"\"' argument set. \n Publish Date : 2007-09-04 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2115,7 +2115,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-4010",
-            "summary": "The win32std extension in PHP 5.2.3 does not follow safe_mode and disable_functions restrictions, which allows remote attackers to execute arbitrary commands via the win_shell_execute function.",
+            "summary": "The win32std extension in PHP 5.2.3 does not follow safe_mode and disable_functions restrictions, which allows remote attackers to execute arbitrary commands via the win_shell_execute function. \n Publish Date : 2007-07-25 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2125,7 +2125,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4033",
-            "summary": "Buffer overflow in the intT1_EnvGetCompletePath function in lib\/t1lib\/t1env.c in t1lib 5.1.1 allows context-dependent attackers to execute arbitrary code via a long FileName parameter.  NOTE: this issue was originally reported to be in the imagepsloadfont function in php_gd2.dll in the gd (PHP_GD2) extension in PHP 5.2.3.",
+            "summary": "Buffer overflow in the intT1_EnvGetCompletePath function in lib\/t1lib\/t1env.c in t1lib 5.1.1 allows context-dependent attackers to execute arbitrary code via a long FileName parameter.  NOTE: this issue was originally reported to be in the imagepsloadfont function in php_gd2.dll in the gd (PHP_GD2) extension in PHP 5.2.3. \n Publish Date : 2007-07-27 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.1.2",
@@ -2136,7 +2136,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4255",
-            "summary": "Buffer overflow in the mSQL extension in PHP 5.2.3 allows context-dependent attackers to execute arbitrary code via a long first argument to the msql_connect function.",
+            "summary": "Buffer overflow in the mSQL extension in PHP 5.2.3 allows context-dependent attackers to execute arbitrary code via a long first argument to the msql_connect function. \n Publish Date : 2007-08-08 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2146,7 +2146,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2007-4441",
-            "summary": "Buffer overflow in php_win32std.dll in the win32std extension for PHP 5.2.0 and earlier allows context-dependent attackers to execute arbitrary code via a long string in the filename argument to the win_browse_file function.",
+            "summary": "Buffer overflow in php_win32std.dll in the win32std extension for PHP 5.2.0 and earlier allows context-dependent attackers to execute arbitrary code via a long string in the filename argument to the win_browse_file function. \n Publish Date : 2007-08-20 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -2156,7 +2156,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-4507",
-            "summary": "Multiple buffer overflows in the php_ntuser component for PHP 5.2.3 allow context-dependent attackers to cause a denial of service or execute arbitrary code via long arguments to the (1) ntuser_getuserlist, (2) ntuser_getuserinfo, (3) ntuser_getusergroups, or (4) ntuser_getdomaincontroller functions.",
+            "summary": "Multiple buffer overflows in the php_ntuser component for PHP 5.2.3 allow context-dependent attackers to cause a denial of service or execute arbitrary code via long arguments to the (1) ntuser_getuserlist, (2) ntuser_getuserinfo, (3) ntuser_getusergroups, or (4) ntuser_getdomaincontroller functions. \n Publish Date : 2007-08-23 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2166,7 +2166,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-4528",
-            "summary": "The Foreign Function Interface (ffi) extension in PHP 5.0.5 does not follow safe_mode restrictions, which allows context-dependent attackers to execute arbitrary code by loading an arbitrary DLL and calling a function, as demonstrated by kernel32.dll and the WinExec function.  NOTE: this issue does not cross privilege boundaries in most contexts, so perhaps it should not be included in CVE.",
+            "summary": "The Foreign Function Interface (ffi) extension in PHP 5.0.5 does not follow safe_mode restrictions, which allows context-dependent attackers to execute arbitrary code by loading an arbitrary DLL and calling a function, as demonstrated by kernel32.dll and the WinExec function.  NOTE: this issue does not cross privilege boundaries in most contexts, so perhaps it should not be included in CVE. \n Publish Date : 2007-08-24 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.0.6"
@@ -2176,7 +2176,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4586",
-            "summary": "Multiple buffer overflows in php_iisfunc.dll in the iisfunc extension for PHP 5.2.0 and earlier allow context-dependent attackers to execute arbitrary code, probably during Unicode conversion, as demonstrated by a long string in the first argument to the iis_getservicestate function, related to the ServiceId argument to the (1) fnStartService, (2) fnGetServiceState, (3) fnStopService, and possibly other functions.",
+            "summary": "Multiple buffer overflows in php_iisfunc.dll in the iisfunc extension for PHP 5.2.0 and earlier allow context-dependent attackers to execute arbitrary code, probably during Unicode conversion, as demonstrated by a long string in the first argument to the iis_getservicestate function, related to the ServiceId argument to the (1) fnStartService, (2) fnGetServiceState, (3) fnStopService, and possibly other functions. \n Publish Date : 2007-08-28 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -2186,7 +2186,7 @@
         {
             "threat": "4.4",
             "cveid": "CVE-2007-4652",
-            "summary": "The session extension in PHP before 5.2.4 might allow local users to bypass open_basedir restrictions via a session file that is a symlink.",
+            "summary": "The session extension in PHP before 5.2.4 might allow local users to bypass open_basedir restrictions via a session file that is a symlink. \n Publish Date : 2007-09-04 Last Update Date : 2011-08-23",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2203,7 +2203,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4657",
-            "summary": "Multiple integer overflows in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to obtain sensitive information (memory contents) or cause a denial of service (thread crash) via a large len value to the (1) strspn or (2) strcspn function, which triggers an out-of-bounds read.  NOTE: this affects different product versions than CVE-2007-3996.",
+            "summary": "Multiple integer overflows in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to obtain sensitive information (memory contents) or cause a denial of service (thread crash) via a large len value to the (1) strspn or (2) strcspn function, which triggers an out-of-bounds read.  NOTE: this affects different product versions than CVE-2007-3996. \n Publish Date : 2007-09-04 Last Update Date : 2009-09-16",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2214,7 +2214,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4658",
-            "summary": "The money_format function in PHP 5 before 5.2.4, and PHP 4 before 4.4.8, permits multiple (1) %i and (2) %n tokens, which has unknown impact and attack vectors, possibly related to a format string vulnerability.",
+            "summary": "The money_format function in PHP 5 before 5.2.4, and PHP 4 before 4.4.8, permits multiple (1) %i and (2) %n tokens, which has unknown impact and attack vectors, possibly related to a format string vulnerability. \n Publish Date : 2007-09-04 Last Update Date : 2011-06-20",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2231,7 +2231,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4659",
-            "summary": "The zend_alter_ini_entry function in PHP before 5.2.4 does not properly handle an interruption to the flow of execution triggered by a memory_limit violation, which has unknown impact and attack vectors.",
+            "summary": "The zend_alter_ini_entry function in PHP before 5.2.4 does not properly handle an interruption to the flow of execution triggered by a memory_limit violation, which has unknown impact and attack vectors. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2241,7 +2241,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4660",
-            "summary": "Unspecified vulnerability in the chunk_split function in PHP before 5.2.4 has unknown impact and attack vectors, related to an incorrect size calculation.",
+            "summary": "Unspecified vulnerability in the chunk_split function in PHP before 5.2.4 has unknown impact and attack vectors, related to an incorrect size calculation. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-10",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2251,7 +2251,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4661",
-            "summary": "The chunk_split function in string.c in PHP 5.2.3 does not properly calculate the needed buffer size due to precision loss when performing integer arithmetic with floating point numbers, which has unknown attack vectors and impact, possibly resulting in a heap-based buffer overflow.  NOTE: this is due to an incomplete fix for CVE-2007-2872.",
+            "summary": "The chunk_split function in string.c in PHP 5.2.3 does not properly calculate the needed buffer size due to precision loss when performing integer arithmetic with floating point numbers, which has unknown attack vectors and impact, possibly resulting in a heap-based buffer overflow.  NOTE: this is due to an incomplete fix for CVE-2007-2872. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2261,7 +2261,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4662",
-            "summary": "Buffer overflow in the php_openssl_make_REQ function in PHP before 5.2.4 has unknown impact and attack vectors.",
+            "summary": "Buffer overflow in the php_openssl_make_REQ function in PHP before 5.2.4 has unknown impact and attack vectors. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2271,7 +2271,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4663",
-            "summary": "Directory traversal vulnerability in PHP before 5.2.4 allows attackers to bypass open_basedir restrictions via unspecified vectors involving the glob function.",
+            "summary": "Directory traversal vulnerability in PHP before 5.2.4 allows attackers to bypass open_basedir restrictions via unspecified vectors involving the glob function. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2281,7 +2281,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4670",
-            "summary": "Unspecified vulnerability in PHP before 5.2.4 has unknown impact and attack vectors, related to an \"Improved fix for MOPB-03-2007,\" probably a variant of CVE-2007-1285.",
+            "summary": "Unspecified vulnerability in PHP before 5.2.4 has unknown impact and attack vectors, related to an \"Improved fix for MOPB-03-2007,\" probably a variant of CVE-2007-1285. \n Publish Date : 2007-09-04 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2291,7 +2291,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4782",
-            "summary": "PHP before 5.2.3 allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the pattern parameter to the glob function; or (2) a long string in the string parameter to the fnmatch function, accompanied by a pattern parameter value with undefined characteristics, as demonstrated by a \"*[1]e\" value.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
+            "summary": "PHP before 5.2.3 allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the pattern parameter to the glob function; or (2) a long string in the string parameter to the fnmatch function, accompanied by a pattern parameter value with undefined characteristics, as demonstrated by a \"*[1]e\" value.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \n Publish Date : 2007-09-10 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2301,7 +2301,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4783",
-            "summary": "The iconv_substr function in PHP 5.2.4 and earlier allows context-dependent attackers to cause (1) a denial of service (application crash) via a long string in the charset parameter, probably also requiring a long string in the str parameter; or (2) a denial of service (temporary application hang) via a long string in the str parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
+            "summary": "The iconv_substr function in PHP 5.2.4 and earlier allows context-dependent attackers to cause (1) a denial of service (application crash) via a long string in the charset parameter, probably also requiring a long string in the str parameter; or (2) a denial of service (temporary application hang) via a long string in the str parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \n Publish Date : 2007-09-10 Last Update Date : 2009-02-05",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2311,7 +2311,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4784",
-            "summary": "The setlocale function in PHP before 5.2.4 allows context-dependent attackers to cause a denial of service (application crash) via a long string in the locale parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution.",
+            "summary": "The setlocale function in PHP before 5.2.4 allows context-dependent attackers to cause a denial of service (application crash) via a long string in the locale parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution. \n Publish Date : 2007-09-10 Last Update Date : 2009-02-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2321,7 +2321,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4825",
-            "summary": "Directory traversal vulnerability in PHP 5.2.4 and earlier allows attackers to bypass open_basedir restrictions and possibly execute arbitrary code via a .. (dot dot) in the dl function.",
+            "summary": "Directory traversal vulnerability in PHP 5.2.4 and earlier allows attackers to bypass open_basedir restrictions and possibly execute arbitrary code via a .. (dot dot) in the dl function. \n Publish Date : 2007-09-11 Last Update Date : 2009-02-05",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2331,7 +2331,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4840",
-            "summary": "PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the out_charset parameter to the iconv function; or a long string in the charset parameter to the (2) iconv_mime_decode_headers, (3) iconv_mime_decode, or (4) iconv_strlen function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
+            "summary": "PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the out_charset parameter to the iconv function; or a long string in the charset parameter to the (2) iconv_mime_decode_headers, (3) iconv_mime_decode, or (4) iconv_strlen function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \n Publish Date : 2007-09-12 Last Update Date : 2009-02-05",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2341,7 +2341,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4850",
-            "summary": "curl\/interface.c in the cURL library (aka libcurl) in PHP 5.2.4 and 5.2.5 allows context-dependent attackers to bypass safe_mode and open_basedir restrictions and read arbitrary files via a file:\/\/ request containing a \\x00 sequence, a different vulnerability than CVE-2006-2563.",
+            "summary": "curl\/interface.c in the cURL library (aka libcurl) in PHP 5.2.4 and 5.2.5 allows context-dependent attackers to bypass safe_mode and open_basedir restrictions and read arbitrary files via a file:\/\/ request containing a \\x00 sequence, a different vulnerability than CVE-2006-2563. \n Publish Date : 2008-01-24 Last Update Date : 2009-04-08",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -2351,7 +2351,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-4887",
-            "summary": "The dl function in PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in the library parameter.  NOTE: there are limited usage scenarios under which this would be a vulnerability.",
+            "summary": "The dl function in PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in the library parameter.  NOTE: there are limited usage scenarios under which this would be a vulnerability. \n Publish Date : 2007-09-13 Last Update Date : 2009-03-04",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2361,7 +2361,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-4889",
-            "summary": "The MySQL extension in PHP 5.2.4 and earlier allows remote attackers to bypass safe_mode and open_basedir restrictions via the MySQL (1) LOAD_FILE, (2) INTO DUMPFILE, and (3) INTO OUTFILE functions, a different issue than CVE-2007-3997.",
+            "summary": "The MySQL extension in PHP 5.2.4 and earlier allows remote attackers to bypass safe_mode and open_basedir restrictions via the MySQL (1) LOAD_FILE, (2) INTO DUMPFILE, and (3) INTO OUTFILE functions, a different issue than CVE-2007-3997. \n Publish Date : 2007-09-13 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2371,7 +2371,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-5128",
-            "summary": "SimpNews 2.41.03 on Windows, when PHP before 5.0.0 is used, allows remote attackers to obtain sensitive information via an certain link_date parameter to events.php, which reveals the path in an error message due to an unsupported argument type for the mktime function on Windows.",
+            "summary": "SimpNews 2.41.03 on Windows, when PHP before 5.0.0 is used, allows remote attackers to obtain sensitive information via an certain link_date parameter to events.php, which reveals the path in an error message due to an unsupported argument type for the mktime function on Windows. \n Publish Date : 2007-09-27 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.0.1"
@@ -2381,7 +2381,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-5424",
-            "summary": "The disable_functions feature in PHP 4 and 5 allows attackers to bypass intended restrictions by using an alias, as demonstrated by using ini_alter when ini_set is disabled.",
+            "summary": "The disable_functions feature in PHP 4 and 5 allows attackers to bypass intended restrictions by using an alias, as demonstrated by using ini_alter when ini_set is disabled. \n Publish Date : 2007-10-12 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -2392,7 +2392,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-5447",
-            "summary": "ioncube_loader_win_5.2.dll in the ionCube Loader 6.5 extension for PHP 5.2.4 does not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by reading arbitrary files via the ioncube_read_file function.",
+            "summary": "ioncube_loader_win_5.2.dll in the ionCube Loader 6.5 extension for PHP 5.2.4 does not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by reading arbitrary files via the ioncube_read_file function. \n Publish Date : 2007-10-14 Last Update Date : 2008-11-15",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2402,7 +2402,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2007-5653",
-            "summary": "The Component Object Model (COM) functions in PHP 5.x on Windows do not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by executing objects with the kill bit set in the corresponding ActiveX control Compatibility Flags, executing programs via a function in compatUI.dll, invoking wscript.shell via wscript.exe, invoking Scripting.FileSystemObject via wshom.ocx, and adding users via a function in shgina.dll, related to the com_load_typelib function.",
+            "summary": "The Component Object Model (COM) functions in PHP 5.x on Windows do not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by executing objects with the kill bit set in the corresponding ActiveX control Compatibility Flags, executing programs via a function in compatUI.dll, invoking wscript.shell via wscript.exe, invoking Scripting.FileSystemObject via wshom.ocx, and adding users via a function in shgina.dll, related to the com_load_typelib function. \n Publish Date : 2007-10-23 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2412,7 +2412,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2007-5898",
-            "summary": "The (1) htmlentities and (2) htmlspecialchars functions in PHP before 5.2.5 accept partial multibyte sequences, which has unknown impact and attack vectors, a different issue than CVE-2006-5465.",
+            "summary": "The (1) htmlentities and (2) htmlspecialchars functions in PHP before 5.2.5 accept partial multibyte sequences, which has unknown impact and attack vectors, a different issue than CVE-2006-5465. \n Publish Date : 2007-11-20 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2422,7 +2422,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-5899",
-            "summary": "The output_add_rewrite_var function in PHP before 5.2.5 rewrites local forms in which the ACTION attribute references a non-local URL, which allows remote attackers to obtain potentially sensitive information by reading the requests for this URL, as demonstrated by a rewritten form containing a local session ID.",
+            "summary": "The output_add_rewrite_var function in PHP before 5.2.5 rewrites local forms in which the ACTION attribute references a non-local URL, which allows remote attackers to obtain potentially sensitive information by reading the requests for this URL, as demonstrated by a rewritten form containing a local session ID. \n Publish Date : 2007-11-20 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2432,7 +2432,7 @@
         {
             "threat": "6.9",
             "cveid": "CVE-2007-5900",
-            "summary": "PHP before 5.2.5 allows local users to bypass protection mechanisms configured through php_admin_value or php_admin_flag in httpd.conf by using ini_set to modify arbitrary configuration variables, a different issue than CVE-2006-4625.",
+            "summary": "PHP before 5.2.5 allows local users to bypass protection mechanisms configured through php_admin_value or php_admin_flag in httpd.conf by using ini_set to modify arbitrary configuration variables, a different issue than CVE-2006-4625. \n Publish Date : 2007-11-20 Last Update Date : 2009-02-05",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2442,7 +2442,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2007-6039",
-            "summary": "PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in (1) the domain parameter to the dgettext function, the message parameter to the (2) dcgettext or (3) gettext function, the msgid1 parameter to the (4) dngettext or (5) ngettext function, or (6) the classname parameter to the stream_wrapper_register function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution.",
+            "summary": "PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in (1) the domain parameter to the dgettext function, the message parameter to the (2) dcgettext or (3) gettext function, the msgid1 parameter to the (4) dngettext or (5) ngettext function, or (6) the classname parameter to the stream_wrapper_register function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution. \n Publish Date : 2007-11-20 Last Update Date : 2008-09-05",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2452,7 +2452,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-0145",
-            "summary": "Unspecified vulnerability in glob in PHP before 4.4.8, when open_basedir is enabled, has unknown impact and attack vectors.  NOTE: this issue reportedly exists because of a regression related to CVE-2007-4663.",
+            "summary": "Unspecified vulnerability in glob in PHP before 4.4.8, when open_basedir is enabled, has unknown impact and attack vectors.  NOTE: this issue reportedly exists because of a regression related to CVE-2007-4663. \n Publish Date : 2008-01-08 Last Update Date : 2009-09-16",
             "fixVersions": {
                 "base": [
                     "4.4.8"
@@ -2462,7 +2462,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-0599",
-            "summary": "The init_request_info function in sapi\/cgi\/cgi_main.c in PHP before 5.2.6 does not properly consider operator precedence when calculating the length of PATH_TRANSLATED, which might allow remote attackers to execute arbitrary code via a crafted URI.",
+            "summary": "The init_request_info function in sapi\/cgi\/cgi_main.c in PHP before 5.2.6 does not properly consider operator precedence when calculating the length of PATH_TRANSLATED, which might allow remote attackers to execute arbitrary code via a crafted URI. \n Publish Date : 2008-05-05 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2474,7 +2474,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-1384",
-            "summary": "Integer overflow in PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service and possibly have unspecified other impact via a printf format parameter with a large width specifier, related to the php_sprintf_appendstring function in formatted_print.c and probably other functions for formatted strings (aka *printf functions).",
+            "summary": "Integer overflow in PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service and possibly have unspecified other impact via a printf format parameter with a large width specifier, related to the php_sprintf_appendstring function in formatted_print.c and probably other functions for formatted strings (aka *printf functions). \n Publish Date : 2008-03-27 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -2484,7 +2484,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-2050",
-            "summary": "Stack-based buffer overflow in the FastCGI SAPI (fastcgi.c) in PHP before 5.2.6 has unknown impact and attack vectors.",
+            "summary": "Stack-based buffer overflow in the FastCGI SAPI (fastcgi.c) in PHP before 5.2.6 has unknown impact and attack vectors. \n Publish Date : 2008-05-05 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2496,7 +2496,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-2051",
-            "summary": "The escapeshellcmd API function in PHP before 5.2.6 has unknown impact and context-dependent attack vectors related to \"incomplete multibyte chars.\"",
+            "summary": "The escapeshellcmd API function in PHP before 5.2.6 has unknown impact and context-dependent attack vectors related to \"incomplete multibyte chars.\" \n Publish Date : 2008-05-05 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2508,7 +2508,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-2107",
-            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 32-bit systems, performs a multiplication using values that can produce a zero seed in rare circumstances, which allows context-dependent attackers to predict subsequent values of the rand and mt_rand functions and possibly bypass protection mechanisms that rely on an unknown initial seed.",
+            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 32-bit systems, performs a multiplication using values that can produce a zero seed in rare circumstances, which allows context-dependent attackers to predict subsequent values of the rand and mt_rand functions and possibly bypass protection mechanisms that rely on an unknown initial seed. \n Publish Date : 2008-05-07 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2521,7 +2521,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-2108",
-            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 64-bit systems, performs a multiplication that generates a portion of zero bits during conversion due to insufficient precision, which produces 24 bits of entropy and simplifies brute force attacks against protection mechanisms that use the rand and mt_rand functions.",
+            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 64-bit systems, performs a multiplication that generates a portion of zero bits during conversion due to insufficient precision, which produces 24 bits of entropy and simplifies brute force attacks against protection mechanisms that use the rand and mt_rand functions. \n Publish Date : 2008-05-07 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2544,7 +2544,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-2665",
-            "summary": "Directory traversal vulnerability in the posix_access function in PHP 5.2.6 and earlier allows remote attackers to bypass safe_mode restrictions via a .. (dot dot) in an http URL, which results in the URL being canonicalized to a local filename after the safe_mode check has successfully run.",
+            "summary": "Directory traversal vulnerability in the posix_access function in PHP 5.2.6 and earlier allows remote attackers to bypass safe_mode restrictions via a .. (dot dot) in an http URL, which results in the URL being canonicalized to a local filename after the safe_mode check has successfully run. \n Publish Date : 2008-06-19 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.2.7"
@@ -2554,7 +2554,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-2666",
-            "summary": "Multiple directory traversal vulnerabilities in PHP 5.2.6 and earlier allow context-dependent attackers to bypass safe_mode restrictions by creating a subdirectory named http: and then placing ..\/ (dot dot slash) sequences in an http URL argument to the (1) chdir or (2) ftok function.",
+            "summary": "Multiple directory traversal vulnerabilities in PHP 5.2.6 and earlier allow context-dependent attackers to bypass safe_mode restrictions by creating a subdirectory named http: and then placing ..\/ (dot dot slash) sequences in an http URL argument to the (1) chdir or (2) ftok function. \n Publish Date : 2008-06-19 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2566,7 +2566,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-2829",
-            "summary": "php_imap.c in PHP 5.2.5, 5.2.6, 4.x, and other versions, uses obsolete API calls that allow context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long IMAP request, which triggers an \"rfc822.c legacy routine buffer overflow\" error message, related to the rfc822_write_address function.",
+            "summary": "php_imap.c in PHP 5.2.5, 5.2.6, 4.x, and other versions, uses obsolete API calls that allow context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long IMAP request, which triggers an \"rfc822.c legacy routine buffer overflow\" error message, related to the rfc822_write_address function. \n Publish Date : 2008-06-23 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -2577,7 +2577,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-3658",
-            "summary": "Buffer overflow in the imageloadfont function in ext\/gd\/gd.c in PHP 4.4.x before 4.4.9 and PHP 5.2 before 5.2.6-r6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted font file.",
+            "summary": "Buffer overflow in the imageloadfont function in ext\/gd\/gd.c in PHP 4.4.x before 4.4.9 and PHP 5.2 before 5.2.6-r6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted font file. \n Publish Date : 2008-08-14 Last Update Date : 2013-08-01",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -2588,7 +2588,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2008-3659",
-            "summary": "Buffer overflow in the memnstr function in PHP 4.4.x before 4.4.9 and PHP 5.6 through 5.2.6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via the delimiter argument to the explode function.  NOTE: the scope of this issue is limited since most applications would not use an attacker-controlled delimiter, but local attacks against safe_mode are feasible.",
+            "summary": "Buffer overflow in the memnstr function in PHP 4.4.x before 4.4.9 and PHP 5.6 through 5.2.6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via the delimiter argument to the explode function.  NOTE: the scope of this issue is limited since most applications would not use an attacker-controlled delimiter, but local attacks against safe_mode are feasible. \n Publish Date : 2008-08-14 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -2599,7 +2599,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-3660",
-            "summary": "PHP 4.4.x before 4.4.9, and 5.x through 5.2.6, when used as a FastCGI module, allows remote attackers to cause a denial of service (crash) via a request with multiple dots preceding the extension, as demonstrated using foo..php.",
+            "summary": "PHP 4.4.x before 4.4.9, and 5.x through 5.2.6, when used as a FastCGI module, allows remote attackers to cause a denial of service (crash) via a request with multiple dots preceding the extension, as demonstrated using foo..php. \n Publish Date : 2008-08-14 Last Update Date : 2012-10-30",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -2610,7 +2610,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2008-4107",
-            "summary": "The (1) rand and (2) mt_rand functions in PHP 5.2.6 do not produce cryptographically strong random numbers, which allows attackers to leverage exposures in products that rely on these functions for security-relevant functionality, as demonstrated by the password-reset functionality in Joomla! 1.5.x and WordPress before 2.6.2, a different vulnerability than CVE-2008-2107, CVE-2008-2108, and CVE-2008-4102.",
+            "summary": "The (1) rand and (2) mt_rand functions in PHP 5.2.6 do not produce cryptographically strong random numbers, which allows attackers to leverage exposures in products that rely on these functions for security-relevant functionality, as demonstrated by the password-reset functionality in Joomla! 1.5.x and WordPress before 2.6.2, a different vulnerability than CVE-2008-2107, CVE-2008-2108, and CVE-2008-4102. \n Publish Date : 2008-09-18 Last Update Date : 2012-10-29",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2627,7 +2627,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-5498",
-            "summary": "Array index error in the imageRotate function in PHP 5.2.8 and earlier allows context-dependent attackers to read the contents of arbitrary memory locations via a crafted value of the third argument (aka the bgd_color or clrBack argument) for an indexed image.",
+            "summary": "Array index error in the imageRotate function in PHP 5.2.8 and earlier allows context-dependent attackers to read the contents of arbitrary memory locations via a crafted value of the third argument (aka the bgd_color or clrBack argument) for an indexed image. \n Publish Date : 2008-12-26 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2639,7 +2639,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-5557",
-            "summary": "Heap-based buffer overflow in ext\/mbstring\/libmbfl\/filters\/mbfilter_htmlent.c in the mbstring extension in PHP 4.3.0 through 5.2.6 allows context-dependent attackers to execute arbitrary code via a crafted string containing an HTML entity, which is not properly handled during Unicode conversion, related to the (1) mb_convert_encoding, (2) mb_check_encoding, (3) mb_convert_variables, and (4) mb_parse_str functions.",
+            "summary": "Heap-based buffer overflow in ext\/mbstring\/libmbfl\/filters\/mbfilter_htmlent.c in the mbstring extension in PHP 4.3.0 through 5.2.6 allows context-dependent attackers to execute arbitrary code via a crafted string containing an HTML entity, which is not properly handled during Unicode conversion, related to the (1) mb_convert_encoding, (2) mb_check_encoding, (3) mb_convert_variables, and (4) mb_parse_str functions. \n Publish Date : 2008-12-23 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.3.12",
@@ -2653,7 +2653,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5624",
-            "summary": "PHP 5 before 5.2.7 does not properly initialize the page_uid and page_gid global variables for use by the SAPI php_getuid function, which allows context-dependent attackers to bypass safe_mode restrictions via variable settings that are intended to be restricted to root, as demonstrated by a setting of \/etc for the error_log variable.",
+            "summary": "PHP 5 before 5.2.7 does not properly initialize the page_uid and page_gid global variables for use by the SAPI php_getuid function, which allows context-dependent attackers to bypass safe_mode restrictions via variable settings that are intended to be restricted to root, as demonstrated by a setting of \/etc for the error_log variable. \n Publish Date : 2008-12-17 Last Update Date : 2009-10-31",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2665,7 +2665,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5625",
-            "summary": "PHP 5 before 5.2.7 does not enforce the error_log safe_mode restrictions when safe_mode is enabled through a php_admin_flag setting in httpd.conf, which allows context-dependent attackers to write to arbitrary files by placing a \"php_value error_log\" entry in a .htaccess file.",
+            "summary": "PHP 5 before 5.2.7 does not enforce the error_log safe_mode restrictions when safe_mode is enabled through a php_admin_flag setting in httpd.conf, which allows context-dependent attackers to write to arbitrary files by placing a \"php_value error_log\" entry in a .htaccess file. \n Publish Date : 2008-12-17 Last Update Date : 2009-10-31",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2677,7 +2677,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5658",
-            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in PHP 5.2.6 and earlier allows context-dependent attackers to write arbitrary files via a ZIP file with a file whose name contains .. (dot dot) sequences.",
+            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in PHP 5.2.6 and earlier allows context-dependent attackers to write arbitrary files via a ZIP file with a file whose name contains .. (dot dot) sequences. \n Publish Date : 2008-12-17 Last Update Date : 2009-10-31",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2689,7 +2689,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2008-5814",
-            "summary": "Cross-site scripting (XSS) vulnerability in PHP, possibly 5.2.7 and earlier, when display_errors is enabled, allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.  NOTE: because of the lack of details, it is unclear whether this is related to CVE-2006-0208.",
+            "summary": "Cross-site scripting (XSS) vulnerability in PHP, possibly 5.2.7 and earlier, when display_errors is enabled, allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.  NOTE: because of the lack of details, it is unclear whether this is related to CVE-2006-0208. \n Publish Date : 2009-01-02 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2706,7 +2706,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5844",
-            "summary": "PHP 5.2.7 contains an incorrect change to the FILTER_UNSAFE_RAW functionality, and unintentionally disables magic_quotes_gpc regardless of the actual magic_quotes_gpc setting, which might make it easier for context-dependent attackers to conduct SQL injection attacks and unspecified other attacks.",
+            "summary": "PHP 5.2.7 contains an incorrect change to the FILTER_UNSAFE_RAW functionality, and unintentionally disables magic_quotes_gpc regardless of the actual magic_quotes_gpc setting, which might make it easier for context-dependent attackers to conduct SQL injection attacks and unspecified other attacks. \n Publish Date : 2009-01-05 Last Update Date : 2009-05-14",
             "fixVersions": {
                 "base": [
                     "5.2.8"
@@ -2716,7 +2716,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2008-7002",
-            "summary": "PHP 5.2.5 does not enforce (a) open_basedir and (b) safe_mode_exec_dir restrictions for certain functions, which might allow local users to bypass intended access restrictions and call programs outside of the intended directory via the (1) exec, (2) system, (3) shell_exec, (4) passthru, or (5) popen functions, possibly involving pathnames such as \"C:\" drive notation.",
+            "summary": "PHP 5.2.5 does not enforce (a) open_basedir and (b) safe_mode_exec_dir restrictions for certain functions, which might allow local users to bypass intended access restrictions and call programs outside of the intended directory via the (1) exec, (2) system, (3) shell_exec, (4) passthru, or (5) popen functions, possibly involving pathnames such as \"C:\" drive notation. \n Publish Date : 2009-08-19 Last Update Date : 2009-08-19",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -2726,7 +2726,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2008-7068",
-            "summary": "The dba_replace function in PHP 5.2.6 and 4.x allows context-dependent attackers to cause a denial of service (file truncation) via a key with the NULL byte.  NOTE: this might only be a vulnerability in limited circumstances in which the attacker can modify or add database entries but does not have permissions to truncate the file.",
+            "summary": "The dba_replace function in PHP 5.2.6 and 4.x allows context-dependent attackers to cause a denial of service (file truncation) via a key with the NULL byte.  NOTE: this might only be a vulnerability in limited circumstances in which the attacker can modify or add database entries but does not have permissions to truncate the file. \n Publish Date : 2009-08-25 Last Update Date : 2009-08-25",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2741,7 +2741,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2009-0754",
-            "summary": "PHP 4.4.4, 5.1.6, and other versions, when running on Apache, allows local users to modify behavior of other sites hosted on the same web server by modifying the mbstring.func_overload setting within .htaccess, which causes this setting to be applied to other virtual hosts on the same server.",
+            "summary": "PHP 4.4.4, 5.1.6, and other versions, when running on Apache, allows local users to modify behavior of other sites hosted on the same web server by modifying the mbstring.func_overload setting within .htaccess, which causes this setting to be applied to other virtual hosts on the same server. \n Publish Date : 2009-03-03 Last Update Date : 2010-08-21",
             "fixVersions": {
                 "base": [
                     "4.4.5",
@@ -2752,7 +2752,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-1271",
-            "summary": "The JSON_parser function (ext\/json\/JSON_parser.c) in PHP 5.2.x before 5.2.9 allows remote attackers to cause a denial of service (segmentation fault) via a malformed string to the json_decode API function.",
+            "summary": "The JSON_parser function (ext\/json\/JSON_parser.c) in PHP 5.2.x before 5.2.9 allows remote attackers to cause a denial of service (segmentation fault) via a malformed string to the json_decode API function. \n Publish Date : 2009-04-08 Last Update Date : 2009-09-16",
             "fixVersions": {
                 "base": [
                     "5.2.9"
@@ -2762,7 +2762,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-1272",
-            "summary": "The php_zip_make_relative_path function in php_zip.c in PHP 5.2.x before 5.2.9 allows context-dependent attackers to cause a denial of service (crash) via a ZIP file that contains filenames with relative paths, which is not properly handled during extraction.",
+            "summary": "The php_zip_make_relative_path function in php_zip.c in PHP 5.2.x before 5.2.9 allows context-dependent attackers to cause a denial of service (crash) via a ZIP file that contains filenames with relative paths, which is not properly handled during extraction. \n Publish Date : 2009-04-08 Last Update Date : 2009-09-16",
             "fixVersions": {
                 "base": [
                     "5.2.9"
@@ -2772,7 +2772,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2009-2626",
-            "summary": "The zend_restore_ini_entry_cb function in zend_ini.c in PHP 5.3.0, 5.2.10, and earlier versions allows context-specific attackers to obtain sensitive information (memory contents) and cause a PHP crash by using the ini_set function to declare a variable, then using the ini_restore function to restore the variable.",
+            "summary": "The zend_restore_ini_entry_cb function in zend_ini.c in PHP 5.3.0, 5.2.10, and earlier versions allows context-specific attackers to obtain sensitive information (memory contents) and cause a PHP crash by using the ini_set function to declare a variable, then using the ini_restore function to restore the variable. \n Publish Date : 2009-12-01 Last Update Date : 2009-12-19",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2790,7 +2790,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2009-2687",
-            "summary": "The exif_read_data function in the Exif module in PHP before 5.2.10 allows remote attackers to cause a denial of service (crash) via a malformed JPEG image with invalid offset fields, a different issue than CVE-2005-3353.",
+            "summary": "The exif_read_data function in the Exif module in PHP before 5.2.10 allows remote attackers to cause a denial of service (crash) via a malformed JPEG image with invalid offset fields, a different issue than CVE-2005-3353. \n Publish Date : 2009-08-05 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "5.2.11"
@@ -2800,7 +2800,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3291",
-            "summary": "The php_openssl_apply_verification_policy function in PHP before 5.2.11 does not properly perform certificate validation, which has unknown impact and attack vectors, probably related to an ability to spoof certificates.",
+            "summary": "The php_openssl_apply_verification_policy function in PHP before 5.2.11 does not properly perform certificate validation, which has unknown impact and attack vectors, probably related to an ability to spoof certificates. \n Publish Date : 2009-09-22 Last Update Date : 2011-09-06",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2817,7 +2817,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3292",
-            "summary": "Unspecified vulnerability in PHP before 5.2.11, and 5.3.x before 5.3.1, has unknown impact and attack vectors related to \"missing sanity checks around exif processing.\"",
+            "summary": "Unspecified vulnerability in PHP before 5.2.11, and 5.3.x before 5.3.1, has unknown impact and attack vectors related to \"missing sanity checks around exif processing.\" \n Publish Date : 2009-09-22 Last Update Date : 2011-09-06",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2834,7 +2834,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3293",
-            "summary": "Unspecified vulnerability in the imagecolortransparent function in PHP before 5.2.11 has unknown impact and attack vectors related to an incorrect \"sanity check for the color index.\"",
+            "summary": "Unspecified vulnerability in the imagecolortransparent function in PHP before 5.2.11 has unknown impact and attack vectors related to an incorrect \"sanity check for the color index.\" \n Publish Date : 2009-09-22 Last Update Date : 2011-09-06",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2851,7 +2851,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-3294",
-            "summary": "The popen API function in TSRM\/tsrm_win32.c in PHP before 5.2.11 and 5.3.x before 5.3.1, when running on certain Windows operating systems, allows context-dependent attackers to cause a denial of service (crash) via a crafted (1) \"e\" or (2) \"er\" string in the second argument (aka mode), possibly related to the _fdopen function in the Microsoft C runtime library. NOTE: this might not cross privilege boundaries except in rare cases in which the mode argument is accessible to an attacker outside of an application that uses the popen function.",
+            "summary": "The popen API function in TSRM\/tsrm_win32.c in PHP before 5.2.11 and 5.3.x before 5.3.1, when running on certain Windows operating systems, allows context-dependent attackers to cause a denial of service (crash) via a crafted (1) \"e\" or (2) \"er\" string in the second argument (aka mode), possibly related to the _fdopen function in the Microsoft C runtime library. NOTE: this might not cross privilege boundaries except in rare cases in which the mode argument is accessible to an attacker outside of an application that uses the popen function. \n Publish Date : 2009-09-22 Last Update Date : 2009-11-25",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2868,7 +2868,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2009-3546",
-            "summary": "The _gdGetColors function in gd_gd.c in PHP 5.2.11 and 5.3.x before 5.3.1, and the GD Graphics Library 2.x, does not properly verify a certain colorsTotal structure member, which might allow remote attackers to conduct buffer overflow or buffer over-read attacks via a crafted GD file, a different vulnerability than CVE-2009-3293. NOTE: some of these details are obtained from third party information.",
+            "summary": "The _gdGetColors function in gd_gd.c in PHP 5.2.11 and 5.3.x before 5.3.1, and the GD Graphics Library 2.x, does not properly verify a certain colorsTotal structure member, which might allow remote attackers to conduct buffer overflow or buffer over-read attacks via a crafted GD file, a different vulnerability than CVE-2009-3293. NOTE: some of these details are obtained from third party information. \n Publish Date : 2009-10-19 Last Update Date : 2011-08-25",
             "fixVersions": {
                 "base": [
                     "5.2.12",
@@ -2879,7 +2879,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-3557",
-            "summary": "The tempnam function in ext\/standard\/file.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass safe_mode restrictions, and create files in group-writable or world-writable directories, via the dir and prefix arguments.",
+            "summary": "The tempnam function in ext\/standard\/file.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass safe_mode restrictions, and create files in group-writable or world-writable directories, via the dir and prefix arguments. \n Publish Date : 2009-11-23 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2897,7 +2897,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2009-3558",
-            "summary": "The posix_mkfifo function in ext\/posix\/posix.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass open_basedir restrictions, and create FIFO files, via the pathname and mode arguments, as demonstrated by creating a .htaccess file.",
+            "summary": "The posix_mkfifo function in ext\/posix\/posix.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass open_basedir restrictions, and create FIFO files, via the pathname and mode arguments, as demonstrated by creating a .htaccess file. \n Publish Date : 2009-11-23 Last Update Date : 2010-04-01",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2915,7 +2915,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3559",
-            "summary": "** DISPUTED **  main\/streams\/plain_wrapper.c in PHP 5.3.x before 5.3.1 does not recognize the safe_mode_include_dir directive, which allows context-dependent attackers to have an unknown impact by triggering the failure of PHP scripts that perform include or require operations, as demonstrated by a script that attempts to perform a require_once on a file in a standard library directory.  NOTE: a reliable third party reports that this is not a vulnerability, because it results in a more restrictive security policy.",
+            "summary": "** DISPUTED **  main\/streams\/plain_wrapper.c in PHP 5.3.x before 5.3.1 does not recognize the safe_mode_include_dir directive, which allows context-dependent attackers to have an unknown impact by triggering the failure of PHP scripts that perform include or require operations, as demonstrated by a script that attempts to perform a require_once on a file in a standard library directory.  NOTE: a reliable third party reports that this is not a vulnerability, because it results in a more restrictive security policy. \n Publish Date : 2009-11-23 Last Update Date : 2010-04-01",
             "fixVersions": {
                 "base": [
                     "5.3.1"
@@ -2925,7 +2925,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-4017",
-            "summary": "PHP before 5.2.12 and 5.3.x before 5.3.1 does not restrict the number of temporary files created when handling a multipart\/form-data POST request, which allows remote attackers to cause a denial of service (resource exhaustion), and makes it easier for remote attackers to exploit local file inclusion vulnerabilities, via multiple requests, related to lack of support for the max_file_uploads directive.",
+            "summary": "PHP before 5.2.12 and 5.3.x before 5.3.1 does not restrict the number of temporary files created when handling a multipart\/form-data POST request, which allows remote attackers to cause a denial of service (resource exhaustion), and makes it easier for remote attackers to exploit local file inclusion vulnerabilities, via multiple requests, related to lack of support for the max_file_uploads directive. \n Publish Date : 2009-11-23 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "5.2.12",
@@ -2936,7 +2936,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-4018",
-            "summary": "The proc_open function in ext\/standard\/proc_open.c in PHP before 5.2.11 and 5.3.x before 5.3.1 does not enforce the (1) safe_mode_allowed_env_vars and (2) safe_mode_protected_env_vars directives, which allows context-dependent attackers to execute programs with an arbitrary environment via the env parameter, as demonstrated by a crafted value of the LD_LIBRARY_PATH environment variable.",
+            "summary": "The proc_open function in ext\/standard\/proc_open.c in PHP before 5.2.11 and 5.3.x before 5.3.1 does not enforce the (1) safe_mode_allowed_env_vars and (2) safe_mode_protected_env_vars directives, which allows context-dependent attackers to execute programs with an arbitrary environment via the env parameter, as demonstrated by a crafted value of the LD_LIBRARY_PATH environment variable. \n Publish Date : 2009-11-29 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2954,7 +2954,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2009-4142",
-            "summary": "The htmlspecialchars function in PHP before 5.2.12 does not properly handle (1) overlong UTF-8 sequences, (2) invalid Shift_JIS sequences, and (3) invalid EUC-JP sequences, which allows remote attackers to conduct cross-site scripting (XSS) attacks by placing a crafted byte sequence before a special character.",
+            "summary": "The htmlspecialchars function in PHP before 5.2.12 does not properly handle (1) overlong UTF-8 sequences, (2) invalid Shift_JIS sequences, and (3) invalid EUC-JP sequences, which allows remote attackers to conduct cross-site scripting (XSS) attacks by placing a crafted byte sequence before a special character. \n Publish Date : 2009-12-21 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2971,7 +2971,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2009-4143",
-            "summary": "PHP before 5.2.12 does not properly handle session data, which has unspecified impact and attack vectors related to (1) interrupt corruption of the SESSION superglobal array and (2) the session.save_path directive.",
+            "summary": "PHP before 5.2.12 does not properly handle session data, which has unspecified impact and attack vectors related to (1) interrupt corruption of the SESSION superglobal array and (2) the session.save_path directive. \n Publish Date : 2009-12-21 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2988,7 +2988,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-4418",
-            "summary": "The unserialize function in PHP 5.3.0 and earlier allows context-dependent attackers to cause a denial of service (resource consumption) via a deeply nested serialized variable, as demonstrated by a string beginning with a:1: followed by many {a:1: sequences.",
+            "summary": "The unserialize function in PHP 5.3.0 and earlier allows context-dependent attackers to cause a denial of service (resource consumption) via a deeply nested serialized variable, as demonstrated by a string beginning with a:1: followed by many {a:1: sequences. \n Publish Date : 2009-12-24 Last Update Date : 2009-12-28",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3001,7 +3001,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2009-5016",
-            "summary": "Integer overflow in the xml_utf8_decode function in ext\/xml\/xml.c in PHP before 5.2.11 makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string that uses overlong UTF-8 encoding, a different vulnerability than CVE-2010-3870.",
+            "summary": "Integer overflow in the xml_utf8_decode function in ext\/xml\/xml.c in PHP before 5.2.11 makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string that uses overlong UTF-8 encoding, a different vulnerability than CVE-2010-3870. \n Publish Date : 2010-11-12 Last Update Date : 2011-02-23",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3018,7 +3018,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-0397",
-            "summary": "The xmlrpc extension in PHP 5.3.1 does not properly handle a missing methodName element in the first argument to the xmlrpc_decode_request function, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) and possibly have unspecified other impact via a crafted argument.",
+            "summary": "The xmlrpc extension in PHP 5.3.1 does not properly handle a missing methodName element in the first argument to the xmlrpc_decode_request function, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) and possibly have unspecified other impact via a crafted argument. \n Publish Date : 2010-03-16 Last Update Date : 2010-12-10",
             "fixVersions": {
                 "base": [
                     "5.3.2"
@@ -3028,7 +3028,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2010-1128",
-            "summary": "The Linear Congruential Generator (LCG) in PHP before 5.2.13 does not provide the expected entropy, which makes it easier for context-dependent attackers to guess values that were intended to be unpredictable, as demonstrated by session cookies generated by using the uniqid function.",
+            "summary": "The Linear Congruential Generator (LCG) in PHP before 5.2.13 does not provide the expected entropy, which makes it easier for context-dependent attackers to guess values that were intended to be unpredictable, as demonstrated by session cookies generated by using the uniqid function. \n Publish Date : 2010-03-26 Last Update Date : 2010-12-10",
             "fixVersions": {
                 "base": [
                     "5.2.13"
@@ -3038,7 +3038,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-1129",
-            "summary": "The safe_mode implementation in PHP before 5.2.13 does not properly handle directory pathnames that lack a trailing \/ (slash) character, which allows context-dependent attackers to bypass intended access restrictions via vectors related to use of the tempnam function.",
+            "summary": "The safe_mode implementation in PHP before 5.2.13 does not properly handle directory pathnames that lack a trailing \/ (slash) character, which allows context-dependent attackers to bypass intended access restrictions via vectors related to use of the tempnam function. \n Publish Date : 2010-03-26 Last Update Date : 2010-08-31",
             "fixVersions": {
                 "base": [
                     "5.2.13"
@@ -3048,7 +3048,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1130",
-            "summary": "session.c in the session extension in PHP before 5.2.13, and 5.3.1, does not properly interpret ; (semicolon) characters in the argument to the session_save_path function, which allows context-dependent attackers to bypass open_basedir and safe_mode restrictions via an argument that contains multiple ; characters in conjunction with a .. (dot dot).",
+            "summary": "session.c in the session extension in PHP before 5.2.13, and 5.3.1, does not properly interpret ; (semicolon) characters in the argument to the session_save_path function, which allows context-dependent attackers to bypass open_basedir and safe_mode restrictions via an argument that contains multiple ; characters in conjunction with a .. (dot dot). \n Publish Date : 2010-03-26 Last Update Date : 2010-06-08",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3061,7 +3061,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1860",
-            "summary": "The html_entity_decode function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal call, related to the call time pass by reference feature.",
+            "summary": "The html_entity_decode function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal call, related to the call time pass by reference feature. \n Publish Date : 2010-05-07 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3072,7 +3072,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2010-1861",
-            "summary": "The sysvshm extension for PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to write to arbitrary memory addresses by using an object's __sleep function to interrupt an internal call to the shm_put_var function, which triggers access of a freed resource.",
+            "summary": "The sysvshm extension for PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to write to arbitrary memory addresses by using an object's __sleep function to interrupt an internal call to the shm_put_var function, which triggers access of a freed resource. \n Publish Date : 2010-05-07 Last Update Date : 2010-05-10",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3083,7 +3083,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1862",
-            "summary": "The chunk_split function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "summary": "The chunk_split function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-07 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3094,7 +3094,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1864",
-            "summary": "The addcslashes function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "summary": "The addcslashes function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-07 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3105,7 +3105,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-1866",
-            "summary": "The dechunk filter in PHP 5.3 through 5.3.2, when decoding an HTTP chunked encoding stream, allows context-dependent attackers to cause a denial of service (crash) and possibly trigger memory corruption via a negative chunk size, which bypasses a signed comparison, related to an integer overflow in the chunk size decoder.",
+            "summary": "The dechunk filter in PHP 5.3 through 5.3.2, when decoding an HTTP chunked encoding stream, allows context-dependent attackers to cause a denial of service (crash) and possibly trigger memory corruption via a negative chunk size, which bypasses a signed comparison, related to an integer overflow in the chunk size decoder. \n Publish Date : 2010-05-07 Last Update Date : 2010-09-30",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3115,7 +3115,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-1868",
-            "summary": "The (1) sqlite_single_query and (2) sqlite_array_query functions in ext\/sqlite\/sqlite.c in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to execute arbitrary code by calling these functions with an empty SQL query, which triggers access of uninitialized memory.",
+            "summary": "The (1) sqlite_single_query and (2) sqlite_array_query functions in ext\/sqlite\/sqlite.c in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to execute arbitrary code by calling these functions with an empty SQL query, which triggers access of uninitialized memory. \n Publish Date : 2010-05-07 Last Update Date : 2010-05-11",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3126,7 +3126,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1914",
-            "summary": "The Zend Engine in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information by interrupting the handler for the (1) ZEND_BW_XOR opcode (shift_left_function), (2) ZEND_SL opcode (bitwise_xor_function), or (3) ZEND_SR opcode (shift_right_function), related to the convert_to_long_base function.",
+            "summary": "The Zend Engine in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information by interrupting the handler for the (1) ZEND_BW_XOR opcode (shift_left_function), (2) ZEND_SL opcode (bitwise_xor_function), or (3) ZEND_SR opcode (shift_right_function), related to the convert_to_long_base function. \n Publish Date : 2010-05-12 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -3137,7 +3137,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1915",
-            "summary": "The preg_quote function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature, modification of ZVALs whose values are not updated in the associated local variables, and access of previously-freed memory.",
+            "summary": "The preg_quote function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature, modification of ZVALs whose values are not updated in the associated local variables, and access of previously-freed memory. \n Publish Date : 2010-05-12 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -3148,7 +3148,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1917",
-            "summary": "Stack consumption vulnerability in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (PHP crash) via a crafted first argument to the fnmatch function, as demonstrated using a long string.",
+            "summary": "Stack consumption vulnerability in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (PHP crash) via a crafted first argument to the fnmatch function, as demonstrated using a long string. \n Publish Date : 2010-05-12 Last Update Date : 2011-05-03",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3159,7 +3159,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2093",
-            "summary": "Use-after-free vulnerability in the request shutdown functionality in PHP 5.2 before 5.2.13 and 5.3 before 5.3.2 allows context-dependent attackers to cause a denial of service (crash) via a stream context structure that is freed before destruction occurs.",
+            "summary": "Use-after-free vulnerability in the request shutdown functionality in PHP 5.2 before 5.2.13 and 5.3 before 5.3.2 allows context-dependent attackers to cause a denial of service (crash) via a stream context structure that is freed before destruction occurs. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -3170,7 +3170,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-2094",
-            "summary": "Multiple format string vulnerabilities in the phar extension in PHP 5.3 before 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the (1) phar_stream_flush, (2) phar_wrapper_unlink, (3) phar_parse_url, or (4) phar_wrapper_open_url functions in ext\/phar\/stream.c; and the (5) phar_wrapper_open_dir function in ext\/phar\/dirstream.c, which triggers errors in the php_stream_wrapper_log_error function.",
+            "summary": "Multiple format string vulnerabilities in the phar extension in PHP 5.3 before 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the (1) phar_stream_flush, (2) phar_wrapper_unlink, (3) phar_parse_url, or (4) phar_wrapper_open_url functions in ext\/phar\/stream.c; and the (5) phar_wrapper_open_dir function in ext\/phar\/dirstream.c, which triggers errors in the php_stream_wrapper_log_error function. \n Publish Date : 2010-05-27 Last Update Date : 2011-01-26",
             "fixVersions": {
                 "base": [
                     "5.3.2"
@@ -3180,7 +3180,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2097",
-            "summary": "The (1) iconv_mime_decode, (2) iconv_substr, and (3) iconv_mime_encode functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "summary": "The (1) iconv_mime_decode, (2) iconv_substr, and (3) iconv_mime_encode functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3191,7 +3191,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2100",
-            "summary": "The (1) htmlentities, (2) htmlspecialchars, (3) str_getcsv, (4) http_build_query, (5) strpbrk, and (6) strtr functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "summary": "The (1) htmlentities, (2) htmlspecialchars, (3) str_getcsv, (4) http_build_query, (5) strpbrk, and (6) strtr functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3202,7 +3202,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2101",
-            "summary": "The (1) strip_tags, (2) setcookie, (3) strtok, (4) wordwrap, (5) str_word_count, and (6) str_pad functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "summary": "The (1) strip_tags, (2) setcookie, (3) strtok, (4) wordwrap, (5) str_word_count, and (6) str_pad functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3213,7 +3213,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2190",
-            "summary": "The (1) trim, (2) ltrim, (3) rtrim, and (4) substr_replace functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "summary": "The (1) trim, (2) ltrim, (3) rtrim, and (4) substr_replace functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-06-07 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3224,7 +3224,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2010-2191",
-            "summary": "The (1) parse_str, (2) preg_match, (3) unpack, and (4) pack functions; the (5) ZEND_FETCH_RW, (6) ZEND_CONCAT, and (7) ZEND_ASSIGN_CONCAT opcodes; and the (8) ArrayObject::uasort method in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.  NOTE: vectors 2 through 4 are related to the call time pass by reference feature.",
+            "summary": "The (1) parse_str, (2) preg_match, (3) unpack, and (4) pack functions; the (5) ZEND_FETCH_RW, (6) ZEND_CONCAT, and (7) ZEND_ASSIGN_CONCAT opcodes; and the (8) ArrayObject::uasort method in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.  NOTE: vectors 2 through 4 are related to the call time pass by reference feature. \n Publish Date : 2010-06-07 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3235,7 +3235,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-2225",
-            "summary": "Use-after-free vulnerability in the SplObjectStorage unserializer in PHP 5.2.x and 5.3.x through 5.3.2 allows remote attackers to execute arbitrary code or obtain sensitive information via serialized data, related to the PHP unserialize function.",
+            "summary": "Use-after-free vulnerability in the SplObjectStorage unserializer in PHP 5.2.x and 5.3.x through 5.3.2 allows remote attackers to execute arbitrary code or obtain sensitive information via serialized data, related to the PHP unserialize function. \n Publish Date : 2010-06-24 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3246,7 +3246,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2484",
-            "summary": "The strrchr function in PHP 5.2 before 5.2.14 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.",
+            "summary": "The strrchr function in PHP 5.2 before 5.2.14 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.2.14"
@@ -3256,7 +3256,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2010-2531",
-            "summary": "The var_export function in PHP 5.2 before 5.2.14 and 5.3 before 5.3.3 flushes the output buffer to the user when certain fatal errors occur, even if display_errors is off, which allows remote attackers to obtain sensitive information by causing the application to exceed limits for memory, execution time, or recursion.",
+            "summary": "The var_export function in PHP 5.2 before 5.2.14 and 5.3 before 5.3.3 flushes the output buffer to the user when certain fatal errors occur, even if display_errors is off, which allows remote attackers to obtain sensitive information by causing the application to exceed limits for memory, execution time, or recursion. \n Publish Date : 2010-08-20 Last Update Date : 2011-08-26",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3267,7 +3267,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-2950",
-            "summary": "Format string vulnerability in stream.c in the phar extension in PHP 5.3.x through 5.3.3 allows context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the phar_stream_flush function, leading to errors in the php_stream_wrapper_log_error function.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2010-2094.",
+            "summary": "Format string vulnerability in stream.c in the phar extension in PHP 5.3.x through 5.3.3 allows context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the phar_stream_flush function, leading to errors in the php_stream_wrapper_log_error function.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2010-2094. \n Publish Date : 2010-09-28 Last Update Date : 2011-05-03",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -3277,7 +3277,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3062",
-            "summary": "mysqlnd_wireprotocol.c in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows remote attackers to (1) read sensitive memory via a modified length value, which is not properly handled by the php_mysqlnd_ok_read function; or (2) trigger a heap-based buffer overflow via a modified length value, which is not properly handled by the php_mysqlnd_rset_header_read function.",
+            "summary": "mysqlnd_wireprotocol.c in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows remote attackers to (1) read sensitive memory via a modified length value, which is not properly handled by the php_mysqlnd_ok_read function; or (2) trigger a heap-based buffer overflow via a modified length value, which is not properly handled by the php_mysqlnd_rset_header_read function. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3287,7 +3287,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3063",
-            "summary": "The php_mysqlnd_read_error_from_line function in the Mysqlnd extension in PHP 5.3 through 5.3.2 does not properly calculate a buffer length, which allows context-dependent attackers to trigger a heap-based buffer overflow via crafted inputs that cause a negative length value to be used.",
+            "summary": "The php_mysqlnd_read_error_from_line function in the Mysqlnd extension in PHP 5.3 through 5.3.2 does not properly calculate a buffer length, which allows context-dependent attackers to trigger a heap-based buffer overflow via crafted inputs that cause a negative length value to be used. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3297,7 +3297,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-3064",
-            "summary": "Stack-based buffer overflow in the php_mysqlnd_auth_write function in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long (1) username or (2) database name argument to the (a) mysql_connect or (b) mysqli_connect function.",
+            "summary": "Stack-based buffer overflow in the php_mysqlnd_auth_write function in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long (1) username or (2) database name argument to the (a) mysql_connect or (b) mysqli_connect function. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3307,7 +3307,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3065",
-            "summary": "The default session serializer in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 does not properly handle the PS_UNDEF_MARKER marker, which allows context-dependent attackers to modify arbitrary session variables via a crafted session variable name.",
+            "summary": "The default session serializer in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 does not properly handle the PS_UNDEF_MARKER marker, which allows context-dependent attackers to modify arbitrary session variables via a crafted session variable name. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-10",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3318,7 +3318,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3436",
-            "summary": "fopen_wrappers.c in PHP 5.3.x through 5.3.3 might allow remote attackers to bypass open_basedir restrictions via vectors related to the length of a filename.",
+            "summary": "fopen_wrappers.c in PHP 5.3.x through 5.3.3 might allow remote attackers to bypass open_basedir restrictions via vectors related to the length of a filename. \n Publish Date : 2010-11-08 Last Update Date : 2011-10-20",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -3328,7 +3328,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2010-3709",
-            "summary": "The ZipArchive::getArchiveComment function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3 allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted ZIP archive.",
+            "summary": "The ZipArchive::getArchiveComment function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3 allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted ZIP archive. \n Publish Date : 2010-11-08 Last Update Date : 2011-05-03",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3339,7 +3339,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2010-3710",
-            "summary": "Stack consumption vulnerability in the filter_var function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3, when FILTER_VALIDATE_EMAIL mode is used, allows remote attackers to cause a denial of service (memory consumption and application crash) via a long e-mail address string.",
+            "summary": "Stack consumption vulnerability in the filter_var function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3, when FILTER_VALIDATE_EMAIL mode is used, allows remote attackers to cause a denial of service (memory consumption and application crash) via a long e-mail address string. \n Publish Date : 2010-10-25 Last Update Date : 2011-03-23",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3350,7 +3350,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-3870",
-            "summary": "The utf8_decode function in PHP before 5.3.4 does not properly handle non-shortest form UTF-8 encoding and ill-formed subsequences in UTF-8 data, which makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string.",
+            "summary": "The utf8_decode function in PHP before 5.3.4 does not properly handle non-shortest form UTF-8 encoding and ill-formed subsequences in UTF-8 data, which makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string. \n Publish Date : 2010-11-12 Last Update Date : 2011-03-23",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3368,7 +3368,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4150",
-            "summary": "Double free vulnerability in the imap_do_open function in the IMAP extension (ext\/imap\/php_imap.c) in PHP 5.2 before 5.2.15 and 5.3 before 5.3.4 allows attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via unspecified vectors.",
+            "summary": "Double free vulnerability in the imap_do_open function in the IMAP extension (ext\/imap\/php_imap.c) in PHP 5.2 before 5.2.15 and 5.3 before 5.3.4 allows attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via unspecified vectors. \n Publish Date : 2010-12-07 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3379,7 +3379,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4409",
-            "summary": "Integer overflow in the NumberFormatter::getSymbol (aka numfmt_get_symbol) function in PHP 5.3.3 and earlier allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument.",
+            "summary": "Integer overflow in the NumberFormatter::getSymbol (aka numfmt_get_symbol) function in PHP 5.3.3 and earlier allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument. \n Publish Date : 2010-12-06 Last Update Date : 2012-06-22",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3394,7 +3394,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4645",
-            "summary": "strtod.c, as used in the zend_strtod function in PHP 5.2 before 5.2.17 and 5.3 before 5.3.5, and other products, allows context-dependent attackers to cause a denial of service (infinite loop) via a certain floating-point value in scientific notation, which is not properly handled in x87 FPU registers, as demonstrated using 2.2250738585072011e-308.",
+            "summary": "strtod.c, as used in the zend_strtod function in PHP 5.2 before 5.2.17 and 5.3 before 5.3.5, and other products, allows context-dependent attackers to cause a denial of service (infinite loop) via a certain floating-point value in scientific notation, which is not properly handled in x87 FPU registers, as demonstrated using 2.2250738585072011e-308. \n Publish Date : 2011-01-10 Last Update Date : 2012-08-13",
             "fixVersions": {
                 "base": [
                     "5.2.17",
@@ -3405,7 +3405,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-4697",
-            "summary": "Use-after-free vulnerability in the Zend engine in PHP before 5.2.15 and 5.3.x before 5.3.4 might allow context-dependent attackers to cause a denial of service (heap memory corruption) or have unspecified other impact via vectors related to use of __set, __get, __isset, and __unset methods on objects accessed by a reference.",
+            "summary": "Use-after-free vulnerability in the Zend engine in PHP before 5.2.15 and 5.3.x before 5.3.4 might allow context-dependent attackers to cause a denial of service (heap memory corruption) or have unspecified other impact via vectors related to use of __set, __get, __isset, and __unset methods on objects accessed by a reference. \n Publish Date : 2011-01-18 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3423,7 +3423,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4698",
-            "summary": "Stack-based buffer overflow in the GD extension in PHP before 5.2.15 and 5.3.x before 5.3.4 allows context-dependent attackers to cause a denial of service (application crash) via a large number of anti-aliasing steps in an argument to the imagepstext function.",
+            "summary": "Stack-based buffer overflow in the GD extension in PHP before 5.2.15 and 5.3.x before 5.3.4 allows context-dependent attackers to cause a denial of service (application crash) via a large number of anti-aliasing steps in an argument to the imagepstext function. \n Publish Date : 2011-01-18 Last Update Date : 2011-08-01",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3434,7 +3434,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4699",
-            "summary": "The iconv_mime_decode_headers function in the Iconv extension in PHP before 5.3.4 does not properly handle encodings that are unrecognized by the iconv and mbstring (aka Multibyte String) implementations, which allows remote attackers to trigger an incomplete output array, and possibly bypass spam detection or have unspecified other impact, via a crafted Subject header in an e-mail message, as demonstrated by the ks_c_5601-1987 character set.",
+            "summary": "The iconv_mime_decode_headers function in the Iconv extension in PHP before 5.3.4 does not properly handle encodings that are unrecognized by the iconv and mbstring (aka Multibyte String) implementations, which allows remote attackers to trigger an incomplete output array, and possibly bypass spam detection or have unspecified other impact, via a crafted Subject header in an e-mail message, as demonstrated by the ks_c_5601-1987 character set. \n Publish Date : 2011-01-18 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3452,7 +3452,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-4700",
-            "summary": "The set_magic_quotes_runtime function in PHP 5.3.2 and 5.3.3, when the MySQLi extension is used, does not properly interact with use of the mysqli_fetch_assoc function, which might make it easier for context-dependent attackers to conduct SQL injection attacks via crafted input that had been properly handled in earlier PHP versions.",
+            "summary": "The set_magic_quotes_runtime function in PHP 5.3.2 and 5.3.3, when the MySQLi extension is used, does not properly interact with use of the mysqli_fetch_assoc function, which might make it easier for context-dependent attackers to conduct SQL injection attacks via crafted input that had been properly handled in earlier PHP versions. \n Publish Date : 2011-01-18 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -3462,7 +3462,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-0420",
-            "summary": "The grapheme_extract function in the Internationalization extension (Intl) for ICU for PHP 5.3.5 allows context-dependent attackers to cause a denial of service (crash) via an invalid size argument, which triggers a NULL pointer dereference.",
+            "summary": "The grapheme_extract function in the Internationalization extension (Intl) for ICU for PHP 5.3.5 allows context-dependent attackers to cause a denial of service (crash) via an invalid size argument, which triggers a NULL pointer dereference. \n Publish Date : 2011-02-18 Last Update Date : 2013-09-07",
             "fixVersions": {
                 "base": [
                     "5.3.6"
@@ -3472,7 +3472,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-0421",
-            "summary": "The _zip_name_locate function in zip_name_locate.c in the Zip extension in PHP before 5.3.6 does not properly handle a ZIPARCHIVE::FL_UNCHANGED argument, which might allow context-dependent attackers to cause a denial of service (NULL pointer dereference) via an empty ZIP archive that is processed with a (1) locateName or (2) statName operation.",
+            "summary": "The _zip_name_locate function in zip_name_locate.c in the Zip extension in PHP before 5.3.6 does not properly handle a ZIPARCHIVE::FL_UNCHANGED argument, which might allow context-dependent attackers to cause a denial of service (NULL pointer dereference) via an empty ZIP archive that is processed with a (1) locateName or (2) statName operation. \n Publish Date : 2011-03-19 Last Update Date : 2014-02-20",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3490,7 +3490,7 @@
         {
             "threat": "6.3",
             "cveid": "CVE-2011-0441",
-            "summary": "The Debian GNU\/Linux \/etc\/cron.d\/php5 cron job for PHP 5.3.5 allows local users to delete arbitrary files via a symlink attack on a directory under \/var\/lib\/php5\/.",
+            "summary": "The Debian GNU\/Linux \/etc\/cron.d\/php5 cron job for PHP 5.3.5 allows local users to delete arbitrary files via a symlink attack on a directory under \/var\/lib\/php5\/. \n Publish Date : 2011-03-29 Last Update Date : 2011-04-20",
             "fixVersions": {
                 "base": [
                     "5.3.6"
@@ -3500,7 +3500,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-0708",
-            "summary": "exif.c in the Exif extension in PHP before 5.3.6 on 64-bit platforms performs an incorrect cast, which allows remote attackers to cause a denial of service (application crash) via an image with a crafted Image File Directory (IFD) that triggers a buffer over-read.",
+            "summary": "exif.c in the Exif extension in PHP before 5.3.6 on 64-bit platforms performs an incorrect cast, which allows remote attackers to cause a denial of service (application crash) via an image with a crafted Image File Directory (IFD) that triggers a buffer over-read. \n Publish Date : 2011-03-19 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3518,7 +3518,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-0752",
-            "summary": "The extract function in PHP before 5.2.15 does not prevent use of the EXTR_OVERWRITE parameter to overwrite (1) the GLOBALS superglobal array and (2) the this variable, which allows context-dependent attackers to bypass intended access restrictions by modifying data structures that were not intended to depend on external input, a related issue to CVE-2005-2691 and CVE-2006-3758.",
+            "summary": "The extract function in PHP before 5.2.15 does not prevent use of the EXTR_OVERWRITE parameter to overwrite (1) the GLOBALS superglobal array and (2) the this variable, which allows context-dependent attackers to bypass intended access restrictions by modifying data structures that were not intended to depend on external input, a related issue to CVE-2005-2691 and CVE-2006-3758. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3535,7 +3535,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-0753",
-            "summary": "Race condition in the PCNTL extension in PHP before 5.3.4, when a user-defined signal handler exists, might allow context-dependent attackers to cause a denial of service (memory corruption) via a large number of concurrent signals.",
+            "summary": "Race condition in the PCNTL extension in PHP before 5.3.4, when a user-defined signal handler exists, might allow context-dependent attackers to cause a denial of service (memory corruption) via a large number of concurrent signals. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3550,7 +3550,7 @@
         {
             "threat": "4.4",
             "cveid": "CVE-2011-0754",
-            "summary": "The SplFileInfo::getType function in the Standard PHP Library (SPL) extension in PHP before 5.3.4 on Windows does not properly detect symbolic links, which might make it easier for local users to conduct symlink attacks by leveraging cross-platform differences in the stat structure, related to lack of a FILE_ATTRIBUTE_REPARSE_POINT check.",
+            "summary": "The SplFileInfo::getType function in the Standard PHP Library (SPL) extension in PHP before 5.3.4 on Windows does not properly detect symbolic links, which might make it easier for local users to conduct symlink attacks by leveraging cross-platform differences in the stat structure, related to lack of a FILE_ATTRIBUTE_REPARSE_POINT check. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3565,7 +3565,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-0755",
-            "summary": "Integer overflow in the mt_rand function in PHP before 5.3.4 might make it easier for context-dependent attackers to predict the return values by leveraging a script's use of a large max parameter, as demonstrated by a value that exceeds mt_getrandmax.",
+            "summary": "Integer overflow in the mt_rand function in PHP before 5.3.4 might make it easier for context-dependent attackers to predict the return values by leveraging a script's use of a large max parameter, as demonstrated by a value that exceeds mt_getrandmax. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3583,7 +3583,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1092",
-            "summary": "Integer overflow in ext\/shmop\/shmop.c in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (crash) and possibly read sensitive memory via a large third argument to the shmop_read function.",
+            "summary": "Integer overflow in ext\/shmop\/shmop.c in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (crash) and possibly read sensitive memory via a large third argument to the shmop_read function. \n Publish Date : 2011-03-15 Last Update Date : 2011-10-20",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3601,7 +3601,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1148",
-            "summary": "Use-after-free vulnerability in the substr_replace function in PHP 5.3.6 and earlier allows context-dependent attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact by using the same variable for multiple arguments.",
+            "summary": "Use-after-free vulnerability in the substr_replace function in PHP 5.3.6 and earlier allows context-dependent attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact by using the same variable for multiple arguments. \n Publish Date : 2011-03-18 Last Update Date : 2012-02-03",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3616,7 +3616,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1153",
-            "summary": "Multiple format string vulnerabilities in phar_object.c in the phar extension in PHP 5.3.5 and earlier allow context-dependent attackers to obtain sensitive information from process memory, cause a denial of service (memory corruption), or possibly execute arbitrary code via format string specifiers in an argument to a class method, leading to an incorrect zend_throw_exception_ex call.",
+            "summary": "Multiple format string vulnerabilities in phar_object.c in the phar extension in PHP 5.3.5 and earlier allow context-dependent attackers to obtain sensitive information from process memory, cause a denial of service (memory corruption), or possibly execute arbitrary code via format string specifiers in an argument to a class method, leading to an incorrect zend_throw_exception_ex call. \n Publish Date : 2011-03-16 Last Update Date : 2011-10-20",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3634,7 +3634,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1398",
-            "summary": "The sapi_header_op function in main\/SAPI.c in PHP before 5.3.11 and 5.4.x before 5.4.0RC2 does not check for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.",
+            "summary": "The sapi_header_op function in main\/SAPI.c in PHP before 5.3.11 and 5.4.x before 5.4.0RC2 does not check for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome. \n Publish Date : 2012-08-30 Last Update Date : 2013-10-10",
             "fixVersions": {
                 "base": [
                     "5.3.11"
@@ -3644,7 +3644,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1464",
-            "summary": "Buffer overflow in the strval function in PHP before 5.3.6, when the precision configuration option has a large value, might allow context-dependent attackers to cause a denial of service (application crash) via a small numerical value in the argument.",
+            "summary": "Buffer overflow in the strval function in PHP before 5.3.6, when the precision configuration option has a large value, might allow context-dependent attackers to cause a denial of service (application crash) via a small numerical value in the argument. \n Publish Date : 2011-03-19 Last Update Date : 2011-04-08",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3662,7 +3662,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-1466",
-            "summary": "Integer overflow in the SdnToJulian function in the Calendar extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a large integer in the first argument to the cal_from_jd function.",
+            "summary": "Integer overflow in the SdnToJulian function in the Calendar extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a large integer in the first argument to the cal_from_jd function. \n Publish Date : 2011-03-19 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3680,7 +3680,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-1467",
-            "summary": "Unspecified vulnerability in the NumberFormatter::setSymbol (aka numfmt_set_symbol) function in the Intl extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument, a related issue to CVE-2010-4409.",
+            "summary": "Unspecified vulnerability in the NumberFormatter::setSymbol (aka numfmt_set_symbol) function in the Intl extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument, a related issue to CVE-2010-4409. \n Publish Date : 2011-03-19 Last Update Date : 2011-10-20",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3698,7 +3698,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1468",
-            "summary": "Multiple memory leaks in the OpenSSL extension in PHP before 5.3.6 might allow remote attackers to cause a denial of service (memory consumption) via (1) plaintext data to the openssl_encrypt function or (2) ciphertext data to the openssl_decrypt function.",
+            "summary": "Multiple memory leaks in the OpenSSL extension in PHP before 5.3.6 might allow remote attackers to cause a denial of service (memory consumption) via (1) plaintext data to the openssl_encrypt function or (2) ciphertext data to the openssl_decrypt function. \n Publish Date : 2011-03-19 Last Update Date : 2012-01-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3716,7 +3716,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1469",
-            "summary": "Unspecified vulnerability in the Streams component in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) by accessing an ftp:\/\/ URL during use of an HTTP proxy with the FTP wrapper.",
+            "summary": "Unspecified vulnerability in the Streams component in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) by accessing an ftp:\/\/ URL during use of an HTTP proxy with the FTP wrapper. \n Publish Date : 2011-03-19 Last Update Date : 2012-01-18",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3734,7 +3734,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1470",
-            "summary": "The Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a ziparchive stream that is not properly handled by the stream_get_contents function.",
+            "summary": "The Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a ziparchive stream that is not properly handled by the stream_get_contents function. \n Publish Date : 2011-03-19 Last Update Date : 2011-10-20",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3752,7 +3752,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1471",
-            "summary": "Integer signedness error in zip_stream.c in the Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (CPU consumption) via a malformed archive file that triggers errors in zip_fread function calls.",
+            "summary": "Integer signedness error in zip_stream.c in the Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (CPU consumption) via a malformed archive file that triggers errors in zip_fread function calls. \n Publish Date : 2011-03-19 Last Update Date : 2013-08-31",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3767,7 +3767,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-1657",
-            "summary": "The (1) ZipArchive::addGlob and (2) ZipArchive::addPattern functions in ext\/zip\/php_zip.c in PHP 5.3.6 allow context-dependent attackers to cause a denial of service (application crash) via certain flags arguments, as demonstrated by (a) GLOB_ALTDIRFUNC and (b) GLOB_APPEND.",
+            "summary": "The (1) ZipArchive::addGlob and (2) ZipArchive::addPattern functions in ext\/zip\/php_zip.c in PHP 5.3.6 allow context-dependent attackers to cause a denial of service (application crash) via certain flags arguments, as demonstrated by (a) GLOB_ALTDIRFUNC and (b) GLOB_APPEND. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
             "fixVersions": {
                 "base": [
                     "5.3.7"
@@ -3777,7 +3777,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1938",
-            "summary": "Stack-based buffer overflow in the socket_connect function in ext\/sockets\/sockets.c in PHP 5.3.3 through 5.3.6 might allow context-dependent attackers to execute arbitrary code via a long pathname for a UNIX socket.",
+            "summary": "Stack-based buffer overflow in the socket_connect function in ext\/sockets\/sockets.c in PHP 5.3.3 through 5.3.6 might allow context-dependent attackers to execute arbitrary code via a long pathname for a UNIX socket. \n Publish Date : 2011-05-31 Last Update Date : 2012-02-08",
             "fixVersions": {
                 "base": [
                     "5.3.7"
@@ -3787,7 +3787,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2011-2202",
-            "summary": "The rfc1867_post_handler function in main\/rfc1867.c in PHP before 5.3.7 does not properly restrict filenames in multipart\/form-data POST requests, which allows remote attackers to conduct absolute path traversal attacks, and possibly create or overwrite arbitrary files, via a crafted upload request, related to a \"file path injection vulnerability.\"",
+            "summary": "The rfc1867_post_handler function in main\/rfc1867.c in PHP before 5.3.7 does not properly restrict filenames in multipart\/form-data POST requests, which allows remote attackers to conduct absolute path traversal attacks, and possibly create or overwrite arbitrary files, via a crafted upload request, related to a \"file path injection vulnerability.\" \n Publish Date : 2011-06-16 Last Update Date : 2012-11-05",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3802,7 +3802,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-2483",
-            "summary": "crypt_blowfish before 1.1, as used in PHP before 5.3.7 on certain platforms, PostgreSQL before 8.4.9, and other products, does not properly handle 8-bit characters, which makes it easier for context-dependent attackers to determine a cleartext password by leveraging knowledge of a password hash.",
+            "summary": "crypt_blowfish before 1.1, as used in PHP before 5.3.7 on certain platforms, PostgreSQL before 8.4.9, and other products, does not properly handle 8-bit characters, which makes it easier for context-dependent attackers to determine a cleartext password by leveraging knowledge of a password hash. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-08",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3820,7 +3820,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-3182",
-            "summary": "PHP before 5.3.7 does not properly check the return values of the malloc, calloc, and realloc library functions, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger a buffer overflow by leveraging the ability to provide an arbitrary value for a function argument, related to (1) ext\/curl\/interface.c, (2) ext\/date\/lib\/parse_date.c, (3) ext\/date\/lib\/parse_iso_intervals.c, (4) ext\/date\/lib\/parse_tz.c, (5) ext\/date\/lib\/timelib.c, (6) ext\/pdo_odbc\/pdo_odbc.c, (7) ext\/reflection\/php_reflection.c, (8) ext\/soap\/php_sdl.c, (9) ext\/xmlrpc\/libxmlrpc\/base64.c, (10) TSRM\/tsrm_win32.c, and (11) the strtotime function.",
+            "summary": "PHP before 5.3.7 does not properly check the return values of the malloc, calloc, and realloc library functions, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger a buffer overflow by leveraging the ability to provide an arbitrary value for a function argument, related to (1) ext\/curl\/interface.c, (2) ext\/date\/lib\/parse_date.c, (3) ext\/date\/lib\/parse_iso_intervals.c, (4) ext\/date\/lib\/parse_tz.c, (5) ext\/date\/lib\/timelib.c, (6) ext\/pdo_odbc\/pdo_odbc.c, (7) ext\/reflection\/php_reflection.c, (8) ext\/soap\/php_sdl.c, (9) ext\/xmlrpc\/libxmlrpc\/base64.c, (10) TSRM\/tsrm_win32.c, and (11) the strtotime function. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3838,7 +3838,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-3189",
-            "summary": "The crypt function in PHP 5.3.7, when the MD5 hash type is used, returns the value of the salt argument instead of the hashed string, which might allow remote attackers to bypass authentication via an arbitrary password, a different vulnerability than CVE-2011-2483.",
+            "summary": "The crypt function in PHP 5.3.7, when the MD5 hash type is used, returns the value of the salt argument instead of the hashed string, which might allow remote attackers to bypass authentication via an arbitrary password, a different vulnerability than CVE-2011-2483. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
             "fixVersions": {
                 "base": [
                     "5.3.8"
@@ -3848,7 +3848,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-3267",
-            "summary": "PHP before 5.3.7 does not properly implement the error_log function, which allows context-dependent attackers to cause a denial of service (application crash) via unspecified vectors.",
+            "summary": "PHP before 5.3.7 does not properly implement the error_log function, which allows context-dependent attackers to cause a denial of service (application crash) via unspecified vectors. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3866,7 +3866,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2011-3268",
-            "summary": "Buffer overflow in the crypt function in PHP before 5.3.7 allows context-dependent attackers to have an unspecified impact via a long salt argument, a different vulnerability than CVE-2011-2483.",
+            "summary": "Buffer overflow in the crypt function in PHP before 5.3.7 allows context-dependent attackers to have an unspecified impact via a long salt argument, a different vulnerability than CVE-2011-2483. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3884,7 +3884,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-3379",
-            "summary": "The is_a function in PHP 5.3.7 and 5.3.8 triggers a call to the __autoload function, which makes it easier for remote attackers to execute arbitrary code by providing a crafted URL and leveraging potentially unsafe behavior in certain PEAR packages and custom autoloaders.",
+            "summary": "The is_a function in PHP 5.3.7 and 5.3.8 triggers a call to the __autoload function, which makes it easier for remote attackers to execute arbitrary code by providing a crafted URL and leveraging potentially unsafe behavior in certain PEAR packages and custom autoloaders. \n Publish Date : 2011-11-03 Last Update Date : 2012-07-03",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3894,7 +3894,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-4153",
-            "summary": "PHP 5.3.8 does not always check the return value of the zend_strndup function, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that performs strndup operations on untrusted string data, as demonstrated by the define function in zend_builtin_functions.c, and unspecified functions in ext\/soap\/php_sdl.c, ext\/standard\/syslog.c, ext\/standard\/browscap.c, ext\/oci8\/oci8.c, ext\/com_dotnet\/com_typeinfo.c, and main\/php_open_temporary_file.c.",
+            "summary": "PHP 5.3.8 does not always check the return value of the zend_strndup function, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that performs strndup operations on untrusted string data, as demonstrated by the define function in zend_builtin_functions.c, and unspecified functions in ext\/soap\/php_sdl.c, ext\/standard\/syslog.c, ext\/standard\/browscap.c, ext\/oci8\/oci8.c, ext\/com_dotnet\/com_typeinfo.c, and main\/php_open_temporary_file.c. \n Publish Date : 2012-01-18 Last Update Date : 2012-07-21",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3904,7 +3904,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2011-4566",
-            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in the exif extension in PHP 5.4.0beta2 on 32-bit platforms allows remote attackers to read the contents of arbitrary memory locations or cause a denial of service via a crafted offset_val value in an EXIF header in a JPEG file, a different vulnerability than CVE-2011-0708.",
+            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in the exif extension in PHP 5.4.0beta2 on 32-bit platforms allows remote attackers to read the contents of arbitrary memory locations or cause a denial of service via a crafted offset_val value in an EXIF header in a JPEG file, a different vulnerability than CVE-2011-0708. \n Publish Date : 2011-11-28 Last Update Date : 2012-11-06",
             "fixVersions": {
                 "base": [
                     "5.4.1"
@@ -3914,7 +3914,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2011-4718",
-            "summary": "Session fixation vulnerability in the Sessions subsystem in PHP before 5.5.2 allows remote attackers to hijack web sessions by specifying a session ID.",
+            "summary": "Session fixation vulnerability in the Sessions subsystem in PHP before 5.5.2 allows remote attackers to hijack web sessions by specifying a session ID. \n Publish Date : 2013-08-13 Last Update Date : 2013-08-13",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3929,7 +3929,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-4885",
-            "summary": "PHP before 5.3.9 computes hash values for form parameters without restricting the ability to trigger hash collisions predictably, which allows remote attackers to cause a denial of service (CPU consumption) by sending many crafted parameters.",
+            "summary": "PHP before 5.3.9 computes hash values for form parameters without restricting the ability to trigger hash collisions predictably, which allows remote attackers to cause a denial of service (CPU consumption) by sending many crafted parameters. \n Publish Date : 2011-12-29 Last Update Date : 2013-10-10",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3942,7 +3942,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2012-0057",
-            "summary": "PHP before 5.3.9 has improper libxslt security settings, which allows remote attackers to create arbitrary files via a crafted XSLT stylesheet that uses the libxslt output extension.",
+            "summary": "PHP before 5.3.9 has improper libxslt security settings, which allows remote attackers to create arbitrary files via a crafted XSLT stylesheet that uses the libxslt output extension. \n Publish Date : 2012-02-01 Last Update Date : 2012-07-03",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3955,7 +3955,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-0781",
-            "summary": "The tidy_diagnose function in PHP 5.3.8 might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that attempts to perform Tidy::diagnose operations on invalid objects, a different vulnerability than CVE-2011-4153.",
+            "summary": "The tidy_diagnose function in PHP 5.3.8 might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that attempts to perform Tidy::diagnose operations on invalid objects, a different vulnerability than CVE-2011-4153. \n Publish Date : 2012-01-18 Last Update Date : 2012-06-27",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3965,7 +3965,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-0788",
-            "summary": "The PDORow implementation in PHP before 5.3.9 does not properly interact with the session feature, which allows remote attackers to cause a denial of service (application crash) via a crafted application that uses a PDO driver for a fetch and then calls the session_start function, as demonstrated by a crash of the Apache HTTP Server.",
+            "summary": "The PDORow implementation in PHP before 5.3.9 does not properly interact with the session feature, which allows remote attackers to cause a denial of service (application crash) via a crafted application that uses a PDO driver for a fetch and then calls the session_start function, as demonstrated by a crash of the Apache HTTP Server. \n Publish Date : 2012-02-14 Last Update Date : 2012-06-27",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3978,7 +3978,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-0789",
-            "summary": "Memory leak in the timezone functionality in PHP before 5.3.9 allows remote attackers to cause a denial of service (memory consumption) by triggering many strtotime function calls, which are not properly handled by the php_date_parse_tzfile cache.",
+            "summary": "Memory leak in the timezone functionality in PHP before 5.3.9 allows remote attackers to cause a denial of service (memory consumption) by triggering many strtotime function calls, which are not properly handled by the php_date_parse_tzfile cache. \n Publish Date : 2012-02-14 Last Update Date : 2012-06-27",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3991,7 +3991,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-0830",
-            "summary": "The php_register_variable_ex function in php_variables.c in PHP 5.3.9 allows remote attackers to execute arbitrary code via a request containing a large number of variables, related to improper handling of array variables.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-4885.",
+            "summary": "The php_register_variable_ex function in php_variables.c in PHP 5.3.9 allows remote attackers to execute arbitrary code via a request containing a large number of variables, related to improper handling of array variables.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-4885. \n Publish Date : 2012-02-06 Last Update Date : 2012-07-21",
             "fixVersions": {
                 "base": [
                     "5.3.10"
@@ -4001,7 +4001,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2012-0831",
-            "summary": "PHP before 5.3.10 does not properly perform a temporary change to the magic_quotes_gpc directive during the importing of environment variables, which makes it easier for remote attackers to conduct SQL injection attacks via a crafted request, related to main\/php_variables.c, sapi\/cgi\/cgi_main.c, and sapi\/fpm\/fpm\/fpm_main.c.",
+            "summary": "PHP before 5.3.10 does not properly perform a temporary change to the magic_quotes_gpc directive during the importing of environment variables, which makes it easier for remote attackers to conduct SQL injection attacks via a crafted request, related to main\/php_variables.c, sapi\/cgi\/cgi_main.c, and sapi\/fpm\/fpm\/fpm_main.c. \n Publish Date : 2012-02-10 Last Update Date : 2013-10-10",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4019,7 +4019,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-1171",
-            "summary": "The libxml RSHUTDOWN function in PHP 5.x allows remote attackers to bypass the open_basedir protection mechanism and read arbitrary files via vectors involving a stream_close method call during use of a custom stream wrapper.",
+            "summary": "The libxml RSHUTDOWN function in PHP 5.x allows remote attackers to bypass the open_basedir protection mechanism and read arbitrary files via vectors involving a stream_close method call during use of a custom stream wrapper. \n Publish Date : 2014-02-15 Last Update Date : 2014-02-18",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4034,7 +4034,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2012-1172",
-            "summary": "The file-upload implementation in rfc1867.c in PHP before 5.4.0 does not properly handle invalid [ (open square bracket) characters in name values, which makes it easier for remote attackers to cause a denial of service (malformed $_FILES indexes) or conduct directory traversal attacks during multi-file uploads by leveraging a script that lacks its own filename restrictions.",
+            "summary": "The file-upload implementation in rfc1867.c in PHP before 5.4.0 does not properly handle invalid [ (open square bracket) characters in name values, which makes it easier for remote attackers to cause a denial of service (malformed $_FILES indexes) or conduct directory traversal attacks during multi-file uploads by leveraging a script that lacks its own filename restrictions. \n Publish Date : 2012-05-23 Last Update Date : 2012-09-21",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4047,7 +4047,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-1823",
-            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.",
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-19",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4061,7 +4061,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2012-2143",
-            "summary": "The crypt_des (aka DES-based crypt) function in FreeBSD before 9.0-RELEASE-p2, as used in PHP, PostgreSQL, and other products, does not process the complete cleartext password if this password contains a 0x80 character, which makes it easier for context-dependent attackers to obtain access via an authentication attempt with an initial substring of the intended password, as demonstrated by a Unicode password.",
+            "summary": "The crypt_des (aka DES-based crypt) function in FreeBSD before 9.0-RELEASE-p2, as used in PHP, PostgreSQL, and other products, does not process the complete cleartext password if this password contains a 0x80 character, which makes it easier for context-dependent attackers to obtain access via an authentication attempt with an initial substring of the intended password, as demonstrated by a Unicode password. \n Publish Date : 2012-07-05 Last Update Date : 2013-06-10",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4079,7 +4079,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-2311",
-            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that contain a %3D sequence but no = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823.",
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that contain a %3D sequence but no = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4098,7 +4098,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-2329",
-            "summary": "Buffer overflow in the apache_request_headers function in sapi\/cgi\/cgi_main.c in PHP 5.4.x before 5.4.3 allows remote attackers to cause a denial of service (application crash) via a long string in the header of an HTTP request.",
+            "summary": "Buffer overflow in the apache_request_headers function in sapi\/cgi\/cgi_main.c in PHP 5.4.x before 5.4.3 allows remote attackers to cause a denial of service (application crash) via a long string in the header of an HTTP request. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
             "fixVersions": {
                 "base": [
                     "5.4.3"
@@ -4108,7 +4108,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-2335",
-            "summary": "php-wrapper.fcgi does not properly handle command-line arguments, which allows remote attackers to bypass a protection mechanism in PHP 5.3.12 and 5.4.2 and execute arbitrary code by leveraging improper interaction between the PHP sapi\/cgi\/cgi_main.c component and a query string beginning with a +- sequence.",
+            "summary": "php-wrapper.fcgi does not properly handle command-line arguments, which allows remote attackers to bypass a protection mechanism in PHP 5.3.12 and 5.4.2 and execute arbitrary code by leveraging improper interaction between the PHP sapi\/cgi\/cgi_main.c component and a query string beginning with a +- sequence. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
             "fixVersions": {
                 "base": [
                     "5.3.13",
@@ -4119,7 +4119,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-2336",
-            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to cause a denial of service (resource consumption) by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'T' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823.",
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to cause a denial of service (resource consumption) by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'T' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4138,7 +4138,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2012-2376",
-            "summary": "Buffer overflow in the com_print_typeinfo function in PHP 5.4.3 and earlier on Windows allows remote attackers to execute arbitrary code via crafted arguments that trigger incorrect handling of COM object VARIANT types, as exploited in the wild in May 2012.",
+            "summary": "Buffer overflow in the com_print_typeinfo function in PHP 5.4.3 and earlier on Windows allows remote attackers to execute arbitrary code via crafted arguments that trigger incorrect handling of COM object VARIANT types, as exploited in the wild in May 2012. \n Publish Date : 2012-05-21 Last Update Date : 2012-08-16",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4157,7 +4157,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-2386",
-            "summary": "Integer overflow in the phar_parse_tarfile function in tar.c in the phar extension in PHP before 5.3.14 and 5.4.x before 5.4.4 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted tar file that triggers a heap-based buffer overflow.",
+            "summary": "Integer overflow in the phar_parse_tarfile function in tar.c in the phar extension in PHP before 5.3.14 and 5.4.x before 5.4.4 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted tar file that triggers a heap-based buffer overflow. \n Publish Date : 2012-07-07 Last Update Date : 2012-09-21",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4176,7 +4176,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2012-2688",
-            "summary": "Unspecified vulnerability in the _php_stream_scandir function in the stream implementation in PHP before 5.3.15 and 5.4.x before 5.4.5 has unknown impact and remote attack vectors, related to an \"overflow.\"",
+            "summary": "Unspecified vulnerability in the _php_stream_scandir function in the stream implementation in PHP before 5.3.15 and 5.4.x before 5.4.5 has unknown impact and remote attack vectors, related to an \"overflow.\" \n Publish Date : 2012-07-20 Last Update Date : 2013-10-10",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4195,7 +4195,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-3365",
-            "summary": "The SQLite functionality in PHP before 5.3.15 allows remote attackers to bypass the open_basedir protection mechanism via unspecified vectors.",
+            "summary": "The SQLite functionality in PHP before 5.3.15 allows remote attackers to bypass the open_basedir protection mechanism via unspecified vectors. \n Publish Date : 2012-07-20 Last Update Date : 2013-06-25",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4213,7 +4213,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2012-3450",
-            "summary": "pdo_sql_parser.re in the PDO extension in PHP before 5.3.14 and 5.4.x before 5.4.4 does not properly determine the end of the query string during parsing of prepared statements, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted parameter value.",
+            "summary": "pdo_sql_parser.re in the PDO extension in PHP before 5.3.14 and 5.4.x before 5.4.4 does not properly determine the end of the query string during parsing of prepared statements, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted parameter value. \n Publish Date : 2012-08-06 Last Update Date : 2013-04-18",
             "fixVersions": {
                 "base": [
                     "5.3.14",
@@ -4224,7 +4224,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2012-4388",
-            "summary": "The sapi_header_op function in main\/SAPI.c in PHP 5.4.0RC2 through 5.4.0 does not properly determine a pointer during checks for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-1398.",
+            "summary": "The sapi_header_op function in main\/SAPI.c in PHP 5.4.0RC2 through 5.4.0 does not properly determine a pointer during checks for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-1398. \n Publish Date : 2012-09-07 Last Update Date : 2013-09-11",
             "fixVersions": {
                 "base": [
                     "5.4.1"
@@ -4234,7 +4234,7 @@
         {
             "threat": "6.0",
             "cveid": "CVE-2012-5381",
-            "summary": "** DISPUTED ** Untrusted search path vulnerability in the installation functionality in PHP 5.3.17, when installed in the top-level C:\\ directory, might allow local users to gain privileges via a Trojan horse DLL in the C:\\PHP directory, which may be added to the PATH system environment variable by an administrator, as demonstrated by a Trojan horse wlbsctrl.dll file used by the \"IKE and AuthIP IPsec Keying Modules\" system service in Windows Vista SP1, Windows Server 2008 SP2, Windows 7 SP1, and Windows 8 Release Preview.  NOTE: CVE disputes this issue because the unsafe PATH is established only by a separate administrative action that is not a default part of the PHP installation.",
+            "summary": "** DISPUTED ** Untrusted search path vulnerability in the installation functionality in PHP 5.3.17, when installed in the top-level C:\\ directory, might allow local users to gain privileges via a Trojan horse DLL in the C:\\PHP directory, which may be added to the PATH system environment variable by an administrator, as demonstrated by a Trojan horse wlbsctrl.dll file used by the \"IKE and AuthIP IPsec Keying Modules\" system service in Windows Vista SP1, Windows Server 2008 SP2, Windows 7 SP1, and Windows 8 Release Preview.  NOTE: CVE disputes this issue because the unsafe PATH is established only by a separate administrative action that is not a default part of the PHP installation. \n Publish Date : 2012-10-11 Last Update Date : 2013-03-01",
             "fixVersions": {
                 "base": [
                     "5.3.18"
@@ -4244,7 +4244,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-6113",
-            "summary": "The openssl_encrypt function in ext\/openssl\/openssl.c in PHP 5.3.9 through 5.3.13 does not initialize a certain variable, which allows remote attackers to obtain sensitive information from process memory by providing zero bytes of input data.",
+            "summary": "The openssl_encrypt function in ext\/openssl\/openssl.c in PHP 5.3.9 through 5.3.13 does not initialize a certain variable, which allows remote attackers to obtain sensitive information from process memory by providing zero bytes of input data. \n Publish Date : 2013-01-19 Last Update Date : 2013-02-02",
             "fixVersions": {
                 "base": [
                     "5.3.14"
@@ -4254,7 +4254,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2013-1635",
-            "summary": "ext\/soap\/soap.c in PHP before 5.3.22 and 5.4.x before 5.4.13 does not validate the relationship between the soap.wsdl_cache_dir directive and the open_basedir directive, which allows remote attackers to bypass intended access restrictions by triggering the creation of cached SOAP WSDL files in an arbitrary directory.",
+            "summary": "ext\/soap\/soap.c in PHP before 5.3.22 and 5.4.x before 5.4.13 does not validate the relationship between the soap.wsdl_cache_dir directive and the open_basedir directive, which allows remote attackers to bypass intended access restrictions by triggering the creation of cached SOAP WSDL files in an arbitrary directory. \n Publish Date : 2013-03-06 Last Update Date : 2014-01-27",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4273,7 +4273,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-1643",
-            "summary": "The SOAP parser in PHP before 5.3.23 and 5.4.x before 5.4.13 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2013-1824.",
+            "summary": "The SOAP parser in PHP before 5.3.23 and 5.4.x before 5.4.13 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2013-1824. \n Publish Date : 2013-03-06 Last Update Date : 2014-01-27",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4292,7 +4292,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2013-1824",
-            "summary": "The SOAP parser in PHP before 5.3.22 and 5.4.x before 5.4.12 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.",
+            "summary": "The SOAP parser in PHP before 5.3.22 and 5.4.x before 5.4.12 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions. \n Publish Date : 2013-09-16 Last Update Date : 2013-09-18",
             "fixVersions": {
                 "base": [
                     "5.3.22",
@@ -4303,7 +4303,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-2110",
-            "summary": "Heap-based buffer overflow in the php_quot_print_encode function in ext\/standard\/quot_print.c in PHP before 5.3.26 and 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted argument to the quoted_printable_encode function.",
+            "summary": "Heap-based buffer overflow in the php_quot_print_encode function in ext\/standard\/quot_print.c in PHP before 5.3.26 and 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted argument to the quoted_printable_encode function. \n Publish Date : 2013-06-21 Last Update Date : 2013-09-17",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4322,7 +4322,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-3735",
-            "summary": "** DISPUTED ** The Zend Engine in PHP before 5.4.16 RC1, and 5.5.0 before RC2, does not properly determine whether a parser error occurred, which allows context-dependent attackers to cause a denial of service (memory consumption and application crash) via a crafted function definition, as demonstrated by an attack within a shared web-hosting environment.  NOTE: the vendor's http:\/\/php.net\/security-note.php page says \"for critical security situations you should be using OS-level security by running multiple web servers each as their own user id.\"",
+            "summary": "** DISPUTED ** The Zend Engine in PHP before 5.4.16 RC1, and 5.5.0 before RC2, does not properly determine whether a parser error occurred, which allows context-dependent attackers to cause a denial of service (memory consumption and application crash) via a crafted function definition, as demonstrated by an attack within a shared web-hosting environment.  NOTE: the vendor's http:\/\/php.net\/security-note.php page says \"for critical security situations you should be using OS-level security by running multiple web servers each as their own user id.\" \n Publish Date : 2013-05-31 Last Update Date : 2013-06-03",
             "fixVersions": {
                 "base": [
                     "5.4.16",
@@ -4333,7 +4333,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2013-4113",
-            "summary": "ext\/xml\/xml.c in PHP before 5.3.27 does not properly consider parsing depth, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted document that is processed by the xml_parse_into_struct function.",
+            "summary": "ext\/xml\/xml.c in PHP before 5.3.27 does not properly consider parsing depth, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted document that is processed by the xml_parse_into_struct function. \n Publish Date : 2013-07-13 Last Update Date : 2014-03-05",
             "fixVersions": {
                 "base": [
                     "5.3.27"
@@ -4343,7 +4343,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2013-4248",
-            "summary": "The openssl_x509_parse function in openssl.c in the OpenSSL module in PHP before 5.4.18 and 5.5.x before 5.5.2 does not properly handle a '\\0' character in a domain name in the Subject Alternative Name field of an X.509 certificate, which allows man-in-the-middle attackers to spoof arbitrary SSL servers via a crafted certificate issued by a legitimate Certification Authority, a related issue to CVE-2009-2408.",
+            "summary": "The openssl_x509_parse function in openssl.c in the OpenSSL module in PHP before 5.4.18 and 5.5.x before 5.5.2 does not properly handle a '\\0' character in a domain name in the Subject Alternative Name field of an X.509 certificate, which allows man-in-the-middle attackers to spoof arbitrary SSL servers via a crafted certificate issued by a legitimate Certification Authority, a related issue to CVE-2009-2408. \n Publish Date : 2013-08-17 Last Update Date : 2015-11-20",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4358,7 +4358,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-4635",
-            "summary": "Integer overflow in the SdnToJewish function in jewish.c in the Calendar component in PHP before 5.3.26 and 5.4.x before 5.4.16 allows context-dependent attackers to cause a denial of service (application hang) via a large argument to the jdtojewish function.",
+            "summary": "Integer overflow in the SdnToJewish function in jewish.c in the Calendar component in PHP before 5.3.26 and 5.4.x before 5.4.16 allows context-dependent attackers to cause a denial of service (application hang) via a large argument to the jdtojewish function. \n Publish Date : 2013-06-21 Last Update Date : 2013-09-11",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4377,7 +4377,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2013-4636",
-            "summary": "The mget function in libmagic\/softmagic.c in the Fileinfo component in PHP 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (invalid pointer dereference and application crash) via an MP3 file that triggers incorrect MIME type detection during access to an finfo object.",
+            "summary": "The mget function in libmagic\/softmagic.c in the Fileinfo component in PHP 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (invalid pointer dereference and application crash) via an MP3 file that triggers incorrect MIME type detection during access to an finfo object. \n Publish Date : 2013-06-21 Last Update Date : 2013-06-24",
             "fixVersions": {
                 "base": [
                     "5.4.16"
@@ -4387,7 +4387,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2013-6420",
-            "summary": "The asn1_time_to_time_t function in ext\/openssl\/openssl.c in PHP before 5.3.28, 5.4.x before 5.4.23, and 5.5.x before 5.5.7 does not properly parse (1) notBefore and (2) notAfter timestamps in X.509 certificates, which allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted certificate that is not properly handled by the openssl_x509_parse function.",
+            "summary": "The asn1_time_to_time_t function in ext\/openssl\/openssl.c in PHP before 5.3.28, 5.4.x before 5.4.23, and 5.5.x before 5.5.7 does not properly parse (1) notBefore and (2) notAfter timestamps in X.509 certificates, which allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted certificate that is not properly handled by the openssl_x509_parse function. \n Publish Date : 2013-12-16 Last Update Date : 2015-05-18",
             "fixVersions": {
                 "base": [
                     "5.3.28",
@@ -4399,7 +4399,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2013-6501",
-            "summary": "The default soap.wsdl_cache_dir setting in (1) php.ini-production and (2) php.ini-development in PHP through 5.6.7 specifies the \/tmp directory, which makes it easier for local users to conduct WSDL injection attacks by creating a file under \/tmp with a predictable filename that is used by the get_sdl function in ext\/soap\/php_sdl.c.",
+            "summary": "The default soap.wsdl_cache_dir setting in (1) php.ini-production and (2) php.ini-development in PHP through 5.6.7 specifies the \/tmp directory, which makes it easier for local users to conduct WSDL injection attacks by creating a file under \/tmp with a predictable filename that is used by the get_sdl function in ext\/soap\/php_sdl.c. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-22",
             "fixVersions": {
                 "base": [
                     "5.6.8"
@@ -4409,7 +4409,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-6712",
-            "summary": "The scan function in ext\/date\/lib\/parse_iso_intervals.c in PHP through 5.5.6 does not properly restrict creation of DateInterval objects, which might allow remote attackers to cause a denial of service (heap-based buffer over-read) via a crafted interval specification.",
+            "summary": "The scan function in ext\/date\/lib\/parse_iso_intervals.c in PHP through 5.5.6 does not properly restrict creation of DateInterval objects, which might allow remote attackers to cause a denial of service (heap-based buffer over-read) via a crafted interval specification. \n Publish Date : 2013-11-27 Last Update Date : 2015-05-18",
             "fixVersions": {
                 "base": [
                     "5.5.7"
@@ -4419,7 +4419,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2013-7226",
-            "summary": "Integer overflow in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via an imagecrop function call with a large x dimension value, leading to a heap-based buffer overflow.",
+            "summary": "Integer overflow in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via an imagecrop function call with a large x dimension value, leading to a heap-based buffer overflow. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-13",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4429,7 +4429,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2013-7327",
-            "summary": "The gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check return values, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via invalid imagecrop arguments that lead to use of a NULL pointer as a return value, a different vulnerability than CVE-2013-7226.",
+            "summary": "The gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check return values, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via invalid imagecrop arguments that lead to use of a NULL pointer as a return value, a different vulnerability than CVE-2013-7226. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-08",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4439,7 +4439,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2013-7328",
-            "summary": "Multiple integer signedness errors in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allow remote attackers to cause a denial of service (application crash) or obtain sensitive information via an imagecrop function call with a negative value for the (1) x or (2) y dimension, a different vulnerability than CVE-2013-7226.",
+            "summary": "Multiple integer signedness errors in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allow remote attackers to cause a denial of service (application crash) or obtain sensitive information via an imagecrop function call with a negative value for the (1) x or (2) y dimension, a different vulnerability than CVE-2013-7226. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-08",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4461,7 +4461,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2014-0185",
-            "summary": "sapi\/fpm\/fpm\/fpm_unix.c in the FastCGI Process Manager (FPM) in PHP before 5.4.28 and 5.5.x before 5.5.12 uses 0666 permissions for the UNIX socket, which allows local users to gain privileges via a crafted FastCGI client.",
+            "summary": "sapi\/fpm\/fpm\/fpm_unix.c in the FastCGI Process Manager (FPM) in PHP before 5.4.28 and 5.5.x before 5.5.12 uses 0666 permissions for the UNIX socket, which allows local users to gain privileges via a crafted FastCGI client. \n Publish Date : 2014-05-06 Last Update Date : 2014-09-23",
             "fixVersions": {
                 "base": [
                     "5.4.28",
@@ -4472,7 +4472,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-0207",
-            "summary": "The cdf_read_short_sector function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (assertion failure and application exit) via a crafted CDF file.",
+            "summary": "The cdf_read_short_sector function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (assertion failure and application exit) via a crafted CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4483,7 +4483,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-0237",
-            "summary": "The cdf_unpack_summary_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (performance degradation) by triggering many file_printf calls.",
+            "summary": "The cdf_unpack_summary_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (performance degradation) by triggering many file_printf calls. \n Publish Date : 2014-06-01 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4498,7 +4498,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-0238",
-            "summary": "The cdf_read_property_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (infinite loop or out-of-bounds memory access) via a vector that (1) has zero length or (2) is too long.",
+            "summary": "The cdf_read_property_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (infinite loop or out-of-bounds memory access) via a vector that (1) has zero length or (2) is too long. \n Publish Date : 2014-06-01 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4524,7 +4524,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-2020",
-            "summary": "ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check data types, which might allow remote attackers to obtain sensitive information by using a (1) string or (2) array data type in place of a numeric data type, as demonstrated by an imagecrop function call with a string for the x dimension value, a different vulnerability than CVE-2013-7226.",
+            "summary": "ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check data types, which might allow remote attackers to obtain sensitive information by using a (1) string or (2) array data type in place of a numeric data type, as demonstrated by an imagecrop function call with a string for the x dimension value, a different vulnerability than CVE-2013-7226. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-08",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4534,7 +4534,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-2497",
-            "summary": "The gdImageCreateFromXpm function in gdxpm.c in libgd, as used in PHP 5.4.26 and earlier, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted color table in an XPM file.",
+            "summary": "The gdImageCreateFromXpm function in gdxpm.c in libgd, as used in PHP 5.4.26 and earlier, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted color table in an XPM file. \n Publish Date : 2014-03-21 Last Update Date : 2015-04-14",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4548,7 +4548,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-3478",
-            "summary": "Buffer overflow in the mconvert function in softmagic.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (application crash) via a crafted Pascal string in a FILE_PSTRING conversion.",
+            "summary": "Buffer overflow in the mconvert function in softmagic.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (application crash) via a crafted Pascal string in a FILE_PSTRING conversion. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4559,7 +4559,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3479",
-            "summary": "The cdf_check_stream_offset function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, relies on incorrect sector-size data, which allows remote attackers to cause a denial of service (application crash) via a crafted stream offset in a CDF file.",
+            "summary": "The cdf_check_stream_offset function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, relies on incorrect sector-size data, which allows remote attackers to cause a denial of service (application crash) via a crafted stream offset in a CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4570,7 +4570,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3480",
-            "summary": "The cdf_count_chain function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate sector-count data, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.",
+            "summary": "The cdf_count_chain function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate sector-count data, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4581,7 +4581,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3487",
-            "summary": "The cdf_read_property_info function in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate a stream offset, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.",
+            "summary": "The cdf_read_property_info function in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate a stream offset, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4592,7 +4592,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-3515",
-            "summary": "The SPL component in PHP before 5.4.30 and 5.5.x before 5.5.14 incorrectly anticipates that certain data structures will have the array data type after unserialization, which allows remote attackers to execute arbitrary code via a crafted string that triggers use of a Hashtable destructor, related to \"type confusion\" issues in (1) ArrayObject and (2) SPLObjectStorage.",
+            "summary": "The SPL component in PHP before 5.4.30 and 5.5.x before 5.5.14 incorrectly anticipates that certain data structures will have the array data type after unserialization, which allows remote attackers to execute arbitrary code via a crafted string that triggers use of a Hashtable destructor, related to \"type confusion\" issues in (1) ArrayObject and (2) SPLObjectStorage. \n Publish Date : 2014-07-09 Last Update Date : 2014-11-18",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4613,7 +4613,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3587",
-            "summary": "Integer overflow in the cdf_read_property_info function in cdf.c in file through 5.19, as used in the Fileinfo component in PHP before 5.4.32 and 5.5.x before 5.5.16, allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1571.",
+            "summary": "Integer overflow in the cdf_read_property_info function in cdf.c in file through 5.19, as used in the Fileinfo component in PHP before 5.4.32 and 5.5.x before 5.5.16, allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1571. \n Publish Date : 2014-08-22 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -4624,7 +4624,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2014-3597",
-            "summary": "Multiple buffer overflows in the php_parserr function in ext\/standard\/dns.c in PHP before 5.4.32 and 5.5.x before 5.5.16 allow remote DNS servers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted DNS record, related to the dns_get_record function and the dn_expand function.  NOTE: this issue exists because of an incomplete fix for CVE-2014-4049.",
+            "summary": "Multiple buffer overflows in the php_parserr function in ext\/standard\/dns.c in PHP before 5.4.32 and 5.5.x before 5.5.16 allow remote DNS servers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted DNS record, related to the dns_get_record function and the dn_expand function.  NOTE: this issue exists because of an incomplete fix for CVE-2014-4049. \n Publish Date : 2014-08-22 Last Update Date : 2015-05-11",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -4635,7 +4635,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-3668",
-            "summary": "Buffer overflow in the date_from_ISO8601 function in the mkgmtime implementation in libxmlrpc\/xmlrpc.c in the XMLRPC extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) via (1) a crafted first argument to the xmlrpc_set_type function or (2) a crafted argument to the xmlrpc_decode function, related to an out-of-bounds read operation.",
+            "summary": "Buffer overflow in the date_from_ISO8601 function in the mkgmtime implementation in libxmlrpc\/xmlrpc.c in the XMLRPC extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) via (1) a crafted first argument to the xmlrpc_set_type function or (2) a crafted argument to the xmlrpc_decode function, related to an out-of-bounds read operation. \n Publish Date : 2014-10-29 Last Update Date : 2015-05-13",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -4647,7 +4647,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-3669",
-            "summary": "Integer overflow in the object_custom function in ext\/standard\/var_unserializer.c in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an argument to the unserialize function that triggers calculation of a large length value.",
+            "summary": "Integer overflow in the object_custom function in ext\/standard\/var_unserializer.c in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an argument to the unserialize function that triggers calculation of a large length value. \n Publish Date : 2014-10-29 Last Update Date : 2015-04-17",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -4659,7 +4659,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2014-3670",
-            "summary": "The exif_ifd_make_value function in exif.c in the EXIF extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 operates on floating-point arrays incorrectly, which allows remote attackers to cause a denial of service (heap memory corruption and application crash) or possibly execute arbitrary code via a crafted JPEG image with TIFF thumbnail data that is improperly handled by the exif_thumbnail function.",
+            "summary": "The exif_ifd_make_value function in exif.c in the EXIF extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 operates on floating-point arrays incorrectly, which allows remote attackers to cause a denial of service (heap memory corruption and application crash) or possibly execute arbitrary code via a crafted JPEG image with TIFF thumbnail data that is improperly handled by the exif_thumbnail function. \n Publish Date : 2014-10-29 Last Update Date : 2015-05-13",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -4671,7 +4671,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-3710",
-            "summary": "The donote function in readelf.c in file through 5.20, as used in the Fileinfo component in PHP 5.4.34, does not ensure that sufficient note headers are present, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted ELF file.",
+            "summary": "The donote function in readelf.c in file through 5.20, as used in the Fileinfo component in PHP 5.4.34, does not ensure that sufficient note headers are present, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted ELF file. \n Publish Date : 2014-11-05 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.35",
@@ -4683,7 +4683,7 @@
         {
             "threat": "3.3",
             "cveid": "CVE-2014-3981",
-            "summary": "acinclude.m4, as used in the configure script in PHP 5.5.13 and earlier, allows local users to overwrite arbitrary files via a symlink attack on the \/tmp\/phpglibccheck file.",
+            "summary": "acinclude.m4, as used in the configure script in PHP 5.5.13 and earlier, allows local users to overwrite arbitrary files via a symlink attack on the \/tmp\/phpglibccheck file. \n Publish Date : 2014-06-08 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.5.14"
@@ -4693,7 +4693,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2014-4049",
-            "summary": "Heap-based buffer overflow in the php_parserr function in ext\/standard\/dns.c in PHP 5.6.0beta4 and earlier allows remote servers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted DNS TXT record, related to the dns_get_record function.",
+            "summary": "Heap-based buffer overflow in the php_parserr function in ext\/standard\/dns.c in PHP 5.6.0beta4 and earlier allows remote servers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted DNS TXT record, related to the dns_get_record function. \n Publish Date : 2014-06-18 Last Update Date : 2015-08-28",
             "fixVersions": {
                 "base": [
                     "5.6.1"
@@ -4703,7 +4703,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2014-4670",
-            "summary": "Use-after-free vulnerability in ext\/spl\/spl_dllist.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted iterator usage within applications in certain web-hosting environments.",
+            "summary": "Use-after-free vulnerability in ext\/spl\/spl_dllist.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted iterator usage within applications in certain web-hosting environments. \n Publish Date : 2014-07-10 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.5.15"
@@ -4713,7 +4713,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2014-4698",
-            "summary": "Use-after-free vulnerability in ext\/spl\/spl_array.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted ArrayIterator usage within applications in certain web-hosting environments.",
+            "summary": "Use-after-free vulnerability in ext\/spl\/spl_array.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted ArrayIterator usage within applications in certain web-hosting environments. \n Publish Date : 2014-07-10 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.5.15"
@@ -4723,7 +4723,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2014-4721",
-            "summary": "The phpinfo implementation in ext\/standard\/info.c in PHP before 5.4.30 and 5.5.x before 5.5.14 does not ensure use of the string data type for the PHP_AUTH_PW, PHP_AUTH_TYPE, PHP_AUTH_USER, and PHP_SELF variables, which might allow context-dependent attackers to obtain sensitive information from process memory by using the integer data type with crafted values, related to a \"type confusion\" vulnerability, as demonstrated by reading a private SSL key in an Apache HTTP Server web-hosting environment with mod_ssl and a PHP 5.3.x mod_php.",
+            "summary": "The phpinfo implementation in ext\/standard\/info.c in PHP before 5.4.30 and 5.5.x before 5.5.14 does not ensure use of the string data type for the PHP_AUTH_PW, PHP_AUTH_TYPE, PHP_AUTH_USER, and PHP_SELF variables, which might allow context-dependent attackers to obtain sensitive information from process memory by using the integer data type with crafted values, related to a \"type confusion\" vulnerability, as demonstrated by reading a private SSL key in an Apache HTTP Server web-hosting environment with mod_ssl and a PHP 5.3.x mod_php. \n Publish Date : 2014-07-06 Last Update Date : 2014-11-18",
             "fixVersions": {
                 "base": [
                     "5.3.29",
@@ -4735,7 +4735,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2014-5120",
-            "summary": "gd_ctx.c in the GD component in PHP 5.4.x before 5.4.32 and 5.5.x before 5.5.16 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to overwrite arbitrary files via crafted input to an application that calls the (1) imagegd, (2) imagegd2, (3) imagegif, (4) imagejpeg, (5) imagepng, (6) imagewbmp, or (7) imagewebp function.",
+            "summary": "gd_ctx.c in the GD component in PHP 5.4.x before 5.4.32 and 5.5.x before 5.5.16 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to overwrite arbitrary files via crafted input to an application that calls the (1) imagegd, (2) imagegd2, (3) imagegif, (4) imagejpeg, (5) imagepng, (6) imagewbmp, or (7) imagewebp function. \n Publish Date : 2014-08-22 Last Update Date : 2015-04-13",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -4746,7 +4746,7 @@
         {
             "threat": "3.6",
             "cveid": "CVE-2014-5459",
-            "summary": "The PEAR_REST class in REST.php in PEAR in PHP through 5.6.0 allows local users to write to arbitrary files via a symlink attack on a (1) rest.cachefile or (2) rest.cacheid file in \/tmp\/pear\/cache\/, related to the retrieveCacheFirst and useLocalCache functions.",
+            "summary": "The PEAR_REST class in REST.php in PEAR in PHP through 5.6.0 allows local users to write to arbitrary files via a symlink attack on a (1) rest.cachefile or (2) rest.cacheid file in \/tmp\/pear\/cache\/, related to the retrieveCacheFirst and useLocalCache functions. \n Publish Date : 2014-09-27 Last Update Date : 2014-10-17",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4767,7 +4767,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-8142",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019.",
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019. \n Publish Date : 2014-12-20 Last Update Date : 2015-03-17",
             "fixVersions": {
                 "base": [
                     "5.4.36",
@@ -4779,7 +4779,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-8626",
-            "summary": "Stack-based buffer overflow in the date_from_ISO8601 function in ext\/xmlrpc\/libxmlrpc\/xmlrpc.c in PHP before 5.2.7 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code by including a timezone field in a date, leading to improper XML-RPC encoding.",
+            "summary": "Stack-based buffer overflow in the date_from_ISO8601 function in ext\/xmlrpc\/libxmlrpc\/xmlrpc.c in PHP before 5.2.7 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code by including a timezone field in a date, leading to improper XML-RPC encoding. \n Publish Date : 2014-11-22 Last Update Date : 2015-04-29",
             "fixVersions": {
                 "base": [
                     "5.2.7"
@@ -4789,7 +4789,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-9425",
-            "summary": "Double free vulnerability in the zend_ts_hash_graceful_destroy function in zend_ts_hash.c in the Zend Engine in PHP through 5.5.20 and 5.6.x through 5.6.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors.",
+            "summary": "Double free vulnerability in the zend_ts_hash_graceful_destroy function in zend_ts_hash.c in the Zend Engine in PHP through 5.5.20 and 5.6.x through 5.6.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors. \n Publish Date : 2014-12-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.5.21",
@@ -4800,7 +4800,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-9426",
-            "summary": "** DISPUTED ** The apprentice_load function in libmagic\/apprentice.c in the Fileinfo component in PHP through 5.6.4 attempts to perform a free operation on a stack-based character array, which allows remote attackers to cause a denial of service (memory corruption or application crash) or possibly have unspecified other impact via unknown vectors.  NOTE: this is disputed by the vendor because the standard erealloc behavior makes the free operation unreachable.",
+            "summary": "** DISPUTED ** The apprentice_load function in libmagic\/apprentice.c in the Fileinfo component in PHP through 5.6.4 attempts to perform a free operation on a stack-based character array, which allows remote attackers to cause a denial of service (memory corruption or application crash) or possibly have unspecified other impact via unknown vectors.  NOTE: this is disputed by the vendor because the standard erealloc behavior makes the free operation unreachable. \n Publish Date : 2014-12-30 Last Update Date : 2015-03-16",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4812,7 +4812,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-9427",
-            "summary": "sapi\/cgi\/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping.",
+            "summary": "sapi\/cgi\/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping. \n Publish Date : 2015-01-02 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4833,7 +4833,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-9652",
-            "summary": "The mconvert function in softmagic.c in file before 5.21, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not properly handle a certain string-length field during a copy of a truncated version of a Pascal string, which might allow remote attackers to cause a denial of service (out-of-bounds memory access and application crash) via a crafted file.",
+            "summary": "The mconvert function in softmagic.c in file before 5.21, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not properly handle a certain string-length field during a copy of a truncated version of a Pascal string, which might allow remote attackers to cause a denial of service (out-of-bounds memory access and application crash) via a crafted file. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4845,7 +4845,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-9653",
-            "summary": "readelf.c in file before 5.22, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not consider that pread calls sometimes read only a subset of the available data, which allows remote attackers to cause a denial of service (uninitialized memory access) or possibly have unspecified other impact via a crafted ELF file.",
+            "summary": "readelf.c in file before 5.22, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not consider that pread calls sometimes read only a subset of the available data, which allows remote attackers to cause a denial of service (uninitialized memory access) or possibly have unspecified other impact via a crafted ELF file. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-22",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4857,7 +4857,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-9705",
-            "summary": "Heap-based buffer overflow in the enchant_broker_request_dict function in ext\/enchant\/enchant.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allows remote attackers to execute arbitrary code via vectors that trigger creation of multiple dictionaries.",
+            "summary": "Heap-based buffer overflow in the enchant_broker_request_dict function in ext\/enchant\/enchant.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allows remote attackers to execute arbitrary code via vectors that trigger creation of multiple dictionaries. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.38",
@@ -4869,7 +4869,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-9709",
-            "summary": "The GetCode_ function in gd_gif_in.c in GD 2.1.1 and earlier, as used in PHP before 5.5.21 and 5.6.x before 5.6.5, allows remote attackers to cause a denial of service (buffer over-read and application crash) via a crafted GIF image that is improperly handled by the gdImageCreateFromGif function.",
+            "summary": "The GetCode_ function in gd_gif_in.c in GD 2.1.1 and earlier, as used in PHP before 5.5.21 and 5.6.x before 5.6.5, allows remote attackers to cause a denial of service (buffer over-read and application crash) via a crafted GIF image that is improperly handled by the gdImageCreateFromGif function. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4881,7 +4881,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-0231",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate numerical keys within the serialized properties of an object.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-8142.",
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate numerical keys within the serialized properties of an object.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-8142. \n Publish Date : 2015-01-27 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4893,7 +4893,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2015-0232",
-            "summary": "The exif_process_unicode function in ext\/exif\/exif.c in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized pointer free and application crash) via crafted EXIF data in a JPEG image.",
+            "summary": "The exif_process_unicode function in ext\/exif\/exif.c in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized pointer free and application crash) via crafted EXIF data in a JPEG image. \n Publish Date : 2015-01-27 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4917,7 +4917,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-0273",
-            "summary": "Multiple use-after-free vulnerabilities in ext\/date\/php_date.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allow remote attackers to execute arbitrary code via crafted serialized input containing a (1) R or (2) r type specifier in (a) DateTimeZone data handled by the php_date_timezone_initialize_from_hash function or (b) DateTime data handled by the php_date_initialize_from_hash function.",
+            "summary": "Multiple use-after-free vulnerabilities in ext\/date\/php_date.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allow remote attackers to execute arbitrary code via crafted serialized input containing a (1) R or (2) r type specifier in (a) DateTimeZone data handled by the php_date_timezone_initialize_from_hash function or (b) DateTime data handled by the php_date_initialize_from_hash function. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-23",
             "fixVersions": {
                 "base": [
                     "5.4.38",
@@ -4929,7 +4929,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-1351",
-            "summary": "Use-after-free vulnerability in the _zend_shared_memdup function in zend_shared_alloc.c in the OPcache extension in PHP through 5.6.7 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors.",
+            "summary": "Use-after-free vulnerability in the _zend_shared_memdup function in zend_shared_alloc.c in the OPcache extension in PHP through 5.6.7 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.5.24",
@@ -4940,7 +4940,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-1352",
-            "summary": "The build_tablename function in pgsql.c in the PostgreSQL (aka pgsql) extension in PHP through 5.6.7 does not validate token extraction for table names, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted name.",
+            "summary": "The build_tablename function in pgsql.c in the PostgreSQL (aka pgsql) extension in PHP through 5.6.7 does not validate token extraction for table names, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted name. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4952,7 +4952,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-2301",
-            "summary": "Use-after-free vulnerability in the phar_rename_archive function in phar_object.c in PHP before 5.5.22 and 5.6.x before 5.6.6 allows remote attackers to cause a denial of service or possibly have unspecified other impact via vectors that trigger an attempted renaming of a Phar archive to the name of an existing file.",
+            "summary": "Use-after-free vulnerability in the phar_rename_archive function in phar_object.c in PHP before 5.5.22 and 5.6.x before 5.6.6 allows remote attackers to cause a denial of service or possibly have unspecified other impact via vectors that trigger an attempted renaming of a Phar archive to the name of an existing file. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4976,7 +4976,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-2331",
-            "summary": "Integer overflow in the _zip_cdir_new function in zip_dirent.c in libzip 0.11.2 and earlier, as used in the ZIP extension in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 and other products, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a ZIP archive that contains many entries, leading to a heap-based buffer overflow.",
+            "summary": "Integer overflow in the _zip_cdir_new function in zip_dirent.c in libzip 0.11.2 and earlier, as used in the ZIP extension in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 and other products, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a ZIP archive that contains many entries, leading to a heap-based buffer overflow. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -4988,7 +4988,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-2348",
-            "summary": "The move_uploaded_file implementation in ext\/standard\/basic_functions.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 truncates a pathname upon encountering a \\x00 character, which allows remote attackers to bypass intended extension restrictions and create files with unexpected names via a crafted second argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
+            "summary": "The move_uploaded_file implementation in ext\/standard\/basic_functions.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 truncates a pathname upon encountering a \\x00 character, which allows remote attackers to bypass intended extension restrictions and create files with unexpected names via a crafted second argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5000,7 +5000,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2015-2783",
-            "summary": "ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (buffer over-read and application crash) via a crafted length value in conjunction with crafted serialized data in a phar archive, related to the phar_parse_metadata and phar_parse_pharfile functions.",
+            "summary": "ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (buffer over-read and application crash) via a crafted length value in conjunction with crafted serialized data in a phar archive, related to the phar_parse_metadata and phar_parse_pharfile functions. \n Publish Date : 2015-06-09 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5012,7 +5012,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-2787",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages use of the unset function within an __wakeup function, a related issue to CVE-2015-0231.",
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages use of the unset function within an __wakeup function, a related issue to CVE-2015-0231. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5024,7 +5024,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-3307",
-            "summary": "The phar_parse_metadata function in ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (heap metadata corruption) or possibly have unspecified other impact via a crafted tar archive.",
+            "summary": "The phar_parse_metadata function in ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (heap metadata corruption) or possibly have unspecified other impact via a crafted tar archive. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5036,7 +5036,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-3329",
-            "summary": "Multiple stack-based buffer overflows in the phar_set_inode function in phar_internal.h in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allow remote attackers to execute arbitrary code via a crafted length value in a (1) tar, (2) phar, or (3) ZIP archive.",
+            "summary": "Multiple stack-based buffer overflows in the phar_set_inode function in phar_internal.h in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allow remote attackers to execute arbitrary code via a crafted length value in a (1) tar, (2) phar, or (3) ZIP archive. \n Publish Date : 2015-06-09 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5048,7 +5048,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2015-3330",
-            "summary": "The php_handler function in sapi\/apache2handler\/sapi_apache2.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, when the Apache HTTP Server 2.4.x is used, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via pipelined HTTP requests that result in a \"deconfigured interpreter.\"",
+            "summary": "The php_handler function in sapi\/apache2handler\/sapi_apache2.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, when the Apache HTTP Server 2.4.x is used, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via pipelined HTTP requests that result in a \"deconfigured interpreter.\" \n Publish Date : 2015-06-09 Last Update Date : 2015-10-09",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5060,7 +5060,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-4021",
-            "summary": "The phar_parse_tarfile function in ext\/phar\/tar.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 does not verify that the first character of a filename is different from the \\0 character, which allows remote attackers to cause a denial of service (integer underflow and memory corruption) via a crafted entry in a tar archive.",
+            "summary": "The phar_parse_tarfile function in ext\/phar\/tar.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 does not verify that the first character of a filename is different from the \\0 character, which allows remote attackers to cause a denial of service (integer underflow and memory corruption) via a crafted entry in a tar archive. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5072,7 +5072,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-4022",
-            "summary": "Integer overflow in the ftp_genlist function in ext\/ftp\/ftp.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote FTP servers to execute arbitrary code via a long reply to a LIST command, leading to a heap-based buffer overflow.",
+            "summary": "Integer overflow in the ftp_genlist function in ext\/ftp\/ftp.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote FTP servers to execute arbitrary code via a long reply to a LIST command, leading to a heap-based buffer overflow. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5084,7 +5084,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-4024",
-            "summary": "Algorithmic complexity vulnerability in the multipart_buffer_headers function in main\/rfc1867.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote attackers to cause a denial of service (CPU consumption) via crafted form data that triggers an improper order-of-growth outcome.",
+            "summary": "Algorithmic complexity vulnerability in the multipart_buffer_headers function in main\/rfc1867.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote attackers to cause a denial of service (CPU consumption) via crafted form data that triggers an improper order-of-growth outcome. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5096,7 +5096,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-4025",
-            "summary": "PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character in certain situations, which allows remote attackers to bypass intended extension restrictions and access files or directories with unexpected names via a crafted argument to (1) set_include_path, (2) tempnam, (3) rmdir, or (4) readlink.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
+            "summary": "PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character in certain situations, which allows remote attackers to bypass intended extension restrictions and access files or directories with unexpected names via a crafted argument to (1) set_include_path, (2) tempnam, (3) rmdir, or (4) readlink.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5108,7 +5108,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-4026",
-            "summary": "The pcntl_exec implementation in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character, which might allow remote attackers to bypass intended extension restrictions and execute files with unexpected names via a crafted first argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
+            "summary": "The pcntl_exec implementation in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character, which might allow remote attackers to bypass intended extension restrictions and execute files with unexpected names via a crafted first argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243. \n Publish Date : 2015-06-09 Last Update Date : 2015-09-03",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5120,7 +5120,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-4147",
-            "summary": "The SoapClient::__call method in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that __default_headers is an array, which allows remote attackers to execute arbitrary code by providing crafted serialized data with an unexpected data type, related to a \"type confusion\" issue.",
+            "summary": "The SoapClient::__call method in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that __default_headers is an array, which allows remote attackers to execute arbitrary code by providing crafted serialized data with an unexpected data type, related to a \"type confusion\" issue. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5132,7 +5132,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-4148",
-            "summary": "The do_soap_call function in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that the uri property is a string, which allows remote attackers to obtain sensitive information by providing crafted serialized data with an int data type, related to a \"type confusion\" issue.",
+            "summary": "The do_soap_call function in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that the uri property is a string, which allows remote attackers to obtain sensitive information by providing crafted serialized data with an int data type, related to a \"type confusion\" issue. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5144,7 +5144,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-5590",
-            "summary": "Stack-based buffer overflow in the phar_fix_filepath function in ext\/phar\/phar.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large length value, as demonstrated by mishandling of an e-mail attachment by the imap PHP extension.",
+            "summary": "Stack-based buffer overflow in the phar_fix_filepath function in ext\/phar\/phar.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large length value, as demonstrated by mishandling of an e-mail attachment by the imap PHP extension. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-22",
             "fixVersions": {
                 "base": [
                     "5.4.43",
@@ -5156,7 +5156,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-6527",
-            "summary": "The php_str_replace_in_subject function in ext\/standard\/string.c in PHP 7.x before 7.0.0 allows remote attackers to execute arbitrary code via a crafted value in the third argument to the str_ireplace function.",
+            "summary": "The php_str_replace_in_subject function in ext\/standard\/string.c in PHP 7.x before 7.0.0 allows remote attackers to execute arbitrary code via a crafted value in the third argument to the str_ireplace function. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-21",
             "fixVersions": {
                 "base": [
                     "7.0.1"
@@ -5166,7 +5166,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-6831",
-            "summary": "Multiple use-after-free vulnerabilities in SPL in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allow remote attackers to execute arbitrary code via vectors involving (1) ArrayObject, (2) SplObjectStorage, and (3) SplDoublyLinkedList, which are mishandled during unserialization.",
+            "summary": "Multiple use-after-free vulnerabilities in SPL in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allow remote attackers to execute arbitrary code via vectors involving (1) ArrayObject, (2) SplObjectStorage, and (3) SplDoublyLinkedList, which are mishandled during unserialization. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-22",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5178,7 +5178,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-6832",
-            "summary": "Use-after-free vulnerability in the SPL unserialize implementation in ext\/spl\/spl_array.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to execute arbitrary code via crafted serialized data that triggers misuse of an array field.",
+            "summary": "Use-after-free vulnerability in the SPL unserialize implementation in ext\/spl\/spl_array.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to execute arbitrary code via crafted serialized data that triggers misuse of an array field. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-22",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5190,7 +5190,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-6833",
-            "summary": "Directory traversal vulnerability in the PharData class in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to write to arbitrary files via a .. (dot dot) in a ZIP archive entry that is mishandled during an extractTo call.",
+            "summary": "Directory traversal vulnerability in the PharData class in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to write to arbitrary files via a .. (dot dot) in a ZIP archive entry that is mishandled during an extractTo call. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-22",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5202,7 +5202,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-6836",
-            "summary": "The SoapClient __call method in ext\/soap\/soap.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 does not properly manage headers, which allows remote attackers to execute arbitrary code via crafted serialized data that triggers a \"type confusion\" in the serialize_function_call function.",
+            "summary": "The SoapClient __call method in ext\/soap\/soap.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 does not properly manage headers, which allows remote attackers to execute arbitrary code via crafted serialized data that triggers a \"type confusion\" in the serialize_function_call function. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-22",
             "fixVersions": {
                 "base": [
                     "5.4.45",
@@ -5214,7 +5214,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2015-7803",
-            "summary": "The phar_get_entry_data function in ext\/phar\/util.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a .phar file with a crafted TAR archive entry in which the Link indicator references a file that does not exist.",
+            "summary": "The phar_get_entry_data function in ext\/phar\/util.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a .phar file with a crafted TAR archive entry in which the Link indicator references a file that does not exist. \n Publish Date : 2015-12-11 Last Update Date : 2015-12-18",
             "fixVersions": {
                 "base": [
                     "5.5.30",
@@ -5225,7 +5225,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2015-7804",
-            "summary": "Off-by-one error in the phar_parse_zipfile function in ext\/phar\/zip.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (uninitialized pointer dereference and application crash) by including the \/ filename in a .zip PHAR archive.",
+            "summary": "Off-by-one error in the phar_parse_zipfile function in ext\/phar\/zip.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (uninitialized pointer dereference and application crash) by including the \/ filename in a .zip PHAR archive. \n Publish Date : 2015-12-11 Last Update Date : 2015-12-18",
             "fixVersions": {
                 "base": [
                     "5.5.30",
@@ -5236,7 +5236,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-8616",
-            "summary": "Use-after-free vulnerability in the Collator::sortWithSortKeys function in ext\/intl\/collator\/collator_sort.c in PHP 7.x before 7.0.1 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact by leveraging the relationships between a key buffer and a destroyed array.",
+            "summary": "Use-after-free vulnerability in the Collator::sortWithSortKeys function in ext\/intl\/collator\/collator_sort.c in PHP 7.x before 7.0.1 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact by leveraging the relationships between a key buffer and a destroyed array. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-21",
             "fixVersions": {
                 "base": [
                     "7.0.1"
@@ -5246,7 +5246,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2015-8617",
-            "summary": "Format string vulnerability in the zend_throw_or_error function in Zend\/zend_execute_API.c in PHP 7.x before 7.0.1 allows remote attackers to execute arbitrary code via format string specifiers in a string that is misused as a class name, leading to incorrect error handling.",
+            "summary": "Format string vulnerability in the zend_throw_or_error function in Zend\/zend_execute_API.c in PHP 7.x before 7.0.1 allows remote attackers to execute arbitrary code via format string specifiers in a string that is misused as a class name, leading to incorrect error handling. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-21",
             "fixVersions": {
                 "base": [
                     "7.0.2"
@@ -5256,7 +5256,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2016-1903",
-            "summary": "The gdImageRotateInterpolated function in ext\/gd\/libgd\/gd_interpolation.c in PHP before 5.5.31, 5.6.x before 5.6.17, and 7.x before 7.0.2 allows remote attackers to obtain sensitive information or cause a denial of service (out-of-bounds read and application crash) via a large bgd_color argument to the imagerotate function.",
+            "summary": "The gdImageRotateInterpolated function in ext\/gd\/libgd\/gd_interpolation.c in PHP before 5.5.31, 5.6.x before 5.6.17, and 7.x before 7.0.2 allows remote attackers to obtain sensitive information or cause a denial of service (out-of-bounds read and application crash) via a large bgd_color argument to the imagerotate function. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-22",
             "fixVersions": {
                 "base": [
                     "5.5.31",
@@ -5268,7 +5268,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2016-1904",
-            "summary": "Multiple integer overflows in ext\/standard\/exec.c in PHP 7.x before 7.0.2 allow remote attackers to cause a denial of service or possibly have unspecified other impact via a long string to the (1) php_escape_shell_cmd or (2) php_escape_shell_arg function, leading to a heap-based buffer overflow.",
+            "summary": "Multiple integer overflows in ext\/standard\/exec.c in PHP 7.x before 7.0.2 allow remote attackers to cause a denial of service or possibly have unspecified other impact via a long string to the (1) php_escape_shell_cmd or (2) php_escape_shell_arg function, leading to a heap-based buffer overflow. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-21",
             "fixVersions": {
                 "base": [
                     "7.0.2"

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -3908,7 +3908,7 @@
             }
         },
         {
-            "threat": "6.4",
+            "threat": "7.5",
             "cveid": "CVE-2014-8142",
             "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019.",
             "fixVersions": {
@@ -3943,7 +3943,7 @@
             }
         },
         {
-            "threat": "6.4",
+            "threat": "7.5",
             "cveid": "CVE-2014-9427",
             "summary": "sapi\/cgi\/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping.",
             "fixVersions": {

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -23,7 +23,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2001-0108",
-            "summary": "PHP Apache module 4.0.4 and earlier allows remote attackers to bypass .htaccess access restrictions via a malformed HTTP request on an unrestricted page that causes PHP to use those access controls on the next page that is requested. \nPublish Date : 2001-03-12 Last Update Date : 2008-09-10",
+            "summary": "PHP Apache module 4.0.4 and earlier allows remote attackers to bypass .htaccess access restrictions via a malformed HTTP request on an unrestricted page that causes PHP to use those access controls on the next page that is requested.",
             "fixVersions": {
                 "base": [
                     "4.0.5"
@@ -33,7 +33,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2001-1246",
-            "summary": "PHP 4.0.5 through 4.1.0 in safe mode does not properly cleanse the 5th parameter to the mail() function, which allows local users and possibly remote attackers to execute arbitrary commands via shell metacharacters. \nPublish Date : 2001-06-30 Last Update Date : 2008-09-10",
+            "summary": "PHP 4.0.5 through 4.1.0 in safe mode does not properly cleanse the 5th parameter to the mail() function, which allows local users and possibly remote attackers to execute arbitrary commands via shell metacharacters.",
             "fixVersions": {
                 "base": [
                     "4.0.6"
@@ -43,7 +43,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2001-1247",
-            "summary": "PHP 4.0.4pl1 and 4.0.5 in safe mode allows remote attackers to read and write files owned by the web server UID by uploading a PHP script that uses the error_log function to access the files. \nPublish Date : 2001-12-06 Last Update Date : 2012-06-25",
+            "summary": "PHP 4.0.4pl1 and 4.0.5 in safe mode allows remote attackers to read and write files owned by the web server UID by uploading a PHP script that uses the error_log function to access the files.",
             "fixVersions": {
                 "base": [
                     "4.0.6"
@@ -53,7 +53,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2001-1385",
-            "summary": "The Apache module for PHP 4.0.0 through PHP 4.0.4, when disabled with the 'engine = off' option for a virtual host, may disable PHP for other virtual hosts, which could cause Apache to serve the source code of PHP scripts. \nPublish Date : 2001-01-12 Last Update Date : 2008-09-10",
+            "summary": "The Apache module for PHP 4.0.0 through PHP 4.0.4, when disabled with the 'engine = off' option for a virtual host, may disable PHP for other virtual hosts, which could cause Apache to serve the source code of PHP scripts.",
             "fixVersions": {
                 "base": [
                     "4.0.5"
@@ -63,7 +63,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0081",
-            "summary": "Buffer overflows in (1) php_mime_split in PHP 4.1.0, 4.1.1, and 4.0.6 and earlier, and (2) php3_mime_split in PHP 3.0.x allows remote attackers to execute arbitrary code via a multipart/form-data HTTP POST request when file_uploads is enabled. \nPublish Date : 2002-03-08 Last Update Date : 2008-09-05",
+            "summary": "Buffer overflows in (1) php_mime_split in PHP 4.1.0, 4.1.1, and 4.0.6 and earlier, and (2) php3_mime_split in PHP 3.0.x allows remote attackers to execute arbitrary code via a multipart\/form-data HTTP POST request when file_uploads is enabled.",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -74,7 +74,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2002-0121",
-            "summary": "PHP 4.0 through 4.1.1 stores session IDs in temporary files whose name contains the session ID, which allows local users to hijack web connections. \nPublish Date : 2002-03-25 Last Update Date : 2008-09-10",
+            "summary": "PHP 4.0 through 4.1.1 stores session IDs in temporary files whose name contains the session ID, which allows local users to hijack web connections.",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -85,7 +85,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0229",
-            "summary": "Safe Mode feature (safe_mode) in PHP 3.0 through 4.1.0 allows attackers with access to the MySQL database to bypass Safe Mode access restrictions and read arbitrary files using \"LOAD DATA INFILE LOCAL\" SQL statements. \nPublish Date : 2002-05-16 Last Update Date : 2008-09-10",
+            "summary": "Safe Mode feature (safe_mode) in PHP 3.0 through 4.1.0 allows attackers with access to the MySQL database to bypass Safe Mode access restrictions and read arbitrary files using \"LOAD DATA INFILE LOCAL\" SQL statements.",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -96,7 +96,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-0253",
-            "summary": "PHP, when not configured with the \"display_errors = Off\" setting in php.ini, allows remote attackers to obtain the physical path for an include file via a trailing slash in a request to a directly accessible PHP program, which modifies the base path, causes the include directive to fail, and produces an error message that contains the path. \nPublish Date : 2002-05-29 Last Update Date : 2008-09-10",
+            "summary": "PHP, when not configured with the \"display_errors = Off\" setting in php.ini, allows remote attackers to obtain the physical path for an include file via a trailing slash in a request to a directly accessible PHP program, which modifies the base path, causes the include directive to fail, and produces an error message that contains the path.",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -107,7 +107,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-0484",
-            "summary": "move_uploaded_file in PHP does not does not check for the base directory (open_basedir), which could allow remote attackers to upload files to unintended locations on the system. \nPublish Date : 2002-08-12 Last Update Date : 2008-09-05",
+            "summary": "move_uploaded_file in PHP does not does not check for the base directory (open_basedir), which could allow remote attackers to upload files to unintended locations on the system.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -118,7 +118,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0717",
-            "summary": "PHP 4.2.0 and 4.2.1 allows remote attackers to cause a denial of service and possibly execute arbitrary code via an HTTP POST request with certain arguments in a multipart/form-data form, which generates an error condition that is not properly handled and causes improper memory to be freed. \nPublish Date : 2002-07-26 Last Update Date : 2008-09-05",
+            "summary": "PHP 4.2.0 and 4.2.1 allows remote attackers to cause a denial of service and possibly execute arbitrary code via an HTTP POST request with certain arguments in a multipart\/form-data form, which generates an error condition that is not properly handled and causes improper memory to be freed.",
             "fixVersions": {
                 "base": [
                     "4.2.2"
@@ -128,7 +128,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-0985",
-            "summary": "Argument injection vulnerability in the mail function for PHP 4.x to 4.2.2 may allow attackers to bypass safe mode restrictions and modify command line arguments to the MTA (e.g. sendmail) in the 5th argument to mail(), altering MTA behavior and possibly executing commands. \nPublish Date : 2002-09-24 Last Update Date : 2008-09-05",
+            "summary": "Argument injection vulnerability in the mail function for PHP 4.x to 4.2.2 may allow attackers to bypass safe mode restrictions and modify command line arguments to the MTA (e.g. sendmail) in the 5th argument to mail(), altering MTA behavior and possibly executing commands.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -140,7 +140,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-0986",
-            "summary": "The mail function in PHP 4.x to 4.2.2 does not filter ASCII control characters from its arguments, which could allow remote attackers to modify mail message content, including mail headers, and possibly use PHP as a \"spam proxy.\" \nPublish Date : 2002-09-24 Last Update Date : 2008-09-05",
+            "summary": "The mail function in PHP 4.x to 4.2.2 does not filter ASCII control characters from its arguments, which could allow remote attackers to modify mail message content, including mail headers, and possibly use PHP as a \"spam proxy.\"",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -152,7 +152,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2002-1396",
-            "summary": "Heap-based buffer overflow in the wordwrap function in PHP after 4.1.2 and before 4.3.0 may allow attackers to cause a denial of service or execute arbitrary code. \nPublish Date : 2003-01-17 Last Update Date : 2008-09-05",
+            "summary": "Heap-based buffer overflow in the wordwrap function in PHP after 4.1.2 and before 4.3.0 may allow attackers to cause a denial of service or execute arbitrary code.",
             "fixVersions": {
                 "base": [
                     "4.1.3",
@@ -163,7 +163,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-1783",
-            "summary": "CRLF injection vulnerability in PHP 4.2.1 through 4.2.3, when allow_url_fopen is enabled, allows remote attackers to modify HTTP headers for outgoing requests by causing CRLF sequences to be injected into arguments that are passed to the (1) fopen or (2) file functions. \nPublish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "summary": "CRLF injection vulnerability in PHP 4.2.1 through 4.2.3, when allow_url_fopen is enabled, allows remote attackers to modify HTTP headers for outgoing requests by causing CRLF sequences to be injected into arguments that are passed to the (1) fopen or (2) file functions.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -175,7 +175,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2002-1954",
-            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.2.3 allows remote attackers to inject arbitrary web script or HTML via the query string argument, as demonstrated using soinfo.php. \nPublish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.2.3 allows remote attackers to inject arbitrary web script or HTML via the query string argument, as demonstrated using soinfo.php.",
             "fixVersions": {
                 "base": [
                     "4.2.4"
@@ -185,7 +185,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-2214",
-            "summary": "The php_if_imap_mime_header_decode function in the IMAP functionality in PHP before 4.2.2 allows remote attackers to cause a denial of service (crash) via an e-mail header with a long \"To\" header. \nPublish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "summary": "The php_if_imap_mime_header_decode function in the IMAP functionality in PHP before 4.2.2 allows remote attackers to cause a denial of service (crash) via an e-mail header with a long \"To\" header.",
             "fixVersions": {
                 "base": [
                     "4.2.2"
@@ -195,7 +195,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2002-2215",
-            "summary": "The imap_header function in the IMAP functionality for PHP before 4.3.0 allows remote attackers to cause a denial of service via an e-mail message with a large number of \"To\" addresses, which triggers an error in the rfc822_write_address function. \nPublish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "summary": "The imap_header function in the IMAP functionality for PHP before 4.3.0 allows remote attackers to cause a denial of service via an e-mail message with a large number of \"To\" addresses, which triggers an error in the rfc822_write_address function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -207,7 +207,7 @@
         {
             "threat": "7.8",
             "cveid": "CVE-2002-2309",
-            "summary": "php.exe in PHP 3.0 through 4.2.2, when running on Apache, does not terminate properly, which allows remote attackers to cause a denial of service via a direct request without arguments. \nPublish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "summary": "php.exe in PHP 3.0 through 4.2.2, when running on Apache, does not terminate properly, which allows remote attackers to cause a denial of service via a direct request without arguments.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -229,7 +229,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0166",
-            "summary": "Integer signedness error in emalloc() function for PHP before 4.3.2 allow remote attackers to cause a denial of service (memory consumption) and possibly execute arbitrary code via negative arguments to functions such as (1) socket_recv, (2) socket_recvfrom, and possibly other functions. \nPublish Date : 2003-04-02 Last Update Date : 2008-09-10",
+            "summary": "Integer signedness error in emalloc() function for PHP before 4.3.2 allow remote attackers to cause a denial of service (memory consumption) and possibly execute arbitrary code via negative arguments to functions such as (1) socket_recv, (2) socket_recvfrom, and possibly other functions.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -242,7 +242,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0172",
-            "summary": "Buffer overflow in openlog function for PHP 4.3.1 on Windows operating system, and possibly other OSes, allows remote attackers to cause a crash and possibly execute arbitrary code via a long filename argument. \nPublish Date : 2003-04-02 Last Update Date : 2008-09-05",
+            "summary": "Buffer overflow in openlog function for PHP 4.3.1 on Windows operating system, and possibly other OSes, allows remote attackers to cause a crash and possibly execute arbitrary code via a long filename argument.",
             "fixVersions": {
                 "base": [
                     "4.3.2"
@@ -252,7 +252,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0249",
-            "summary": "** DISPUTED ** PHP treats unknown methods such as \"PoSt\" as a GET request, which could allow attackers to intended access restrictions if PHP is running on a server that passes on all methods, such as Apache httpd 2.0, as demonstrated using a Limit directive. NOTE: this issue has been disputed by the Apache security team, saying \"It is by design that PHP allows scripts to process any request method. A script which does not explicitly verify the request method will hence be processed as normal for arbitrary methods. It is therefore expected behaviour that one cannot implement per-method access control using the Apache configuration alone, which is the assumption made in this report.\" \nPublish Date : 2003-12-31 Last Update Date : 2008-09-05",
+            "summary": "** DISPUTED **  PHP treats unknown methods such as \"PoSt\" as a GET request, which could allow attackers to intended access restrictions if PHP is running on a server that passes on all methods, such as Apache httpd 2.0, as demonstrated using a Limit directive.  NOTE: this issue has been disputed by the Apache security team, saying \"It is by design that PHP allows scripts to process any request method.  A script which does not explicitly verify the request method will hence be processed as normal for arbitrary methods.  It is therefore expected behaviour that one cannot implement per-method access control using the Apache configuration alone, which is the assumption made in this report.\"",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -262,7 +262,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2003-0442",
-            "summary": "Cross-site scripting (XSS) vulnerability in the transparent SID support capability for PHP before 4.3.2 (session.use_trans_sid) allows remote attackers to insert arbitrary script via the PHPSESSID parameter. \nPublish Date : 2003-07-24 Last Update Date : 2008-09-10",
+            "summary": "Cross-site scripting (XSS) vulnerability in the transparent SID support capability for PHP before 4.3.2 (session.use_trans_sid) allows remote attackers to insert arbitrary script via the PHPSESSID parameter.",
             "fixVersions": {
                 "base": [
                     "4.3.2"
@@ -272,7 +272,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2003-0860",
-            "summary": "Buffer overflows in PHP before 4.3.3 have unknown impact and unknown attack vectors. \nPublish Date : 2003-11-17 Last Update Date : 2008-09-05",
+            "summary": "Buffer overflows in PHP before 4.3.3 have unknown impact and unknown attack vectors.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -285,7 +285,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2003-0861",
-            "summary": "Integer overflows in (1) base64_encode and (2) the GD library for PHP before 4.3.3 have unknown impact and unknown attack vectors. \nPublish Date : 2003-11-17 Last Update Date : 2008-09-10",
+            "summary": "Integer overflows in (1) base64_encode and (2) the GD library for PHP before 4.3.3 have unknown impact and unknown attack vectors.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -298,7 +298,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2003-0863",
-            "summary": "The php_check_safe_mode_include_dir function in fopen_wrappers.c of PHP 4.3.x returns a success value (0) when the safe_mode_include_dir variable is not specified in configuration, which differs from the previous failure value and may allow remote attackers to exploit file include vulnerabilities in PHP applications. \nPublish Date : 2003-11-17 Last Update Date : 2008-09-10",
+            "summary": "The php_check_safe_mode_include_dir function in fopen_wrappers.c of PHP 4.3.x returns a success value (0) when the safe_mode_include_dir variable is not specified in configuration, which differs from the previous failure value and may allow remote attackers to exploit file include vulnerabilities in PHP applications.",
             "fixVersions": {
                 "base": [
                     "4.3.3"
@@ -308,7 +308,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2003-1302",
-            "summary": "The IMAP functionality in PHP before 4.3.1 allows remote attackers to cause a denial of service via an e-mail message with a (1) To or (2) From header with an address that contains a large number of \"\\\" (backslash) characters. \nPublish Date : 2003-12-31 Last Update Date : 2008-09-05",
+            "summary": "The IMAP functionality in PHP before 4.3.1 allows remote attackers to cause a denial of service via an e-mail message with a (1) To or (2) From header with an address that contains a large number of \"\\\" (backslash) characters.",
             "fixVersions": {
                 "base": [
                     "4.2.4",
@@ -319,7 +319,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2003-1303",
-            "summary": "Buffer overflow in the imap_fetch_overview function in the IMAP functionality (php_imap.c) in PHP before 4.3.3 allows remote attackers to cause a denial of service (segmentation fault) and possibly execute arbitrary code via a long e-mail address in a (1) To or (2) From header. \nPublish Date : 2003-12-31 Last Update Date : 2010-08-21",
+            "summary": "Buffer overflow in the imap_fetch_overview function in the IMAP functionality (php_imap.c) in PHP before 4.3.3 allows remote attackers to cause a denial of service (segmentation fault) and possibly execute arbitrary code via a long e-mail address in a (1) To or (2) From header.",
             "fixVersions": {
                 "base": [
                     "4.3.3"
@@ -329,7 +329,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2004-0542",
-            "summary": "PHP before 4.3.7 on Win32 platforms does not properly filter all shell metacharacters, which allows local or remote attackers to execute arbitrary code, overwrite files, and access internal environment variables via (1) the \"%\", \"|\", or \">\" characters to the escapeshellcmd function, or (2) the \"%\" character to the escapeshellarg function. \nPublish Date : 2004-08-06 Last Update Date : 2008-09-05",
+            "summary": "PHP before 4.3.7 on Win32 platforms does not properly filter all shell metacharacters, which allows local or remote attackers to execute arbitrary code, overwrite files, and access internal environment variables via (1) the \"%\", \"|\", or \">\" characters to the escapeshellcmd function, or (2) the \"%\" character to the escapeshellarg function.",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -367,7 +367,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2004-0958",
-            "summary": "php_variables.c in PHP before 5.0.2 allows remote attackers to read sensitive memory contents via (1) GET, (2) POST, or (3) COOKIE GPC variables that end in an open bracket character, which causes PHP to calculate an incorrect string length. \nPublish Date : 2004-11-03 Last Update Date : 2010-08-21",
+            "summary": "php_variables.c in PHP before 5.0.2 allows remote attackers to read sensitive memory contents via (1) GET, (2) POST, or (3) COOKIE GPC variables that end in an open bracket character, which causes PHP to calculate an incorrect string length.",
             "fixVersions": {
                 "base": [
                     "5.0.3"
@@ -377,7 +377,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2004-0959",
-            "summary": "rfc1867.c in PHP before 5.0.2 allows local users to upload files to arbitrary locations via a PHP script with a certain MIME header that causes the \"$_FILES\" array to be modified. \nPublish Date : 2004-11-03 Last Update Date : 2013-09-11",
+            "summary": "rfc1867.c in PHP before 5.0.2 allows local users to upload files to arbitrary locations via a PHP script with a certain MIME header that causes the \"$_FILES\" array to be modified.",
             "fixVersions": {
                 "base": [
                     "5.0.3"
@@ -401,7 +401,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2004-1020",
-            "summary": "The addslashes function in PHP 4.3.9 does not properly escape a NULL (/0) character, which may allow remote attackers to read arbitrary files in PHP applications that contain a directory traversal vulnerability in require or include statements, but are otherwise protected by the magic_quotes_gpc mechanism. NOTE: this issue was originally REJECTed by its CNA before publication, but that decision is in active dispute. This candidate may change significantly in the future as a result of further discussion. \nPublish Date : 2005-01-10 Last Update Date : 2008-09-10",
+            "summary": "The addslashes function in PHP 4.3.9 does not properly escape a NULL (\/0) character, which may allow remote attackers to read arbitrary files in PHP applications that contain a directory traversal vulnerability in require or include statements, but are otherwise protected by the magic_quotes_gpc mechanism.  NOTE: this issue was originally REJECTed by its CNA before publication, but that decision is in active dispute.  This candidate may change significantly in the future as a result of further discussion.",
             "fixVersions": {
                 "base": [
                     "4.3.10",
@@ -426,7 +426,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2004-1392",
-            "summary": "PHP 4.0 with cURL functions allows remote attackers to bypass the open_basedir setting and read arbitrary files via a file: URL argument to the curl_init function. \nPublish Date : 2004-12-31 Last Update Date : 2010-08-21",
+            "summary": "PHP 4.0 with cURL functions allows remote attackers to bypass the open_basedir setting and read arbitrary files via a file: URL argument to the curl_init function.",
             "fixVersions": {
                 "base": [
                     "4.0.8"
@@ -436,7 +436,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-0524",
-            "summary": "The php_handle_iff function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a -8 size value. \nPublish Date : 2005-05-02 Last Update Date : 2010-08-21",
+            "summary": "The php_handle_iff function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a -8 size value.",
             "fixVersions": {
                 "base": [
                     "4.2.3",
@@ -448,7 +448,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-0525",
-            "summary": "The php_next_marker function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a JPEG image with an invalid marker value, which causes a negative length value to be passed to php_stream_seek. \nPublish Date : 2005-05-02 Last Update Date : 2010-08-21",
+            "summary": "The php_next_marker function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a JPEG image with an invalid marker value, which causes a negative length value to be passed to php_stream_seek.",
             "fixVersions": {
                 "base": [
                     "4.2.3",
@@ -470,7 +470,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-1042",
-            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in PHP before 4.3.11 may allow remote attackers to execute arbitrary code via an IFD tag that leads to a negative byte count. \nPublish Date : 2005-05-02 Last Update Date : 2010-08-21",
+            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in PHP before 4.3.11 may allow remote attackers to execute arbitrary code via an IFD tag that leads to a negative byte count.",
             "fixVersions": {
                 "base": [
                     "4.3.11"
@@ -490,7 +490,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2005-3054",
-            "summary": "fopen_wrappers.c in PHP 4.4.0, and possibly other versions, does not properly restrict access to other directories when the open_basedir directive includes a trailing slash, which allows PHP scripts in one directory to access files in other directories whose names are substrings of the original directory. \nPublish Date : 2005-09-26 Last Update Date : 2010-04-02",
+            "summary": "fopen_wrappers.c in PHP 4.4.0, and possibly other versions, does not properly restrict access to other directories when the open_basedir directive includes a trailing slash, which allows PHP scripts in one directory to access files in other directories whose names are substrings of the original directory.",
             "fixVersions": {
                 "base": [
                     "4.4.1"
@@ -500,7 +500,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2005-3319",
-            "summary": "The apache2handler SAPI (sapi_apache2.c) in the Apache module (mod_php) for PHP 5.x before 5.1.0 final and 4.4 before 4.4.1 final allows attackers to cause a denial of service (segmentation fault) via the session.save_path option in a .htaccess file or VirtualHost. \nPublish Date : 2005-10-27 Last Update Date : 2010-04-02",
+            "summary": "The apache2handler SAPI (sapi_apache2.c) in the Apache module (mod_php) for PHP 5.x before 5.1.0 final and 4.4 before 4.4.1 final allows attackers to cause a denial of service (segmentation fault) via the session.save_path option in a .htaccess file or VirtualHost.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -515,7 +515,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-3353",
-            "summary": "The exif_read_data function in the Exif module in PHP before 4.4.1 allows remote attackers to cause a denial of service (infinite loop) via a malformed JPEG image. \nPublish Date : 2005-11-18 Last Update Date : 2010-08-21",
+            "summary": "The exif_read_data function in the Exif module in PHP before 4.4.1 allows remote attackers to cause a denial of service (infinite loop) via a malformed JPEG image.",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -529,7 +529,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2005-3388",
-            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5 allows remote attackers to inject arbitrary web script or HTML via a crafted URL with a \"stacked array assignment.\" \nPublish Date : 2005-11-01 Last Update Date : 2010-08-21",
+            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5 allows remote attackers to inject arbitrary web script or HTML via a crafted URL with a \"stacked array assignment.\"",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -544,7 +544,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-3389",
-            "summary": "The parse_str function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when called with only one parameter, allows remote attackers to enable the register_globals directive via inputs that cause a request to be terminated due to the memory_limit setting, which causes PHP to set an internal flag that enables register_globals and allows attackers to exploit vulnerabilities in PHP applications that would otherwise be protected. \nPublish Date : 2005-11-01 Last Update Date : 2013-07-05",
+            "summary": "The parse_str function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when called with only one parameter, allows remote attackers to enable the register_globals directive via inputs that cause a request to be terminated due to the memory_limit setting, which causes PHP to set an internal flag that enables register_globals and allows attackers to exploit vulnerabilities in PHP applications that would otherwise be protected.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -559,7 +559,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-3390",
-            "summary": "The RFC1867 file upload feature in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when register_globals is enabled, allows remote attackers to modify the GLOBALS array and bypass security protections of PHP applications via a multipart/form-data POST request with a \"GLOBALS\" fileupload field. \nPublish Date : 2005-11-01 Last Update Date : 2010-08-21",
+            "summary": "The RFC1867 file upload feature in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when register_globals is enabled, allows remote attackers to modify the GLOBALS array and bypass security protections of PHP applications via a multipart\/form-data POST request with a \"GLOBALS\" fileupload field.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -574,7 +574,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-3391",
-            "summary": "Multiple vulnerabilities in PHP before 4.4.1 allow remote attackers to bypass safe_mode and open_basedir restrictions via unknown attack vectors in (1) ext/curl and (2) ext/gd. \nPublish Date : 2005-11-01 Last Update Date : 2008-09-05",
+            "summary": "Multiple vulnerabilities in PHP before 4.4.1 allow remote attackers to bypass safe_mode and open_basedir restrictions via unknown attack vectors in (1) ext\/curl and (2) ext\/gd.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -588,7 +588,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2005-3392",
-            "summary": "Unspecified vulnerability in PHP before 4.4.1, when using the virtual function on Apache 2, allows remote attackers to bypass safe_mode and open_basedir directives. \nPublish Date : 2005-11-01 Last Update Date : 2008-09-05",
+            "summary": "Unspecified vulnerability in PHP before 4.4.1, when using the virtual function on Apache 2, allows remote attackers to bypass safe_mode and open_basedir directives.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -602,7 +602,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2005-3883",
-            "summary": "CRLF injection vulnerability in the mb_send_mail function in PHP before 5.1.0 might allow remote attackers to inject arbitrary e-mail headers via line feeds (LF) in the \"To\" address argument. \nPublish Date : 2005-11-29 Last Update Date : 2013-08-18",
+            "summary": "CRLF injection vulnerability in the mb_send_mail function in PHP before 5.1.0 might allow remote attackers to inject arbitrary e-mail headers via line feeds (LF) in the \"To\" address argument.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -617,7 +617,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2006-0097",
-            "summary": "Stack-based buffer overflow in the create_named_pipe function in libmysql.c in PHP 4.3.10 and 4.4.x before 4.4.3 for Windows allows attackers to execute arbitrary code via a long (1) arg_host or (2) arg_unix_socket argument, as demonstrated by a long named pipe variable in the host argument to the mysql_connect function. \nPublish Date : 2006-01-06 Last Update Date : 2011-08-01",
+            "summary": "Stack-based buffer overflow in the create_named_pipe function in libmysql.c in PHP 4.3.10 and 4.4.x before 4.4.3 for Windows allows attackers to execute arbitrary code via a long (1) arg_host or (2) arg_unix_socket argument, as demonstrated by a long named pipe variable in the host argument to the mysql_connect function.",
             "fixVersions": {
                 "base": [
                     "4.3.11",
@@ -628,7 +628,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-0200",
-            "summary": "Format string vulnerability in the error-reporting feature in the mysqli extension in PHP 5.1.0 and 5.1.1 might allow remote attackers to execute arbitrary code via format string specifiers in MySQL error messages. \nPublish Date : 2006-01-13 Last Update Date : 2008-09-05",
+            "summary": "Format string vulnerability in the error-reporting feature in the mysqli extension in PHP 5.1.0 and 5.1.1 might allow remote attackers to execute arbitrary code via format string specifiers in MySQL error messages.",
             "fixVersions": {
                 "base": [
                     "5.1.2"
@@ -638,7 +638,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-0207",
-            "summary": "Multiple HTTP response splitting vulnerabilities in PHP 5.1.1 allow remote attackers to inject arbitrary HTTP headers via a crafted Set-Cookie header, related to the (1) session extension (aka ext/session) and the (2) header function. \nPublish Date : 2006-01-13 Last Update Date : 2011-09-09",
+            "summary": "Multiple HTTP response splitting vulnerabilities in PHP 5.1.1 allow remote attackers to inject arbitrary HTTP headers via a crafted Set-Cookie header, related to the (1) session extension (aka ext\/session) and the (2) header function.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -649,7 +649,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-0208",
-            "summary": "Multiple cross-site scripting (XSS) vulnerabilities in PHP 4.4.1 and 5.1.1, when display_errors and html_errors are on, allow remote attackers to inject arbitrary web script or HTML via inputs to PHP applications that are not filtered when they are included in the resulting error message. \nPublish Date : 2006-01-13 Last Update Date : 2011-09-13",
+            "summary": "Multiple cross-site scripting (XSS) vulnerabilities in PHP 4.4.1 and 5.1.1, when display_errors and html_errors are on, allow remote attackers to inject arbitrary web script or HTML via inputs to PHP applications that are not filtered when they are included in the resulting error message.",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -665,7 +665,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2006-0996",
-            "summary": "Cross-site scripting (XSS) vulnerability in phpinfo (info.c) in PHP 5.1.2 and 4.4.2 allows remote attackers to inject arbitrary web script or HTML via long array variables, including (1) a large number of dimensions or (2) long values, which prevents HTML tags from being removed. \nPublish Date : 2006-04-10 Last Update Date : 2010-08-21",
+            "summary": "Cross-site scripting (XSS) vulnerability in phpinfo (info.c) in PHP 5.1.2 and 4.4.2 allows remote attackers to inject arbitrary web script or HTML via long array variables, including (1) a large number of dimensions or (2) long values, which prevents HTML tags from being removed.",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -676,7 +676,7 @@
         {
             "threat": "3.2",
             "cveid": "CVE-2006-1014",
-            "summary": "Argument injection vulnerability in certain PHP 4.x and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mb_send_mail function, allows context-dependent attackers to read and create arbitrary files by providing extra -C and -X arguments to sendmail. NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE. \nPublish Date : 2006-03-06 Last Update Date : 2008-09-05",
+            "summary": "Argument injection vulnerability in certain PHP 4.x and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mb_send_mail function, allows context-dependent attackers to read and create arbitrary files by providing extra -C and -X arguments to sendmail.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE.",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -691,7 +691,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2006-1015",
-            "summary": "Argument injection vulnerability in certain PHP 3.x, 4.x, and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mail function, allows remote attackers to read and create arbitrary files via the sendmail -C and -X arguments. NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE. \nPublish Date : 2006-03-06 Last Update Date : 2008-09-05",
+            "summary": "Argument injection vulnerability in certain PHP 3.x, 4.x, and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mail function, allows remote attackers to read and create arbitrary files via the sendmail -C and -X arguments.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -707,7 +707,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-1017",
-            "summary": "The c-client library 2000, 2001, or 2004 for PHP before 4.4.4 and 5.x before 5.1.5 do not check the (1) safe_mode or (2) open_basedir functions, and when used in applications that accept user-controlled input for the mailbox argument to the imap_open function, allow remote attackers to obtain access to an IMAP stream data structure and conduct unauthorized IMAP actions. \nPublish Date : 2006-03-06 Last Update Date : 2011-07-14",
+            "summary": "The c-client library 2000, 2001, or 2004 for PHP before 4.4.4 and 5.x before 5.1.5 do not check the (1) safe_mode or (2) open_basedir functions, and when used in applications that accept user-controlled input for the mailbox argument to the imap_open function, allow remote attackers to obtain access to an IMAP stream data structure and conduct unauthorized IMAP actions.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -723,7 +723,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-1490",
-            "summary": "PHP before 5.1.3-RC1 might allow remote attackers to obtain portions of memory via crafted binary data sent to a script that processes user input in the html_entity_decode function and sends the encoded results back to the client, aka a \"binary safety\" issue. NOTE: this issue has been referred to as a \"memory leak,\" but it is an information leak that discloses memory contents. \nPublish Date : 2006-03-29 Last Update Date : 2010-08-21",
+            "summary": "PHP before 5.1.3-RC1 might allow remote attackers to obtain portions of memory via crafted binary data sent to a script that processes user input in the html_entity_decode function and sends the encoded results back to the client, aka a \"binary safety\" issue.  NOTE: this issue has been referred to as a \"memory leak,\" but it is an information leak that discloses memory contents.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -739,7 +739,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-1494",
-            "summary": "Directory traversal vulnerability in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass open_basedir restrictions allows remote attackers to create files in arbitrary directories via the tempnam function. \nPublish Date : 2006-04-10 Last Update Date : 2010-08-21",
+            "summary": "Directory traversal vulnerability in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass open_basedir restrictions allows remote attackers to create files in arbitrary directories via the tempnam function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -755,7 +755,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-1549",
-            "summary": "PHP 4.4.2 and 5.1.2 allows local users to cause a crash (segmentation fault) by defining and executing a recursive function. NOTE: it has been reported by a reliable third party that some later versions are also affected. \nPublish Date : 2006-04-10 Last Update Date : 2011-08-23",
+            "summary": "PHP 4.4.2 and 5.1.2 allows local users to cause a crash (segmentation fault) by defining and executing a recursive function.  NOTE: it has been reported by a reliable third party that some later versions are also affected.",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -766,7 +766,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-1608",
-            "summary": "The copy function in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass safe mode and read arbitrary files via a source argument containing a compress.zlib:// URI. \nPublish Date : 2006-04-10 Last Update Date : 2010-04-02",
+            "summary": "The copy function in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass safe mode and read arbitrary files via a source argument containing a compress.zlib:\/\/ URI.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -782,7 +782,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-1990",
-            "summary": "Integer overflow in the wordwrap function in string.c in PHP 4.4.2 and 5.1.2 might allow context-dependent attackers to execute arbitrary code via certain long arguments that cause a small buffer to be allocated, which triggers a heap-based buffer overflow in a memcpy function call, a different vulnerability than CVE-2002-1396. \nPublish Date : 2006-04-24 Last Update Date : 2010-08-21",
+            "summary": "Integer overflow in the wordwrap function in string.c in PHP 4.4.2 and 5.1.2 might allow context-dependent attackers to execute arbitrary code via certain long arguments that cause a small buffer to be allocated, which triggers a heap-based buffer overflow in a memcpy function call, a different vulnerability than CVE-2002-1396.",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -793,7 +793,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2006-1991",
-            "summary": "The substr_compare function in string.c in PHP 5.1.2 allows context-dependent attackers to cause a denial of service (memory access violation) via an out-of-bounds offset argument. \nPublish Date : 2006-04-24 Last Update Date : 2011-06-13",
+            "summary": "The substr_compare function in string.c in PHP 5.1.2 allows context-dependent attackers to cause a denial of service (memory access violation) via an out-of-bounds offset argument.",
             "fixVersions": {
                 "base": [
                     "5.1.3"
@@ -803,7 +803,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-2563",
-            "summary": "The cURL library (libcurl) in PHP 4.4.2 and 5.1.4 allows attackers to bypass safe mode and read files via a file:// request containing null characters. \nPublish Date : 2006-05-29 Last Update Date : 2010-04-02",
+            "summary": "The cURL library (libcurl) in PHP 4.4.2 and 5.1.4 allows attackers to bypass safe mode and read files via a file:\/\/ request containing null characters.",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -814,7 +814,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2006-2660",
-            "summary": "Buffer consumption vulnerability in the tempnam function in PHP 5.1.4 and 4.x before 4.4.3 allows local users to bypass restrictions and create PHP files with fixed names in other directories via a pathname argument longer than MAXPATHLEN, which prevents a unique string from being appended to the filename. \nPublish Date : 2006-06-13 Last Update Date : 2010-04-02",
+            "summary": "Buffer consumption vulnerability in the tempnam function in PHP 5.1.4 and 4.x before 4.4.3 allows local users to bypass restrictions and create PHP files with fixed names in other directories via a pathname argument longer than MAXPATHLEN, which prevents a unique string from being appended to the filename.",
             "fixVersions": {
                 "base": [
                     "4.0.6",
@@ -829,7 +829,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2006-3011",
-            "summary": "The error_log function in basic_functions.c in PHP before 4.4.4 and 5.x before 5.1.5 allows local users to bypass safe mode and open_basedir restrictions via a \"php://\" or other scheme in the third argument, which disables safe mode. \nPublish Date : 2006-06-26 Last Update Date : 2011-07-11",
+            "summary": "The error_log function in basic_functions.c in PHP before 4.4.4 and 5.x before 5.1.5 allows local users to bypass safe mode and open_basedir restrictions via a \"php:\/\/\" or other scheme in the third argument, which disables safe mode.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -861,7 +861,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2006-4020",
-            "summary": "scanf.c in PHP 5.1.4 and earlier, and 4.4.3 and earlier, allows context-dependent attackers to execute arbitrary code via a sscanf PHP function call that performs argument swapping, which increments an index past the end of an array and triggers a buffer over-read. \nPublish Date : 2006-08-08 Last Update Date : 2010-08-21",
+            "summary": "scanf.c in PHP 5.1.4 and earlier, and 4.4.3 and earlier, allows context-dependent attackers to execute arbitrary code via a sscanf PHP function call that performs argument swapping, which increments an index past the end of an array and triggers a buffer over-read.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -877,7 +877,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-4023",
-            "summary": "The ip2long function in PHP 5.1.4 and earlier may incorrectly validate an arbitrary string and return a valid network IP address, which allows remote attackers to obtain network information and facilitate other attacks, as demonstrated using SQL injection in the X-FORWARDED-FOR Header in index.php in MiniBB 2.0. NOTE: it could be argued that the ip2long behavior represents a risk for security-relevant issues in a way that is similar to strcpy's role in buffer overflows, in which case this would be a class of implementation bugs that would require separate CVE items for each PHP application that uses ip2long in a security-relevant manner. \nPublish Date : 2006-08-08 Last Update Date : 2008-09-05",
+            "summary": "The ip2long function in PHP 5.1.4 and earlier may incorrectly validate an arbitrary string and return a valid network IP address, which allows remote attackers to obtain network information and facilitate other attacks, as demonstrated using SQL injection in the X-FORWARDED-FOR Header in index.php in MiniBB 2.0.  NOTE: it could be argued that the ip2long behavior represents a risk for security-relevant issues in a way that is similar to strcpy's role in buffer overflows, in which case this would be a class of implementation bugs that would require separate CVE items for each PHP application that uses ip2long in a security-relevant manner.",
             "fixVersions": {
                 "base": [
                     "4.3.4",
@@ -889,7 +889,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2006-4433",
-            "summary": "PHP before 4.4.3 and 5.x before 5.1.4 does not limit the character set of the session identifier (PHPSESSID) for third party session handlers, which might make it easier for remote attackers to exploit other vulnerabilities by inserting PHP code into the PHPSESSID, which is stored in the session file. NOTE: it could be argued that this not a vulnerability in PHP itself, rather a design limitation that enables certain attacks against session handlers that do not account for this limitation. \nPublish Date : 2006-08-28 Last Update Date : 2008-09-05",
+            "summary": "PHP before 4.4.3 and 5.x before 5.1.4 does not limit the character set of the session identifier (PHPSESSID) for third party session handlers, which might make it easier for remote attackers to exploit other vulnerabilities by inserting PHP code into the PHPSESSID, which is stored in the session file.  NOTE: it could be argued that this not a vulnerability in PHP itself, rather a design limitation that enables certain attacks against session handlers that do not account for this limitation.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -905,7 +905,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2006-4481",
-            "summary": "The (1) file_exists and (2) imap_reopen functions in PHP before 5.1.5 do not check for the safe_mode and open_basedir settings, which allows local users to bypass the settings. NOTE: the error_log function is covered by CVE-2006-3011, and the imap_open function is covered by CVE-2006-1017. \nPublish Date : 2006-08-31 Last Update Date : 2010-09-15",
+            "summary": "The (1) file_exists and (2) imap_reopen functions in PHP before 5.1.5 do not check for the safe_mode and open_basedir settings, which allows local users to bypass the settings.  NOTE: the error_log function is covered by CVE-2006-3011, and the imap_open function is covered by CVE-2006-1017.",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -915,7 +915,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-4482",
-            "summary": "Multiple heap-based buffer overflows in the (1) str_repeat and (2) wordwrap functions in ext/standard/string.c in PHP before 5.1.5, when used on a 64-bit system, have unspecified impact and attack vectors, a different vulnerability than CVE-2006-1990. \nPublish Date : 2006-08-31 Last Update Date : 2010-08-21",
+            "summary": "Multiple heap-based buffer overflows in the (1) str_repeat and (2) wordwrap functions in ext\/standard\/string.c in PHP before 5.1.5, when used on a 64-bit system, have unspecified impact and attack vectors, a different vulnerability than CVE-2006-1990.",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -925,7 +925,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2006-4483",
-            "summary": "The cURL extension files (1) ext/curl/interface.c and (2) ext/curl/streams.c in PHP before 5.1.5 permit the CURLOPT_FOLLOWLOCATION option when open_basedir or safe_mode is enabled, which allows attackers to perform unauthorized actions, possibly related to the realpath cache. \nPublish Date : 2006-08-31 Last Update Date : 2008-09-05",
+            "summary": "The cURL extension files (1) ext\/curl\/interface.c and (2) ext\/curl\/streams.c in PHP before 5.1.5 permit the CURLOPT_FOLLOWLOCATION option when open_basedir or safe_mode is enabled, which allows attackers to perform unauthorized actions, possibly related to the realpath cache.",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -935,7 +935,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-4484",
-            "summary": "Buffer overflow in the LWZReadByte_ function in ext/gd/libgd/gd_gif_in.c in the GD extension in PHP before 5.1.5 allows remote attackers to have an unknown impact via a GIF file with input_code_size greater than MAX_LWZ_BITS, which triggers an overflow when initializing the table array. \nPublish Date : 2006-08-31 Last Update Date : 2010-09-15",
+            "summary": "Buffer overflow in the LWZReadByte_ function in ext\/gd\/libgd\/gd_gif_in.c in the GD extension in PHP before 5.1.5 allows remote attackers to have an unknown impact via a GIF file with input_code_size greater than MAX_LWZ_BITS, which triggers an overflow when initializing the table array.",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -945,7 +945,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2006-4485",
-            "summary": "The stripos function in PHP before 5.1.5 has unknown impact and attack vectors related to an out-of-bounds read. \nPublish Date : 2006-08-31 Last Update Date : 2010-09-15",
+            "summary": "The stripos function in PHP before 5.1.5 has unknown impact and attack vectors related to an out-of-bounds read.",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -955,7 +955,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2006-4486",
-            "summary": "Integer overflow in memory allocation routines in PHP before 5.1.6, when running on a 64-bit system, allows context-dependent attackers to bypass the memory_limit restriction. \nPublish Date : 2006-08-31 Last Update Date : 2010-08-21",
+            "summary": "Integer overflow in memory allocation routines in PHP before 5.1.6, when running on a 64-bit system, allows context-dependent attackers to bypass the memory_limit restriction.",
             "fixVersions": {
                 "base": [
                     "5.1.6"
@@ -965,7 +965,7 @@
         {
             "threat": "3.6",
             "cveid": "CVE-2006-4625",
-            "summary": "PHP 4.x up to 4.4.4 and PHP 5 up to 5.1.6 allows local users to bypass certain Apache HTTP Server httpd.conf options, such as safe_mode and open_basedir, via the ini_restore function, which resets the values to their php.ini (Master Value) defaults. \nPublish Date : 2006-09-12 Last Update Date : 2010-09-15",
+            "summary": "PHP 4.x up to 4.4.4 and PHP 5 up to 5.1.6 allows local users to bypass certain Apache HTTP Server httpd.conf options, such as safe_mode and open_basedir, via the ini_restore function, which resets the values to their php.ini (Master Value) defaults.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -981,7 +981,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2006-4812",
-            "summary": "Integer overflow in PHP 5 up to 5.1.6 and 4 before 4.3.0 allows remote attackers to execute arbitrary code via an argument to the unserialize PHP function with a large value for the number of array elements, which triggers the overflow in the Zend Engine ecalloc function (Zend/zend_alloc.c). \nPublish Date : 2006-10-10 Last Update Date : 2008-09-05",
+            "summary": "Integer overflow in PHP 5 up to 5.1.6 and 4 before 4.3.0 allows remote attackers to execute arbitrary code via an argument to the unserialize PHP function with a large value for the number of array elements, which triggers the overflow in the Zend Engine ecalloc function (Zend\/zend_alloc.c).",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -995,7 +995,7 @@
         {
             "threat": "6.2",
             "cveid": "CVE-2006-5178",
-            "summary": "Race condition in the symlink function in PHP 5.1.6 and earlier allows local users to bypass the open_basedir restriction by using a combination of symlink, mkdir, and unlink functions to change the file path after the open_basedir check and before the file is opened by the underlying system, as demonstrated by symlinking a symlink into a subdirectory, to point to a parent directory via .. (dot dot) sequences, and then unlinking the resulting symlink. \nPublish Date : 2006-10-10 Last Update Date : 2010-09-15",
+            "summary": "Race condition in the symlink function in PHP 5.1.6 and earlier allows local users to bypass the open_basedir restriction by using a combination of symlink, mkdir, and unlink functions to change the file path after the open_basedir check and before the file is opened by the underlying system, as demonstrated by symlinking a symlink into a subdirectory, to point to a parent directory via .. (dot dot) sequences, and then unlinking the resulting symlink.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1011,7 +1011,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2006-5465",
-            "summary": "Buffer overflow in PHP before 5.2.0 allows remote attackers to execute arbitrary code via crafted UTF-8 inputs to the (1) htmlentities or (2) htmlspecialchars functions. \nPublish Date : 2006-11-03 Last Update Date : 2010-09-15",
+            "summary": "Buffer overflow in PHP before 5.2.0 allows remote attackers to execute arbitrary code via crafted UTF-8 inputs to the (1) htmlentities or (2) htmlspecialchars functions.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1022,7 +1022,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2006-5706",
-            "summary": "Unspecified vulnerabilities in PHP, probably before 5.2.0, allow local users to bypass open_basedir restrictions and perform unspecified actions via unspecified vectors involving the (1) chdir and (2) tempnam functions. NOTE: the tempnam vector might overlap CVE-2006-1494. \nPublish Date : 2006-11-03 Last Update Date : 2008-09-05",
+            "summary": "Unspecified vulnerabilities in PHP, probably before 5.2.0, allow local users to bypass open_basedir restrictions and perform unspecified actions via unspecified vectors involving the (1) chdir and (2) tempnam functions.  NOTE: the tempnam vector might overlap CVE-2006-1494.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1033,7 +1033,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2006-6383",
-            "summary": "PHP 5.2.0 and 4.4 allows local users to bypass safe_mode and open_basedir restrictions via a malicious path and a null byte before a \";\" in a session_save_path argument, followed by an allowed path, which causes a parsing inconsistency in which PHP validates the allowed path but sets session.save_path to the malicious path. \nPublish Date : 2006-12-10 Last Update Date : 2008-11-15",
+            "summary": "PHP 5.2.0 and 4.4 allows local users to bypass safe_mode and open_basedir restrictions via a malicious path and a null byte before a \";\" in a session_save_path argument, followed by an allowed path, which causes a parsing inconsistency in which PHP validates the allowed path but sets session.save_path to the malicious path.",
             "fixVersions": {
                 "base": [
                     "5.2.1",
@@ -1044,7 +1044,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2006-7243",
-            "summary": "PHP before 5.3.4 accepts the \\0 character in a pathname, which might allow context-dependent attackers to bypass intended access restrictions by placing a safe file extension after this character, as demonstrated by .php\\0.jpg at the end of the argument to the file_exists function. \nPublish Date : 2011-01-18 Last Update Date : 2014-03-25",
+            "summary": "PHP before 5.3.4 accepts the \\0 character in a pathname, which might allow context-dependent attackers to bypass intended access restrictions by placing a safe file extension after this character, as demonstrated by .php\\0.jpg at the end of the argument to the file_exists function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1072,7 +1072,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2007-2509",
-            "summary": "CRLF injection vulnerability in the ftp_putcmd function in PHP before 4.4.7, and 5.x before 5.2.2 allows remote attackers to inject arbitrary FTP commands via CRLF sequences in the parameters to earlier FTP commands. \nPublish Date : 2007-05-08 Last Update Date : 2012-11-05",
+            "summary": "CRLF injection vulnerability in the ftp_putcmd function in PHP before 4.4.7, and 5.x before 5.2.2 allows remote attackers to inject arbitrary FTP commands via CRLF sequences in the parameters to earlier FTP commands.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1089,7 +1089,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2007-2510",
-            "summary": "Buffer overflow in the make_http_soap_request function in PHP before 5.2.2 has unknown impact and remote attack vectors, possibly related to \"/\" (slash) characters. \nPublish Date : 2007-05-08 Last Update Date : 2012-10-30",
+            "summary": "Buffer overflow in the make_http_soap_request function in PHP before 5.2.2 has unknown impact and remote attack vectors, possibly related to \"\/\" (slash) characters.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1106,7 +1106,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2007-2511",
-            "summary": "Buffer overflow in the user_filter_factory_create function in PHP before 5.2.2 has unknown impact and local attack vectors. \nPublish Date : 2007-05-08 Last Update Date : 2012-10-30",
+            "summary": "Buffer overflow in the user_filter_factory_create function in PHP before 5.2.2 has unknown impact and local attack vectors.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1121,7 +1121,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2007-2727",
-            "summary": "The mcrypt_create_iv function in ext/mcrypt/mcrypt.c in PHP before 4.4.7, 5.2.1, and possibly 5.0.x and other PHP 5 versions, calls php_rand_r with an uninitialized seed variable and therefore always generates the same initialization vector (IV), which might allow context-dependent attackers to decrypt certain data more easily because of the guessable encryption keys. \nPublish Date : 2007-05-16 Last Update Date : 2012-11-05",
+            "summary": "The mcrypt_create_iv function in ext\/mcrypt\/mcrypt.c in PHP before 4.4.7, 5.2.1, and possibly 5.0.x and other PHP 5 versions, calls php_rand_r with an uninitialized seed variable and therefore always generates the same initialization vector (IV), which might allow context-dependent attackers to decrypt certain data more easily because of the guessable encryption keys.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1138,7 +1138,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-2748",
-            "summary": "The substr_count function in PHP 5.2.1 and earlier allows context-dependent attackers to obtain sensitive information via unspecified vectors, a different affected function than CVE-2007-1375. \nPublish Date : 2007-05-17 Last Update Date : 2012-10-30",
+            "summary": "The substr_count function in PHP 5.2.1 and earlier allows context-dependent attackers to obtain sensitive information via unspecified vectors, a different affected function than CVE-2007-1375.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1150,7 +1150,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2007-2844",
-            "summary": "PHP 4.x and 5.x before 5.2.1, when running on multi-threaded systems, does not ensure thread safety for libc crypt function calls using protection schemes such as a mutex, which creates race conditions that allow remote attackers to overwrite internal program memory and gain system access. \nPublish Date : 2007-05-24 Last Update Date : 2012-11-05",
+            "summary": "PHP 4.x and 5.x before 5.2.1, when running on multi-threaded systems, does not ensure thread safety for libc crypt function calls using protection schemes such as a mutex, which creates race conditions that allow remote attackers to overwrite internal program memory and gain system access.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1167,7 +1167,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-2872",
-            "summary": "Multiple integer overflows in the chunk_split function in PHP 5 before 5.2.3 and PHP 4 before 4.4.8 allow remote attackers to cause a denial of service (crash) or execute arbitrary code via the (1) chunks, (2) srclen, and (3) chunklen arguments. \nPublish Date : 2007-06-04 Last Update Date : 2012-10-30",
+            "summary": "Multiple integer overflows in the chunk_split function in PHP 5 before 5.2.3 and PHP 4 before 4.4.8 allow remote attackers to cause a denial of service (crash) or execute arbitrary code via the (1) chunks, (2) srclen, and (3) chunklen arguments.",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -1180,7 +1180,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-3007",
-            "summary": "PHP 5 before 5.2.3 does not enforce the open_basedir or safe_mode restriction in certain cases, which allows context-dependent attackers to determine the existence of arbitrary files by checking if the readfile function returns a string. NOTE: this issue might also involve the realpath function. \nPublish Date : 2007-06-04 Last Update Date : 2012-10-30",
+            "summary": "PHP 5 before 5.2.3 does not enforce the open_basedir or safe_mode restriction in certain cases, which allows context-dependent attackers to determine the existence of arbitrary files by checking if the readfile function returns a string.  NOTE: this issue might also involve the realpath function.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1192,7 +1192,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-3294",
-            "summary": "Multiple buffer overflows in libtidy, as used in the Tidy extension for PHP 5.2.3 and possibly other products, allow context-dependent attackers to execute arbitrary code via (1) a long second argument to the tidy_parse_string function or (2) an unspecified vector to the tidy_repair_string function. NOTE: this might only be an issue in environments where vsnprintf is implemented as a wrapper for vsprintf. \nPublish Date : 2007-06-20 Last Update Date : 2012-10-30",
+            "summary": "Multiple buffer overflows in libtidy, as used in the Tidy extension for PHP 5.2.3 and possibly other products, allow context-dependent attackers to execute arbitrary code via (1) a long second argument to the tidy_parse_string function or (2) an unspecified vector to the tidy_repair_string function.  NOTE: this might only be an issue in environments where vsnprintf is implemented as a wrapper for vsprintf.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1202,7 +1202,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-3378",
-            "summary": "The (1) session_save_path, (2) ini_set, and (3) error_log functions in PHP 4.4.7 and earlier, and PHP 5 5.2.3 and earlier, when invoked from a .htaccess file, allow remote attackers to bypass safe_mode and open_basedir restrictions and possibly execute arbitrary commands, as demonstrated using (a) php_value, (b) php_flag, and (c) directives in .htaccess. \nPublish Date : 2007-06-29 Last Update Date : 2010-11-22",
+            "summary": "The (1) session_save_path, (2) ini_set, and (3) error_log functions in PHP 4.4.7 and earlier, and PHP 5 5.2.3 and earlier, when invoked from a .htaccess file, allow remote attackers to bypass safe_mode and open_basedir restrictions and possibly execute arbitrary commands, as demonstrated using (a) php_value, (b) php_flag, and (c) directives in .htaccess.",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -1213,7 +1213,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2007-3790",
-            "summary": "The com_print_typeinfo function in the bz2 extension in PHP 5.2.3 allows context-dependent attackers to cause a denial of service via a long argument. \nPublish Date : 2007-07-15 Last Update Date : 2012-10-30",
+            "summary": "The com_print_typeinfo function in the bz2 extension in PHP 5.2.3 allows context-dependent attackers to cause a denial of service via a long argument.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1223,7 +1223,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-3799",
-            "summary": "The session_start function in ext/session in PHP 4.x up to 4.4.7 and 5.x up to 5.2.3 allows remote attackers to insert arbitrary attributes into the session cookie via special characters in a cookie that is obtained from (1) PATH_INFO, (2) the session_id function, and (3) the session_start function, which are not encoded or filtered when the new session cookie is generated, a related issue to CVE-2006-0207. \nPublish Date : 2007-07-16 Last Update Date : 2012-10-30",
+            "summary": "The session_start function in ext\/session in PHP 4.x up to 4.4.7 and 5.x up to 5.2.3 allows remote attackers to insert arbitrary attributes into the session cookie via special characters in a cookie that is obtained from (1) PATH_INFO, (2) the session_id function, and (3) the session_start function, which are not encoded or filtered when the new session cookie is generated, a related issue to CVE-2006-0207.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1240,7 +1240,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-3806",
-            "summary": "The glob function in PHP 5.2.3 allows context-dependent attackers to cause a denial of service and possibly execute arbitrary code via an invalid value of the flags parameter, probably related to memory corruption or an invalid read on win32 platforms, and possibly related to lack of initialization for a glob structure. \nPublish Date : 2007-07-16 Last Update Date : 2012-11-05",
+            "summary": "The glob function in PHP 5.2.3 allows context-dependent attackers to cause a denial of service and possibly execute arbitrary code via an invalid value of the flags parameter, probably related to memory corruption or an invalid read on win32 platforms, and possibly related to lack of initialization for a glob structure.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1250,7 +1250,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-3996",
-            "summary": "Multiple integer overflows in libgd in PHP before 5.2.4 allow remote attackers to cause a denial of service (application crash) and possibly execute arbitrary code via a large (1) srcW or (2) srcH value to the (a) gdImageCopyResized function, or a large (3) sy (height) or (4) sx (width) value to the (b) gdImageCreate or the (c) gdImageCreateTrueColor function. \nPublish Date : 2007-09-04 Last Update Date : 2010-08-21",
+            "summary": "Multiple integer overflows in libgd in PHP before 5.2.4 allow remote attackers to cause a denial of service (application crash) and possibly execute arbitrary code via a large (1) srcW or (2) srcH value to the (a) gdImageCopyResized function, or a large (3) sy (height) or (4) sx (width) value to the (b) gdImageCreate or the (c) gdImageCreateTrueColor function.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1260,7 +1260,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-3997",
-            "summary": "The (1) MySQL and (2) MySQLi extensions in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to bypass safe_mode and open_basedir restrictions via MySQL LOCAL INFILE operations, as demonstrated by a query with LOAD DATA LOCAL INFILE. \nPublish Date : 2007-09-04 Last Update Date : 2009-09-16",
+            "summary": "The (1) MySQL and (2) MySQLi extensions in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to bypass safe_mode and open_basedir restrictions via MySQL LOCAL INFILE operations, as demonstrated by a query with LOAD DATA LOCAL INFILE.",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -1271,7 +1271,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-3998",
-            "summary": "The wordwrap function in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, does not properly use the breakcharlen variable, which allows remote attackers to cause a denial of service (divide-by-zero error and application crash, or infinite loop) via certain arguments, as demonstrated by a 'chr(0), 0, \"\"' argument set. \nPublish Date : 2007-09-04 Last Update Date : 2010-08-21",
+            "summary": "The wordwrap function in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, does not properly use the breakcharlen variable, which allows remote attackers to cause a denial of service (divide-by-zero error and application crash, or infinite loop) via certain arguments, as demonstrated by a 'chr(0), 0, \"\"' argument set.",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -1282,7 +1282,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-4010",
-            "summary": "The win32std extension in PHP 5.2.3 does not follow safe_mode and disable_functions restrictions, which allows remote attackers to execute arbitrary commands via the win_shell_execute function. \nPublish Date : 2007-07-25 Last Update Date : 2008-09-05",
+            "summary": "The win32std extension in PHP 5.2.3 does not follow safe_mode and disable_functions restrictions, which allows remote attackers to execute arbitrary commands via the win_shell_execute function.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1292,7 +1292,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4033",
-            "summary": "Buffer overflow in the intT1_EnvGetCompletePath function in lib/t1lib/t1env.c in t1lib 5.1.1 allows context-dependent attackers to execute arbitrary code via a long FileName parameter. NOTE: this issue was originally reported to be in the imagepsloadfont function in php_gd2.dll in the gd (PHP_GD2) extension in PHP 5.2.3. \nPublish Date : 2007-07-27 Last Update Date : 2010-08-21",
+            "summary": "Buffer overflow in the intT1_EnvGetCompletePath function in lib\/t1lib\/t1env.c in t1lib 5.1.1 allows context-dependent attackers to execute arbitrary code via a long FileName parameter.  NOTE: this issue was originally reported to be in the imagepsloadfont function in php_gd2.dll in the gd (PHP_GD2) extension in PHP 5.2.3.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1302,7 +1302,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4255",
-            "summary": "Buffer overflow in the mSQL extension in PHP 5.2.3 allows context-dependent attackers to execute arbitrary code via a long first argument to the msql_connect function. \nPublish Date : 2007-08-08 Last Update Date : 2008-09-05",
+            "summary": "Buffer overflow in the mSQL extension in PHP 5.2.3 allows context-dependent attackers to execute arbitrary code via a long first argument to the msql_connect function.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1312,7 +1312,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2007-4441",
-            "summary": "Buffer overflow in php_win32std.dll in the win32std extension for PHP 5.2.0 and earlier allows context-dependent attackers to execute arbitrary code via a long string in the filename argument to the win_browse_file function. \nPublish Date : 2007-08-20 Last Update Date : 2008-09-05",
+            "summary": "Buffer overflow in php_win32std.dll in the win32std extension for PHP 5.2.0 and earlier allows context-dependent attackers to execute arbitrary code via a long string in the filename argument to the win_browse_file function.",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1322,7 +1322,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-4507",
-            "summary": "Multiple buffer overflows in the php_ntuser component for PHP 5.2.3 allow context-dependent attackers to cause a denial of service or execute arbitrary code via long arguments to the (1) ntuser_getuserlist, (2) ntuser_getuserinfo, (3) ntuser_getusergroups, or (4) ntuser_getdomaincontroller functions. \nPublish Date : 2007-08-23 Last Update Date : 2008-09-05",
+            "summary": "Multiple buffer overflows in the php_ntuser component for PHP 5.2.3 allow context-dependent attackers to cause a denial of service or execute arbitrary code via long arguments to the (1) ntuser_getuserlist, (2) ntuser_getuserinfo, (3) ntuser_getusergroups, or (4) ntuser_getdomaincontroller functions.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1332,7 +1332,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-4528",
-            "summary": "The Foreign Function Interface (ffi) extension in PHP 5.0.5 does not follow safe_mode restrictions, which allows context-dependent attackers to execute arbitrary code by loading an arbitrary DLL and calling a function, as demonstrated by kernel32.dll and the WinExec function. NOTE: this issue does not cross privilege boundaries in most contexts, so perhaps it should not be included in CVE. \nPublish Date : 2007-08-24 Last Update Date : 2008-09-05",
+            "summary": "The Foreign Function Interface (ffi) extension in PHP 5.0.5 does not follow safe_mode restrictions, which allows context-dependent attackers to execute arbitrary code by loading an arbitrary DLL and calling a function, as demonstrated by kernel32.dll and the WinExec function.  NOTE: this issue does not cross privilege boundaries in most contexts, so perhaps it should not be included in CVE.",
             "fixVersions": {
                 "base": [
                     "5.0.6"
@@ -1342,7 +1342,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4586",
-            "summary": "Multiple buffer overflows in php_iisfunc.dll in the iisfunc extension for PHP 5.2.0 and earlier allow context-dependent attackers to execute arbitrary code, probably during Unicode conversion, as demonstrated by a long string in the first argument to the iis_getservicestate function, related to the ServiceId argument to the (1) fnStartService, (2) fnGetServiceState, (3) fnStopService, and possibly other functions. \nPublish Date : 2007-08-28 Last Update Date : 2008-09-05",
+            "summary": "Multiple buffer overflows in php_iisfunc.dll in the iisfunc extension for PHP 5.2.0 and earlier allow context-dependent attackers to execute arbitrary code, probably during Unicode conversion, as demonstrated by a long string in the first argument to the iis_getservicestate function, related to the ServiceId argument to the (1) fnStartService, (2) fnGetServiceState, (3) fnStopService, and possibly other functions.",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1352,7 +1352,7 @@
         {
             "threat": "4.4",
             "cveid": "CVE-2007-4652",
-            "summary": "The session extension in PHP before 5.2.4 might allow local users to bypass open_basedir restrictions via a session file that is a symlink. \nPublish Date : 2007-09-04 Last Update Date : 2011-08-23",
+            "summary": "The session extension in PHP before 5.2.4 might allow local users to bypass open_basedir restrictions via a session file that is a symlink.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1369,7 +1369,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4657",
-            "summary": "Multiple integer overflows in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to obtain sensitive information (memory contents) or cause a denial of service (thread crash) via a large len value to the (1) strspn or (2) strcspn function, which triggers an out-of-bounds read. NOTE: this affects different product versions than CVE-2007-3996. \nPublish Date : 2007-09-04 Last Update Date : 2009-09-16",
+            "summary": "Multiple integer overflows in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to obtain sensitive information (memory contents) or cause a denial of service (thread crash) via a large len value to the (1) strspn or (2) strcspn function, which triggers an out-of-bounds read.  NOTE: this affects different product versions than CVE-2007-3996.",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -1380,7 +1380,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4658",
-            "summary": "The money_format function in PHP 5 before 5.2.4, and PHP 4 before 4.4.8, permits multiple (1) %i and (2) %n tokens, which has unknown impact and attack vectors, possibly related to a format string vulnerability. \nPublish Date : 2007-09-04 Last Update Date : 2011-06-20",
+            "summary": "The money_format function in PHP 5 before 5.2.4, and PHP 4 before 4.4.8, permits multiple (1) %i and (2) %n tokens, which has unknown impact and attack vectors, possibly related to a format string vulnerability.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1397,7 +1397,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4659",
-            "summary": "The zend_alter_ini_entry function in PHP before 5.2.4 does not properly handle an interruption to the flow of execution triggered by a memory_limit violation, which has unknown impact and attack vectors. \nPublish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "summary": "The zend_alter_ini_entry function in PHP before 5.2.4 does not properly handle an interruption to the flow of execution triggered by a memory_limit violation, which has unknown impact and attack vectors.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1407,7 +1407,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4660",
-            "summary": "Unspecified vulnerability in the chunk_split function in PHP before 5.2.4 has unknown impact and attack vectors, related to an incorrect size calculation. \nPublish Date : 2007-09-04 Last Update Date : 2008-09-10",
+            "summary": "Unspecified vulnerability in the chunk_split function in PHP before 5.2.4 has unknown impact and attack vectors, related to an incorrect size calculation.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1417,7 +1417,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4661",
-            "summary": "The chunk_split function in string.c in PHP 5.2.3 does not properly calculate the needed buffer size due to precision loss when performing integer arithmetic with floating point numbers, which has unknown attack vectors and impact, possibly resulting in a heap-based buffer overflow. NOTE: this is due to an incomplete fix for CVE-2007-2872. \nPublish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "summary": "The chunk_split function in string.c in PHP 5.2.3 does not properly calculate the needed buffer size due to precision loss when performing integer arithmetic with floating point numbers, which has unknown attack vectors and impact, possibly resulting in a heap-based buffer overflow.  NOTE: this is due to an incomplete fix for CVE-2007-2872.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1427,7 +1427,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4662",
-            "summary": "Buffer overflow in the php_openssl_make_REQ function in PHP before 5.2.4 has unknown impact and attack vectors. \nPublish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "summary": "Buffer overflow in the php_openssl_make_REQ function in PHP before 5.2.4 has unknown impact and attack vectors.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1437,7 +1437,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4663",
-            "summary": "Directory traversal vulnerability in PHP before 5.2.4 allows attackers to bypass open_basedir restrictions via unspecified vectors involving the glob function. \nPublish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "summary": "Directory traversal vulnerability in PHP before 5.2.4 allows attackers to bypass open_basedir restrictions via unspecified vectors involving the glob function.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1447,7 +1447,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4670",
-            "summary": "Unspecified vulnerability in PHP before 5.2.4 has unknown impact and attack vectors, related to an \"Improved fix for MOPB-03-2007,\" probably a variant of CVE-2007-1285. \nPublish Date : 2007-09-04 Last Update Date : 2010-08-21",
+            "summary": "Unspecified vulnerability in PHP before 5.2.4 has unknown impact and attack vectors, related to an \"Improved fix for MOPB-03-2007,\" probably a variant of CVE-2007-1285.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1457,7 +1457,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4782",
-            "summary": "PHP before 5.2.3 allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the pattern parameter to the glob function; or (2) a long string in the string parameter to the fnmatch function, accompanied by a pattern parameter value with undefined characteristics, as demonstrated by a \"*[1]e\" value. NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \nPublish Date : 2007-09-10 Last Update Date : 2010-08-21",
+            "summary": "PHP before 5.2.3 allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the pattern parameter to the glob function; or (2) a long string in the string parameter to the fnmatch function, accompanied by a pattern parameter value with undefined characteristics, as demonstrated by a \"*[1]e\" value.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1467,7 +1467,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4783",
-            "summary": "The iconv_substr function in PHP 5.2.4 and earlier allows context-dependent attackers to cause (1) a denial of service (application crash) via a long string in the charset parameter, probably also requiring a long string in the str parameter; or (2) a denial of service (temporary application hang) via a long string in the str parameter. NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \nPublish Date : 2007-09-10 Last Update Date : 2009-02-05",
+            "summary": "The iconv_substr function in PHP 5.2.4 and earlier allows context-dependent attackers to cause (1) a denial of service (application crash) via a long string in the charset parameter, probably also requiring a long string in the str parameter; or (2) a denial of service (temporary application hang) via a long string in the str parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1477,7 +1477,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4784",
-            "summary": "The setlocale function in PHP before 5.2.4 allows context-dependent attackers to cause a denial of service (application crash) via a long string in the locale parameter. NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution. \nPublish Date : 2007-09-10 Last Update Date : 2009-02-05",
+            "summary": "The setlocale function in PHP before 5.2.4 allows context-dependent attackers to cause a denial of service (application crash) via a long string in the locale parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1487,7 +1487,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-4825",
-            "summary": "Directory traversal vulnerability in PHP 5.2.4 and earlier allows attackers to bypass open_basedir restrictions and possibly execute arbitrary code via a .. (dot dot) in the dl function. \nPublish Date : 2007-09-11 Last Update Date : 2009-02-05",
+            "summary": "Directory traversal vulnerability in PHP 5.2.4 and earlier allows attackers to bypass open_basedir restrictions and possibly execute arbitrary code via a .. (dot dot) in the dl function.",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -1497,7 +1497,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4840",
-            "summary": "PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the out_charset parameter to the iconv function; or a long string in the charset parameter to the (2) iconv_mime_decode_headers, (3) iconv_mime_decode, or (4) iconv_strlen function. NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \nPublish Date : 2007-09-12 Last Update Date : 2009-02-05",
+            "summary": "PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the out_charset parameter to the iconv function; or a long string in the charset parameter to the (2) iconv_mime_decode_headers, (3) iconv_mime_decode, or (4) iconv_strlen function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1507,7 +1507,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-4850",
-            "summary": "curl/interface.c in the cURL library (aka libcurl) in PHP 5.2.4 and 5.2.5 allows context-dependent attackers to bypass safe_mode and open_basedir restrictions and read arbitrary files via a file:// request containing a \\x00 sequence, a different vulnerability than CVE-2006-2563. \nPublish Date : 2008-01-24 Last Update Date : 2009-04-08",
+            "summary": "curl\/interface.c in the cURL library (aka libcurl) in PHP 5.2.4 and 5.2.5 allows context-dependent attackers to bypass safe_mode and open_basedir restrictions and read arbitrary files via a file:\/\/ request containing a \\x00 sequence, a different vulnerability than CVE-2006-2563.",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -1517,7 +1517,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-4887",
-            "summary": "The dl function in PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in the library parameter. NOTE: there are limited usage scenarios under which this would be a vulnerability. \nPublish Date : 2007-09-13 Last Update Date : 2009-03-04",
+            "summary": "The dl function in PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in the library parameter.  NOTE: there are limited usage scenarios under which this would be a vulnerability.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1527,7 +1527,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2007-4889",
-            "summary": "The MySQL extension in PHP 5.2.4 and earlier allows remote attackers to bypass safe_mode and open_basedir restrictions via the MySQL (1) LOAD_FILE, (2) INTO DUMPFILE, and (3) INTO OUTFILE functions, a different issue than CVE-2007-3997. \nPublish Date : 2007-09-13 Last Update Date : 2008-09-05",
+            "summary": "The MySQL extension in PHP 5.2.4 and earlier allows remote attackers to bypass safe_mode and open_basedir restrictions via the MySQL (1) LOAD_FILE, (2) INTO DUMPFILE, and (3) INTO OUTFILE functions, a different issue than CVE-2007-3997.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1537,7 +1537,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2007-5128",
-            "summary": "SimpNews 2.41.03 on Windows, when PHP before 5.0.0 is used, allows remote attackers to obtain sensitive information via an certain link_date parameter to events.php, which reveals the path in an error message due to an unsupported argument type for the mktime function on Windows. \nPublish Date : 2007-09-27 Last Update Date : 2008-09-05",
+            "summary": "SimpNews 2.41.03 on Windows, when PHP before 5.0.0 is used, allows remote attackers to obtain sensitive information via an certain link_date parameter to events.php, which reveals the path in an error message due to an unsupported argument type for the mktime function on Windows.",
             "fixVersions": {
                 "base": [
                     "5.0.1"
@@ -1547,7 +1547,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2007-5424",
-            "summary": "The disable_functions feature in PHP 4 and 5 allows attackers to bypass intended restrictions by using an alias, as demonstrated by using ini_alter when ini_set is disabled. \nPublish Date : 2007-10-12 Last Update Date : 2008-09-05",
+            "summary": "The disable_functions feature in PHP 4 and 5 allows attackers to bypass intended restrictions by using an alias, as demonstrated by using ini_alter when ini_set is disabled.",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -1558,7 +1558,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-5447",
-            "summary": "ioncube_loader_win_5.2.dll in the ionCube Loader 6.5 extension for PHP 5.2.4 does not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by reading arbitrary files via the ioncube_read_file function. \nPublish Date : 2007-10-14 Last Update Date : 2008-11-15",
+            "summary": "ioncube_loader_win_5.2.dll in the ionCube Loader 6.5 extension for PHP 5.2.4 does not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by reading arbitrary files via the ioncube_read_file function.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1568,7 +1568,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2007-5653",
-            "summary": "The Component Object Model (COM) functions in PHP 5.x on Windows do not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by executing objects with the kill bit set in the corresponding ActiveX control Compatibility Flags, executing programs via a function in compatUI.dll, invoking wscript.shell via wscript.exe, invoking Scripting.FileSystemObject via wshom.ocx, and adding users via a function in shgina.dll, related to the com_load_typelib function. \nPublish Date : 2007-10-23 Last Update Date : 2008-09-05",
+            "summary": "The Component Object Model (COM) functions in PHP 5.x on Windows do not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by executing objects with the kill bit set in the corresponding ActiveX control Compatibility Flags, executing programs via a function in compatUI.dll, invoking wscript.shell via wscript.exe, invoking Scripting.FileSystemObject via wshom.ocx, and adding users via a function in shgina.dll, related to the com_load_typelib function.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1578,7 +1578,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2007-5898",
-            "summary": "The (1) htmlentities and (2) htmlspecialchars functions in PHP before 5.2.5 accept partial multibyte sequences, which has unknown impact and attack vectors, a different issue than CVE-2006-5465. \nPublish Date : 2007-11-20 Last Update Date : 2010-08-21",
+            "summary": "The (1) htmlentities and (2) htmlspecialchars functions in PHP before 5.2.5 accept partial multibyte sequences, which has unknown impact and attack vectors, a different issue than CVE-2006-5465.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1588,7 +1588,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2007-5899",
-            "summary": "The output_add_rewrite_var function in PHP before 5.2.5 rewrites local forms in which the ACTION attribute references a non-local URL, which allows remote attackers to obtain potentially sensitive information by reading the requests for this URL, as demonstrated by a rewritten form containing a local session ID. \nPublish Date : 2007-11-20 Last Update Date : 2010-08-21",
+            "summary": "The output_add_rewrite_var function in PHP before 5.2.5 rewrites local forms in which the ACTION attribute references a non-local URL, which allows remote attackers to obtain potentially sensitive information by reading the requests for this URL, as demonstrated by a rewritten form containing a local session ID.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1598,7 +1598,7 @@
         {
             "threat": "6.9",
             "cveid": "CVE-2007-5900",
-            "summary": "PHP before 5.2.5 allows local users to bypass protection mechanisms configured through php_admin_value or php_admin_flag in httpd.conf by using ini_set to modify arbitrary configuration variables, a different issue than CVE-2006-4625. \nPublish Date : 2007-11-20 Last Update Date : 2009-02-05",
+            "summary": "PHP before 5.2.5 allows local users to bypass protection mechanisms configured through php_admin_value or php_admin_flag in httpd.conf by using ini_set to modify arbitrary configuration variables, a different issue than CVE-2006-4625.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1608,7 +1608,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2007-6039",
-            "summary": "PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in (1) the domain parameter to the dgettext function, the message parameter to the (2) dcgettext or (3) gettext function, the msgid1 parameter to the (4) dngettext or (5) ngettext function, or (6) the classname parameter to the stream_wrapper_register function. NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution. \nPublish Date : 2007-11-20 Last Update Date : 2008-09-05",
+            "summary": "PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in (1) the domain parameter to the dgettext function, the message parameter to the (2) dcgettext or (3) gettext function, the msgid1 parameter to the (4) dngettext or (5) ngettext function, or (6) the classname parameter to the stream_wrapper_register function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution.",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -1618,7 +1618,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-0145",
-            "summary": "Unspecified vulnerability in glob in PHP before 4.4.8, when open_basedir is enabled, has unknown impact and attack vectors. NOTE: this issue reportedly exists because of a regression related to CVE-2007-4663. \nPublish Date : 2008-01-08 Last Update Date : 2009-09-16",
+            "summary": "Unspecified vulnerability in glob in PHP before 4.4.8, when open_basedir is enabled, has unknown impact and attack vectors.  NOTE: this issue reportedly exists because of a regression related to CVE-2007-4663.",
             "fixVersions": {
                 "base": [
                     "4.4.8"
@@ -1628,7 +1628,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-0599",
-            "summary": "The init_request_info function in sapi/cgi/cgi_main.c in PHP before 5.2.6 does not properly consider operator precedence when calculating the length of PATH_TRANSLATED, which might allow remote attackers to execute arbitrary code via a crafted URI. \nPublish Date : 2008-05-05 Last Update Date : 2012-10-30",
+            "summary": "The init_request_info function in sapi\/cgi\/cgi_main.c in PHP before 5.2.6 does not properly consider operator precedence when calculating the length of PATH_TRANSLATED, which might allow remote attackers to execute arbitrary code via a crafted URI.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1640,7 +1640,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-1384",
-            "summary": "Integer overflow in PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service and possibly have unspecified other impact via a printf format parameter with a large width specifier, related to the php_sprintf_appendstring function in formatted_print.c and probably other functions for formatted strings (aka *printf functions). \nPublish Date : 2008-03-27 Last Update Date : 2012-10-30",
+            "summary": "Integer overflow in PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service and possibly have unspecified other impact via a printf format parameter with a large width specifier, related to the php_sprintf_appendstring function in formatted_print.c and probably other functions for formatted strings (aka *printf functions).",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -1650,7 +1650,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-2050",
-            "summary": "Stack-based buffer overflow in the FastCGI SAPI (fastcgi.c) in PHP before 5.2.6 has unknown impact and attack vectors. \nPublish Date : 2008-05-05 Last Update Date : 2012-10-30",
+            "summary": "Stack-based buffer overflow in the FastCGI SAPI (fastcgi.c) in PHP before 5.2.6 has unknown impact and attack vectors.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1662,7 +1662,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-2051",
-            "summary": "The escapeshellcmd API function in PHP before 5.2.6 has unknown impact and context-dependent attack vectors related to \"incomplete multibyte chars.\" \nPublish Date : 2008-05-05 Last Update Date : 2012-10-30",
+            "summary": "The escapeshellcmd API function in PHP before 5.2.6 has unknown impact and context-dependent attack vectors related to \"incomplete multibyte chars.\"",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1674,7 +1674,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-2107",
-            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 32-bit systems, performs a multiplication using values that can produce a zero seed in rare circumstances, which allows context-dependent attackers to predict subsequent values of the rand and mt_rand functions and possibly bypass protection mechanisms that rely on an unknown initial seed. \nPublish Date : 2008-05-07 Last Update Date : 2012-10-30",
+            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 32-bit systems, performs a multiplication using values that can produce a zero seed in rare circumstances, which allows context-dependent attackers to predict subsequent values of the rand and mt_rand functions and possibly bypass protection mechanisms that rely on an unknown initial seed.",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -1687,7 +1687,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-2108",
-            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 64-bit systems, performs a multiplication that generates a portion of zero bits during conversion due to insufficient precision, which produces 24 bits of entropy and simplifies brute force attacks against protection mechanisms that use the rand and mt_rand functions. \nPublish Date : 2008-05-07 Last Update Date : 2012-10-30",
+            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 64-bit systems, performs a multiplication that generates a portion of zero bits during conversion due to insufficient precision, which produces 24 bits of entropy and simplifies brute force attacks against protection mechanisms that use the rand and mt_rand functions.",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -1710,7 +1710,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-2665",
-            "summary": "Directory traversal vulnerability in the posix_access function in PHP 5.2.6 and earlier allows remote attackers to bypass safe_mode restrictions via a .. (dot dot) in an http URL, which results in the URL being canonicalized to a local filename after the safe_mode check has successfully run. \nPublish Date : 2008-06-19 Last Update Date : 2012-10-30",
+            "summary": "Directory traversal vulnerability in the posix_access function in PHP 5.2.6 and earlier allows remote attackers to bypass safe_mode restrictions via a .. (dot dot) in an http URL, which results in the URL being canonicalized to a local filename after the safe_mode check has successfully run.",
             "fixVersions": {
                 "base": [
                     "5.2.7"
@@ -1720,7 +1720,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-2666",
-            "summary": "Multiple directory traversal vulnerabilities in PHP 5.2.6 and earlier allow context-dependent attackers to bypass safe_mode restrictions by creating a subdirectory named http: and then placing ../ (dot dot slash) sequences in an http URL argument to the (1) chdir or (2) ftok function. \nPublish Date : 2008-06-19 Last Update Date : 2012-10-30",
+            "summary": "Multiple directory traversal vulnerabilities in PHP 5.2.6 and earlier allow context-dependent attackers to bypass safe_mode restrictions by creating a subdirectory named http: and then placing ..\/ (dot dot slash) sequences in an http URL argument to the (1) chdir or (2) ftok function.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1732,7 +1732,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-2829",
-            "summary": "php_imap.c in PHP 5.2.5, 5.2.6, 4.x, and other versions, uses obsolete API calls that allow context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long IMAP request, which triggers an \"rfc822.c legacy routine buffer overflow\" error message, related to the rfc822_write_address function. \nPublish Date : 2008-06-23 Last Update Date : 2012-10-30",
+            "summary": "php_imap.c in PHP 5.2.5, 5.2.6, 4.x, and other versions, uses obsolete API calls that allow context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long IMAP request, which triggers an \"rfc822.c legacy routine buffer overflow\" error message, related to the rfc822_write_address function.",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -1743,7 +1743,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-3658",
-            "summary": "Buffer overflow in the imageloadfont function in ext/gd/gd.c in PHP 4.4.x before 4.4.9 and PHP 5.2 before 5.2.6-r6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted font file. \nPublish Date : 2008-08-14 Last Update Date : 2013-08-01",
+            "summary": "Buffer overflow in the imageloadfont function in ext\/gd\/gd.c in PHP 4.4.x before 4.4.9 and PHP 5.2 before 5.2.6-r6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted font file.",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -1754,7 +1754,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2008-3659",
-            "summary": "Buffer overflow in the memnstr function in PHP 4.4.x before 4.4.9 and PHP 5.6 through 5.2.6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via the delimiter argument to the explode function. NOTE: the scope of this issue is limited since most applications would not use an attacker-controlled delimiter, but local attacks against safe_mode are feasible. \nPublish Date : 2008-08-14 Last Update Date : 2012-10-30",
+            "summary": "Buffer overflow in the memnstr function in PHP 4.4.x before 4.4.9 and PHP 5.6 through 5.2.6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via the delimiter argument to the explode function.  NOTE: the scope of this issue is limited since most applications would not use an attacker-controlled delimiter, but local attacks against safe_mode are feasible.",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -1765,7 +1765,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-3660",
-            "summary": "PHP 4.4.x before 4.4.9, and 5.x through 5.2.6, when used as a FastCGI module, allows remote attackers to cause a denial of service (crash) via a request with multiple dots preceding the extension, as demonstrated using foo..php. \nPublish Date : 2008-08-14 Last Update Date : 2012-10-30",
+            "summary": "PHP 4.4.x before 4.4.9, and 5.x through 5.2.6, when used as a FastCGI module, allows remote attackers to cause a denial of service (crash) via a request with multiple dots preceding the extension, as demonstrated using foo..php.",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -1776,7 +1776,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2008-4107",
-            "summary": "The (1) rand and (2) mt_rand functions in PHP 5.2.6 do not produce cryptographically strong random numbers, which allows attackers to leverage exposures in products that rely on these functions for security-relevant functionality, as demonstrated by the password-reset functionality in Joomla! 1.5.x and WordPress before 2.6.2, a different vulnerability than CVE-2008-2107, CVE-2008-2108, and CVE-2008-4102. \nPublish Date : 2008-09-18 Last Update Date : 2012-10-29",
+            "summary": "The (1) rand and (2) mt_rand functions in PHP 5.2.6 do not produce cryptographically strong random numbers, which allows attackers to leverage exposures in products that rely on these functions for security-relevant functionality, as demonstrated by the password-reset functionality in Joomla! 1.5.x and WordPress before 2.6.2, a different vulnerability than CVE-2008-2107, CVE-2008-2108, and CVE-2008-4102.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1793,7 +1793,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2008-5498",
-            "summary": "Array index error in the imageRotate function in PHP 5.2.8 and earlier allows context-dependent attackers to read the contents of arbitrary memory locations via a crafted value of the third argument (aka the bgd_color or clrBack argument) for an indexed image. \nPublish Date : 2008-12-26 Last Update Date : 2010-08-21",
+            "summary": "Array index error in the imageRotate function in PHP 5.2.8 and earlier allows context-dependent attackers to read the contents of arbitrary memory locations via a crafted value of the third argument (aka the bgd_color or clrBack argument) for an indexed image.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1805,7 +1805,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2008-5557",
-            "summary": "Heap-based buffer overflow in ext/mbstring/libmbfl/filters/mbfilter_htmlent.c in the mbstring extension in PHP 4.3.0 through 5.2.6 allows context-dependent attackers to execute arbitrary code via a crafted string containing an HTML entity, which is not properly handled during Unicode conversion, related to the (1) mb_convert_encoding, (2) mb_check_encoding, (3) mb_convert_variables, and (4) mb_parse_str functions. \nPublish Date : 2008-12-23 Last Update Date : 2010-08-21",
+            "summary": "Heap-based buffer overflow in ext\/mbstring\/libmbfl\/filters\/mbfilter_htmlent.c in the mbstring extension in PHP 4.3.0 through 5.2.6 allows context-dependent attackers to execute arbitrary code via a crafted string containing an HTML entity, which is not properly handled during Unicode conversion, related to the (1) mb_convert_encoding, (2) mb_check_encoding, (3) mb_convert_variables, and (4) mb_parse_str functions.",
             "fixVersions": {
                 "base": [
                     "4.3.12",
@@ -1819,7 +1819,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5624",
-            "summary": "PHP 5 before 5.2.7 does not properly initialize the page_uid and page_gid global variables for use by the SAPI php_getuid function, which allows context-dependent attackers to bypass safe_mode restrictions via variable settings that are intended to be restricted to root, as demonstrated by a setting of /etc for the error_log variable. \nPublish Date : 2008-12-17 Last Update Date : 2009-10-31",
+            "summary": "PHP 5 before 5.2.7 does not properly initialize the page_uid and page_gid global variables for use by the SAPI php_getuid function, which allows context-dependent attackers to bypass safe_mode restrictions via variable settings that are intended to be restricted to root, as demonstrated by a setting of \/etc for the error_log variable.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1831,7 +1831,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5625",
-            "summary": "PHP 5 before 5.2.7 does not enforce the error_log safe_mode restrictions when safe_mode is enabled through a php_admin_flag setting in httpd.conf, which allows context-dependent attackers to write to arbitrary files by placing a \"php_value error_log\" entry in a .htaccess file. \nPublish Date : 2008-12-17 Last Update Date : 2009-10-31",
+            "summary": "PHP 5 before 5.2.7 does not enforce the error_log safe_mode restrictions when safe_mode is enabled through a php_admin_flag setting in httpd.conf, which allows context-dependent attackers to write to arbitrary files by placing a \"php_value error_log\" entry in a .htaccess file.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1843,7 +1843,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5658",
-            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in PHP 5.2.6 and earlier allows context-dependent attackers to write arbitrary files via a ZIP file with a file whose name contains .. (dot dot) sequences. \nPublish Date : 2008-12-17 Last Update Date : 2009-10-31",
+            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in PHP 5.2.6 and earlier allows context-dependent attackers to write arbitrary files via a ZIP file with a file whose name contains .. (dot dot) sequences.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1855,7 +1855,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2008-5814",
-            "summary": "Cross-site scripting (XSS) vulnerability in PHP, possibly 5.2.7 and earlier, when display_errors is enabled, allows remote attackers to inject arbitrary web script or HTML via unspecified vectors. NOTE: because of the lack of details, it is unclear whether this is related to CVE-2006-0208. \nPublish Date : 2009-01-02 Last Update Date : 2010-08-21",
+            "summary": "Cross-site scripting (XSS) vulnerability in PHP, possibly 5.2.7 and earlier, when display_errors is enabled, allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.  NOTE: because of the lack of details, it is unclear whether this is related to CVE-2006-0208.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1872,7 +1872,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2008-5844",
-            "summary": "PHP 5.2.7 contains an incorrect change to the FILTER_UNSAFE_RAW functionality, and unintentionally disables magic_quotes_gpc regardless of the actual magic_quotes_gpc setting, which might make it easier for context-dependent attackers to conduct SQL injection attacks and unspecified other attacks. \nPublish Date : 2009-01-05 Last Update Date : 2009-05-14",
+            "summary": "PHP 5.2.7 contains an incorrect change to the FILTER_UNSAFE_RAW functionality, and unintentionally disables magic_quotes_gpc regardless of the actual magic_quotes_gpc setting, which might make it easier for context-dependent attackers to conduct SQL injection attacks and unspecified other attacks.",
             "fixVersions": {
                 "base": [
                     "5.2.8"
@@ -1882,7 +1882,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2008-7002",
-            "summary": "PHP 5.2.5 does not enforce (a) open_basedir and (b) safe_mode_exec_dir restrictions for certain functions, which might allow local users to bypass intended access restrictions and call programs outside of the intended directory via the (1) exec, (2) system, (3) shell_exec, (4) passthru, or (5) popen functions, possibly involving pathnames such as \"C:\" drive notation. \nPublish Date : 2009-08-19 Last Update Date : 2009-08-19",
+            "summary": "PHP 5.2.5 does not enforce (a) open_basedir and (b) safe_mode_exec_dir restrictions for certain functions, which might allow local users to bypass intended access restrictions and call programs outside of the intended directory via the (1) exec, (2) system, (3) shell_exec, (4) passthru, or (5) popen functions, possibly involving pathnames such as \"C:\" drive notation.",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -1892,7 +1892,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2008-7068",
-            "summary": "The dba_replace function in PHP 5.2.6 and 4.x allows context-dependent attackers to cause a denial of service (file truncation) via a key with the NULL byte. NOTE: this might only be a vulnerability in limited circumstances in which the attacker can modify or add database entries but does not have permissions to truncate the file. \nPublish Date : 2009-08-25 Last Update Date : 2009-08-25",
+            "summary": "The dba_replace function in PHP 5.2.6 and 4.x allows context-dependent attackers to cause a denial of service (file truncation) via a key with the NULL byte.  NOTE: this might only be a vulnerability in limited circumstances in which the attacker can modify or add database entries but does not have permissions to truncate the file.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1907,7 +1907,7 @@
         {
             "threat": "2.1",
             "cveid": "CVE-2009-0754",
-            "summary": "PHP 4.4.4, 5.1.6, and other versions, when running on Apache, allows local users to modify behavior of other sites hosted on the same web server by modifying the mbstring.func_overload setting within .htaccess, which causes this setting to be applied to other virtual hosts on the same server. \nPublish Date : 2009-03-03 Last Update Date : 2010-08-21",
+            "summary": "PHP 4.4.4, 5.1.6, and other versions, when running on Apache, allows local users to modify behavior of other sites hosted on the same web server by modifying the mbstring.func_overload setting within .htaccess, which causes this setting to be applied to other virtual hosts on the same server.",
             "fixVersions": {
                 "base": [
                     "4.4.5",
@@ -1918,7 +1918,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-1271",
-            "summary": "The JSON_parser function (ext/json/JSON_parser.c) in PHP 5.2.x before 5.2.9 allows remote attackers to cause a denial of service (segmentation fault) via a malformed string to the json_decode API function. \nPublish Date : 2009-04-08 Last Update Date : 2009-09-16",
+            "summary": "The JSON_parser function (ext\/json\/JSON_parser.c) in PHP 5.2.x before 5.2.9 allows remote attackers to cause a denial of service (segmentation fault) via a malformed string to the json_decode API function.",
             "fixVersions": {
                 "base": [
                     "5.2.9"
@@ -1928,7 +1928,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-1272",
-            "summary": "The php_zip_make_relative_path function in php_zip.c in PHP 5.2.x before 5.2.9 allows context-dependent attackers to cause a denial of service (crash) via a ZIP file that contains filenames with relative paths, which is not properly handled during extraction. \nPublish Date : 2009-04-08 Last Update Date : 2009-09-16",
+            "summary": "The php_zip_make_relative_path function in php_zip.c in PHP 5.2.x before 5.2.9 allows context-dependent attackers to cause a denial of service (crash) via a ZIP file that contains filenames with relative paths, which is not properly handled during extraction.",
             "fixVersions": {
                 "base": [
                     "5.2.9"
@@ -1938,7 +1938,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2009-2626",
-            "summary": "The zend_restore_ini_entry_cb function in zend_ini.c in PHP 5.3.0, 5.2.10, and earlier versions allows context-specific attackers to obtain sensitive information (memory contents) and cause a PHP crash by using the ini_set function to declare a variable, then using the ini_restore function to restore the variable. \nPublish Date : 2009-12-01 Last Update Date : 2009-12-19",
+            "summary": "The zend_restore_ini_entry_cb function in zend_ini.c in PHP 5.3.0, 5.2.10, and earlier versions allows context-specific attackers to obtain sensitive information (memory contents) and cause a PHP crash by using the ini_set function to declare a variable, then using the ini_restore function to restore the variable.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1956,7 +1956,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2009-2687",
-            "summary": "The exif_read_data function in the Exif module in PHP before 5.2.10 allows remote attackers to cause a denial of service (crash) via a malformed JPEG image with invalid offset fields, a different issue than CVE-2005-3353. \nPublish Date : 2009-08-05 Last Update Date : 2011-07-18",
+            "summary": "The exif_read_data function in the Exif module in PHP before 5.2.10 allows remote attackers to cause a denial of service (crash) via a malformed JPEG image with invalid offset fields, a different issue than CVE-2005-3353.",
             "fixVersions": {
                 "base": [
                     "5.2.11"
@@ -1966,7 +1966,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3291",
-            "summary": "The php_openssl_apply_verification_policy function in PHP before 5.2.11 does not properly perform certificate validation, which has unknown impact and attack vectors, probably related to an ability to spoof certificates. \nPublish Date : 2009-09-22 Last Update Date : 2011-09-06",
+            "summary": "The php_openssl_apply_verification_policy function in PHP before 5.2.11 does not properly perform certificate validation, which has unknown impact and attack vectors, probably related to an ability to spoof certificates.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1983,7 +1983,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3292",
-            "summary": "Unspecified vulnerability in PHP before 5.2.11, and 5.3.x before 5.3.1, has unknown impact and attack vectors related to \"missing sanity checks around exif processing.\" \nPublish Date : 2009-09-22 Last Update Date : 2011-09-06",
+            "summary": "Unspecified vulnerability in PHP before 5.2.11, and 5.3.x before 5.3.1, has unknown impact and attack vectors related to \"missing sanity checks around exif processing.\"",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2000,7 +2000,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3293",
-            "summary": "Unspecified vulnerability in the imagecolortransparent function in PHP before 5.2.11 has unknown impact and attack vectors related to an incorrect \"sanity check for the color index.\" \nPublish Date : 2009-09-22 Last Update Date : 2011-09-06",
+            "summary": "Unspecified vulnerability in the imagecolortransparent function in PHP before 5.2.11 has unknown impact and attack vectors related to an incorrect \"sanity check for the color index.\"",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2017,7 +2017,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-3294",
-            "summary": "The popen API function in TSRM/tsrm_win32.c in PHP before 5.2.11 and 5.3.x before 5.3.1, when running on certain Windows operating systems, allows context-dependent attackers to cause a denial of service (crash) via a crafted (1) \"e\" or (2) \"er\" string in the second argument (aka mode), possibly related to the _fdopen function in the Microsoft C runtime library. NOTE: this might not cross privilege boundaries except in rare cases in which the mode argument is accessible to an attacker outside of an application that uses the popen function. \nPublish Date : 2009-09-22 Last Update Date : 2009-11-25",
+            "summary": "The popen API function in TSRM\/tsrm_win32.c in PHP before 5.2.11 and 5.3.x before 5.3.1, when running on certain Windows operating systems, allows context-dependent attackers to cause a denial of service (crash) via a crafted (1) \"e\" or (2) \"er\" string in the second argument (aka mode), possibly related to the _fdopen function in the Microsoft C runtime library. NOTE: this might not cross privilege boundaries except in rare cases in which the mode argument is accessible to an attacker outside of an application that uses the popen function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2034,7 +2034,7 @@
         {
             "threat": "9.3",
             "cveid": "CVE-2009-3546",
-            "summary": "The _gdGetColors function in gd_gd.c in PHP 5.2.11 and 5.3.x before 5.3.1, and the GD Graphics Library 2.x, does not properly verify a certain colorsTotal structure member, which might allow remote attackers to conduct buffer overflow or buffer over-read attacks via a crafted GD file, a different vulnerability than CVE-2009-3293. NOTE: some of these details are obtained from third party information. \nPublish Date : 2009-10-19 Last Update Date : 2011-08-25",
+            "summary": "The _gdGetColors function in gd_gd.c in PHP 5.2.11 and 5.3.x before 5.3.1, and the GD Graphics Library 2.x, does not properly verify a certain colorsTotal structure member, which might allow remote attackers to conduct buffer overflow or buffer over-read attacks via a crafted GD file, a different vulnerability than CVE-2009-3293. NOTE: some of these details are obtained from third party information.",
             "fixVersions": {
                 "base": [
                     "5.2.12",
@@ -2045,7 +2045,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-3557",
-            "summary": "The tempnam function in ext/standard/file.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass safe_mode restrictions, and create files in group-writable or world-writable directories, via the dir and prefix arguments. \nPublish Date : 2009-11-23 Last Update Date : 2011-07-18",
+            "summary": "The tempnam function in ext\/standard\/file.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass safe_mode restrictions, and create files in group-writable or world-writable directories, via the dir and prefix arguments.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2063,7 +2063,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2009-3558",
-            "summary": "The posix_mkfifo function in ext/posix/posix.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass open_basedir restrictions, and create FIFO files, via the pathname and mode arguments, as demonstrated by creating a .htaccess file. \nPublish Date : 2009-11-23 Last Update Date : 2010-04-01",
+            "summary": "The posix_mkfifo function in ext\/posix\/posix.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass open_basedir restrictions, and create FIFO files, via the pathname and mode arguments, as demonstrated by creating a .htaccess file.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2081,7 +2081,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-3559",
-            "summary": "** DISPUTED ** main/streams/plain_wrapper.c in PHP 5.3.x before 5.3.1 does not recognize the safe_mode_include_dir directive, which allows context-dependent attackers to have an unknown impact by triggering the failure of PHP scripts that perform include or require operations, as demonstrated by a script that attempts to perform a require_once on a file in a standard library directory. NOTE: a reliable third party reports that this is not a vulnerability, because it results in a more restrictive security policy. \nPublish Date : 2009-11-23 Last Update Date : 2010-04-01",
+            "summary": "** DISPUTED **  main\/streams\/plain_wrapper.c in PHP 5.3.x before 5.3.1 does not recognize the safe_mode_include_dir directive, which allows context-dependent attackers to have an unknown impact by triggering the failure of PHP scripts that perform include or require operations, as demonstrated by a script that attempts to perform a require_once on a file in a standard library directory.  NOTE: a reliable third party reports that this is not a vulnerability, because it results in a more restrictive security policy.",
             "fixVersions": {
                 "base": [
                     "5.3.1"
@@ -2091,7 +2091,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-4017",
-            "summary": "PHP before 5.2.12 and 5.3.x before 5.3.1 does not restrict the number of temporary files created when handling a multipart/form-data POST request, which allows remote attackers to cause a denial of service (resource exhaustion), and makes it easier for remote attackers to exploit local file inclusion vulnerabilities, via multiple requests, related to lack of support for the max_file_uploads directive. \nPublish Date : 2009-11-23 Last Update Date : 2011-07-18",
+            "summary": "PHP before 5.2.12 and 5.3.x before 5.3.1 does not restrict the number of temporary files created when handling a multipart\/form-data POST request, which allows remote attackers to cause a denial of service (resource exhaustion), and makes it easier for remote attackers to exploit local file inclusion vulnerabilities, via multiple requests, related to lack of support for the max_file_uploads directive.",
             "fixVersions": {
                 "base": [
                     "5.2.12",
@@ -2102,7 +2102,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2009-4018",
-            "summary": "The proc_open function in ext/standard/proc_open.c in PHP before 5.2.11 and 5.3.x before 5.3.1 does not enforce the (1) safe_mode_allowed_env_vars and (2) safe_mode_protected_env_vars directives, which allows context-dependent attackers to execute programs with an arbitrary environment via the env parameter, as demonstrated by a crafted value of the LD_LIBRARY_PATH environment variable. \nPublish Date : 2009-11-29 Last Update Date : 2011-07-18",
+            "summary": "The proc_open function in ext\/standard\/proc_open.c in PHP before 5.2.11 and 5.3.x before 5.3.1 does not enforce the (1) safe_mode_allowed_env_vars and (2) safe_mode_protected_env_vars directives, which allows context-dependent attackers to execute programs with an arbitrary environment via the env parameter, as demonstrated by a crafted value of the LD_LIBRARY_PATH environment variable.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2120,7 +2120,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2009-4142",
-            "summary": "The htmlspecialchars function in PHP before 5.2.12 does not properly handle (1) overlong UTF-8 sequences, (2) invalid Shift_JIS sequences, and (3) invalid EUC-JP sequences, which allows remote attackers to conduct cross-site scripting (XSS) attacks by placing a crafted byte sequence before a special character. \nPublish Date : 2009-12-21 Last Update Date : 2011-07-18",
+            "summary": "The htmlspecialchars function in PHP before 5.2.12 does not properly handle (1) overlong UTF-8 sequences, (2) invalid Shift_JIS sequences, and (3) invalid EUC-JP sequences, which allows remote attackers to conduct cross-site scripting (XSS) attacks by placing a crafted byte sequence before a special character.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2137,7 +2137,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2009-4143",
-            "summary": "PHP before 5.2.12 does not properly handle session data, which has unspecified impact and attack vectors related to (1) interrupt corruption of the SESSION superglobal array and (2) the session.save_path directive. \nPublish Date : 2009-12-21 Last Update Date : 2011-07-18",
+            "summary": "PHP before 5.2.12 does not properly handle session data, which has unspecified impact and attack vectors related to (1) interrupt corruption of the SESSION superglobal array and (2) the session.save_path directive.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2154,7 +2154,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2009-4418",
-            "summary": "The unserialize function in PHP 5.3.0 and earlier allows context-dependent attackers to cause a denial of service (resource consumption) via a deeply nested serialized variable, as demonstrated by a string beginning with a:1: followed by many {a:1: sequences. \nPublish Date : 2009-12-24 Last Update Date : 2009-12-28",
+            "summary": "The unserialize function in PHP 5.3.0 and earlier allows context-dependent attackers to cause a denial of service (resource consumption) via a deeply nested serialized variable, as demonstrated by a string beginning with a:1: followed by many {a:1: sequences.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2167,7 +2167,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2009-5016",
-            "summary": "Integer overflow in the xml_utf8_decode function in ext/xml/xml.c in PHP before 5.2.11 makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string that uses overlong UTF-8 encoding, a different vulnerability than CVE-2010-3870. \nPublish Date : 2010-11-12 Last Update Date : 2011-02-23",
+            "summary": "Integer overflow in the xml_utf8_decode function in ext\/xml\/xml.c in PHP before 5.2.11 makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string that uses overlong UTF-8 encoding, a different vulnerability than CVE-2010-3870.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2184,7 +2184,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-0397",
-            "summary": "The xmlrpc extension in PHP 5.3.1 does not properly handle a missing methodName element in the first argument to the xmlrpc_decode_request function, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) and possibly have unspecified other impact via a crafted argument. \nPublish Date : 2010-03-16 Last Update Date : 2010-12-10",
+            "summary": "The xmlrpc extension in PHP 5.3.1 does not properly handle a missing methodName element in the first argument to the xmlrpc_decode_request function, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) and possibly have unspecified other impact via a crafted argument.",
             "fixVersions": {
                 "base": [
                     "5.3.2"
@@ -2194,7 +2194,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2010-1128",
-            "summary": "The Linear Congruential Generator (LCG) in PHP before 5.2.13 does not provide the expected entropy, which makes it easier for context-dependent attackers to guess values that were intended to be unpredictable, as demonstrated by session cookies generated by using the uniqid function. \nPublish Date : 2010-03-26 Last Update Date : 2010-12-10",
+            "summary": "The Linear Congruential Generator (LCG) in PHP before 5.2.13 does not provide the expected entropy, which makes it easier for context-dependent attackers to guess values that were intended to be unpredictable, as demonstrated by session cookies generated by using the uniqid function.",
             "fixVersions": {
                 "base": [
                     "5.2.13"
@@ -2204,7 +2204,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-1129",
-            "summary": "The safe_mode implementation in PHP before 5.2.13 does not properly handle directory pathnames that lack a trailing / (slash) character, which allows context-dependent attackers to bypass intended access restrictions via vectors related to use of the tempnam function. \nPublish Date : 2010-03-26 Last Update Date : 2010-08-31",
+            "summary": "The safe_mode implementation in PHP before 5.2.13 does not properly handle directory pathnames that lack a trailing \/ (slash) character, which allows context-dependent attackers to bypass intended access restrictions via vectors related to use of the tempnam function.",
             "fixVersions": {
                 "base": [
                     "5.2.13"
@@ -2214,7 +2214,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1130",
-            "summary": "session.c in the session extension in PHP before 5.2.13, and 5.3.1, does not properly interpret ; (semicolon) characters in the argument to the session_save_path function, which allows context-dependent attackers to bypass open_basedir and safe_mode restrictions via an argument that contains multiple ; characters in conjunction with a .. (dot dot). \nPublish Date : 2010-03-26 Last Update Date : 2010-06-08",
+            "summary": "session.c in the session extension in PHP before 5.2.13, and 5.3.1, does not properly interpret ; (semicolon) characters in the argument to the session_save_path function, which allows context-dependent attackers to bypass open_basedir and safe_mode restrictions via an argument that contains multiple ; characters in conjunction with a .. (dot dot).",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2227,7 +2227,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1860",
-            "summary": "The html_entity_decode function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal call, related to the call time pass by reference feature. \nPublish Date : 2010-05-07 Last Update Date : 2010-12-07",
+            "summary": "The html_entity_decode function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal call, related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2238,7 +2238,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2010-1861",
-            "summary": "The sysvshm extension for PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to write to arbitrary memory addresses by using an object's __sleep function to interrupt an internal call to the shm_put_var function, which triggers access of a freed resource. \nPublish Date : 2010-05-07 Last Update Date : 2010-05-10",
+            "summary": "The sysvshm extension for PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to write to arbitrary memory addresses by using an object's __sleep function to interrupt an internal call to the shm_put_var function, which triggers access of a freed resource.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2249,7 +2249,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1862",
-            "summary": "The chunk_split function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \nPublish Date : 2010-05-07 Last Update Date : 2010-12-07",
+            "summary": "The chunk_split function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2260,7 +2260,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1864",
-            "summary": "The addcslashes function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \nPublish Date : 2010-05-07 Last Update Date : 2010-12-07",
+            "summary": "The addcslashes function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2271,7 +2271,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-1866",
-            "summary": "The dechunk filter in PHP 5.3 through 5.3.2, when decoding an HTTP chunked encoding stream, allows context-dependent attackers to cause a denial of service (crash) and possibly trigger memory corruption via a negative chunk size, which bypasses a signed comparison, related to an integer overflow in the chunk size decoder. \nPublish Date : 2010-05-07 Last Update Date : 2010-09-30",
+            "summary": "The dechunk filter in PHP 5.3 through 5.3.2, when decoding an HTTP chunked encoding stream, allows context-dependent attackers to cause a denial of service (crash) and possibly trigger memory corruption via a negative chunk size, which bypasses a signed comparison, related to an integer overflow in the chunk size decoder.",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -2281,7 +2281,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-1868",
-            "summary": "The (1) sqlite_single_query and (2) sqlite_array_query functions in ext/sqlite/sqlite.c in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to execute arbitrary code by calling these functions with an empty SQL query, which triggers access of uninitialized memory. \nPublish Date : 2010-05-07 Last Update Date : 2010-05-11",
+            "summary": "The (1) sqlite_single_query and (2) sqlite_array_query functions in ext\/sqlite\/sqlite.c in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to execute arbitrary code by calling these functions with an empty SQL query, which triggers access of uninitialized memory.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2292,7 +2292,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1914",
-            "summary": "The Zend Engine in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information by interrupting the handler for the (1) ZEND_BW_XOR opcode (shift_left_function), (2) ZEND_SL opcode (bitwise_xor_function), or (3) ZEND_SR opcode (shift_right_function), related to the convert_to_long_base function. \nPublish Date : 2010-05-12 Last Update Date : 2010-12-07",
+            "summary": "The Zend Engine in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information by interrupting the handler for the (1) ZEND_BW_XOR opcode (shift_left_function), (2) ZEND_SL opcode (bitwise_xor_function), or (3) ZEND_SR opcode (shift_right_function), related to the convert_to_long_base function.",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -2303,7 +2303,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1915",
-            "summary": "The preg_quote function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature, modification of ZVALs whose values are not updated in the associated local variables, and access of previously-freed memory. \nPublish Date : 2010-05-12 Last Update Date : 2010-12-07",
+            "summary": "The preg_quote function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature, modification of ZVALs whose values are not updated in the associated local variables, and access of previously-freed memory.",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -2314,7 +2314,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-1917",
-            "summary": "Stack consumption vulnerability in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (PHP crash) via a crafted first argument to the fnmatch function, as demonstrated using a long string. \nPublish Date : 2010-05-12 Last Update Date : 2011-05-03",
+            "summary": "Stack consumption vulnerability in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (PHP crash) via a crafted first argument to the fnmatch function, as demonstrated using a long string.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2325,7 +2325,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2093",
-            "summary": "Use-after-free vulnerability in the request shutdown functionality in PHP 5.2 before 5.2.13 and 5.3 before 5.3.2 allows context-dependent attackers to cause a denial of service (crash) via a stream context structure that is freed before destruction occurs. \nPublish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "summary": "Use-after-free vulnerability in the request shutdown functionality in PHP 5.2 before 5.2.13 and 5.3 before 5.3.2 allows context-dependent attackers to cause a denial of service (crash) via a stream context structure that is freed before destruction occurs.",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -2336,7 +2336,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-2094",
-            "summary": "Multiple format string vulnerabilities in the phar extension in PHP 5.3 before 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:// URI that is not properly handled by the (1) phar_stream_flush, (2) phar_wrapper_unlink, (3) phar_parse_url, or (4) phar_wrapper_open_url functions in ext/phar/stream.c; and the (5) phar_wrapper_open_dir function in ext/phar/dirstream.c, which triggers errors in the php_stream_wrapper_log_error function. \nPublish Date : 2010-05-27 Last Update Date : 2011-01-26",
+            "summary": "Multiple format string vulnerabilities in the phar extension in PHP 5.3 before 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the (1) phar_stream_flush, (2) phar_wrapper_unlink, (3) phar_parse_url, or (4) phar_wrapper_open_url functions in ext\/phar\/stream.c; and the (5) phar_wrapper_open_dir function in ext\/phar\/dirstream.c, which triggers errors in the php_stream_wrapper_log_error function.",
             "fixVersions": {
                 "base": [
                     "5.3.2"
@@ -2346,7 +2346,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2097",
-            "summary": "The (1) iconv_mime_decode, (2) iconv_substr, and (3) iconv_mime_encode functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \nPublish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "summary": "The (1) iconv_mime_decode, (2) iconv_substr, and (3) iconv_mime_encode functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2357,7 +2357,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2100",
-            "summary": "The (1) htmlentities, (2) htmlspecialchars, (3) str_getcsv, (4) http_build_query, (5) strpbrk, and (6) strtr functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \nPublish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "summary": "The (1) htmlentities, (2) htmlspecialchars, (3) str_getcsv, (4) http_build_query, (5) strpbrk, and (6) strtr functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2368,7 +2368,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2101",
-            "summary": "The (1) strip_tags, (2) setcookie, (3) strtok, (4) wordwrap, (5) str_word_count, and (6) str_pad functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \nPublish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "summary": "The (1) strip_tags, (2) setcookie, (3) strtok, (4) wordwrap, (5) str_word_count, and (6) str_pad functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2379,7 +2379,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2190",
-            "summary": "The (1) trim, (2) ltrim, (3) rtrim, and (4) substr_replace functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \nPublish Date : 2010-06-07 Last Update Date : 2010-12-07",
+            "summary": "The (1) trim, (2) ltrim, (3) rtrim, and (4) substr_replace functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2390,7 +2390,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2010-2191",
-            "summary": "The (1) parse_str, (2) preg_match, (3) unpack, and (4) pack functions; the (5) ZEND_FETCH_RW, (6) ZEND_CONCAT, and (7) ZEND_ASSIGN_CONCAT opcodes; and the (8) ArrayObject::uasort method in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler. NOTE: vectors 2 through 4 are related to the call time pass by reference feature. \nPublish Date : 2010-06-07 Last Update Date : 2010-12-07",
+            "summary": "The (1) parse_str, (2) preg_match, (3) unpack, and (4) pack functions; the (5) ZEND_FETCH_RW, (6) ZEND_CONCAT, and (7) ZEND_ASSIGN_CONCAT opcodes; and the (8) ArrayObject::uasort method in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.  NOTE: vectors 2 through 4 are related to the call time pass by reference feature.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2401,7 +2401,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2010-2225",
-            "summary": "Use-after-free vulnerability in the SplObjectStorage unserializer in PHP 5.2.x and 5.3.x through 5.3.2 allows remote attackers to execute arbitrary code or obtain sensitive information via serialized data, related to the PHP unserialize function. \nPublish Date : 2010-06-24 Last Update Date : 2010-12-07",
+            "summary": "Use-after-free vulnerability in the SplObjectStorage unserializer in PHP 5.2.x and 5.3.x through 5.3.2 allows remote attackers to execute arbitrary code or obtain sensitive information via serialized data, related to the PHP unserialize function.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2412,7 +2412,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-2484",
-            "summary": "The strrchr function in PHP 5.2 before 5.2.14 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler. \nPublish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "summary": "The strrchr function in PHP 5.2 before 5.2.14 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.",
             "fixVersions": {
                 "base": [
                     "5.2.14"
@@ -2422,7 +2422,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2010-2531",
-            "summary": "The var_export function in PHP 5.2 before 5.2.14 and 5.3 before 5.3.3 flushes the output buffer to the user when certain fatal errors occur, even if display_errors is off, which allows remote attackers to obtain sensitive information by causing the application to exceed limits for memory, execution time, or recursion. \nPublish Date : 2010-08-20 Last Update Date : 2011-08-26",
+            "summary": "The var_export function in PHP 5.2 before 5.2.14 and 5.3 before 5.3.3 flushes the output buffer to the user when certain fatal errors occur, even if display_errors is off, which allows remote attackers to obtain sensitive information by causing the application to exceed limits for memory, execution time, or recursion.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2433,7 +2433,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-2950",
-            "summary": "Format string vulnerability in stream.c in the phar extension in PHP 5.3.x through 5.3.3 allows context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:// URI that is not properly handled by the phar_stream_flush function, leading to errors in the php_stream_wrapper_log_error function. NOTE: this vulnerability exists because of an incomplete fix for CVE-2010-2094. \nPublish Date : 2010-09-28 Last Update Date : 2011-05-03",
+            "summary": "Format string vulnerability in stream.c in the phar extension in PHP 5.3.x through 5.3.3 allows context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the phar_stream_flush function, leading to errors in the php_stream_wrapper_log_error function.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2010-2094.",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -2443,7 +2443,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3062",
-            "summary": "mysqlnd_wireprotocol.c in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows remote attackers to (1) read sensitive memory via a modified length value, which is not properly handled by the php_mysqlnd_ok_read function; or (2) trigger a heap-based buffer overflow via a modified length value, which is not properly handled by the php_mysqlnd_rset_header_read function. \nPublish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "summary": "mysqlnd_wireprotocol.c in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows remote attackers to (1) read sensitive memory via a modified length value, which is not properly handled by the php_mysqlnd_ok_read function; or (2) trigger a heap-based buffer overflow via a modified length value, which is not properly handled by the php_mysqlnd_rset_header_read function.",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -2453,7 +2453,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3063",
-            "summary": "The php_mysqlnd_read_error_from_line function in the Mysqlnd extension in PHP 5.3 through 5.3.2 does not properly calculate a buffer length, which allows context-dependent attackers to trigger a heap-based buffer overflow via crafted inputs that cause a negative length value to be used. \nPublish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "summary": "The php_mysqlnd_read_error_from_line function in the Mysqlnd extension in PHP 5.3 through 5.3.2 does not properly calculate a buffer length, which allows context-dependent attackers to trigger a heap-based buffer overflow via crafted inputs that cause a negative length value to be used.",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -2463,7 +2463,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-3064",
-            "summary": "Stack-based buffer overflow in the php_mysqlnd_auth_write function in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long (1) username or (2) database name argument to the (a) mysql_connect or (b) mysqli_connect function. \nPublish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "summary": "Stack-based buffer overflow in the php_mysqlnd_auth_write function in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long (1) username or (2) database name argument to the (a) mysql_connect or (b) mysqli_connect function.",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -2473,7 +2473,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3065",
-            "summary": "The default session serializer in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 does not properly handle the PS_UNDEF_MARKER marker, which allows context-dependent attackers to modify arbitrary session variables via a crafted session variable name. \nPublish Date : 2010-08-20 Last Update Date : 2010-12-10",
+            "summary": "The default session serializer in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 does not properly handle the PS_UNDEF_MARKER marker, which allows context-dependent attackers to modify arbitrary session variables via a crafted session variable name.",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -2484,7 +2484,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-3436",
-            "summary": "fopen_wrappers.c in PHP 5.3.x through 5.3.3 might allow remote attackers to bypass open_basedir restrictions via vectors related to the length of a filename. \nPublish Date : 2010-11-08 Last Update Date : 2011-10-20",
+            "summary": "fopen_wrappers.c in PHP 5.3.x through 5.3.3 might allow remote attackers to bypass open_basedir restrictions via vectors related to the length of a filename.",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -2494,7 +2494,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2010-3709",
-            "summary": "The ZipArchive::getArchiveComment function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3 allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted ZIP archive. \nPublish Date : 2010-11-08 Last Update Date : 2011-05-03",
+            "summary": "The ZipArchive::getArchiveComment function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3 allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted ZIP archive.",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -2505,7 +2505,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2010-3710",
-            "summary": "Stack consumption vulnerability in the filter_var function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3, when FILTER_VALIDATE_EMAIL mode is used, allows remote attackers to cause a denial of service (memory consumption and application crash) via a long e-mail address string. \nPublish Date : 2010-10-25 Last Update Date : 2011-03-23",
+            "summary": "Stack consumption vulnerability in the filter_var function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3, when FILTER_VALIDATE_EMAIL mode is used, allows remote attackers to cause a denial of service (memory consumption and application crash) via a long e-mail address string.",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -2516,7 +2516,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-3870",
-            "summary": "The utf8_decode function in PHP before 5.3.4 does not properly handle non-shortest form UTF-8 encoding and ill-formed subsequences in UTF-8 data, which makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string. \nPublish Date : 2010-11-12 Last Update Date : 2011-03-23",
+            "summary": "The utf8_decode function in PHP before 5.3.4 does not properly handle non-shortest form UTF-8 encoding and ill-formed subsequences in UTF-8 data, which makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2534,7 +2534,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4150",
-            "summary": "Double free vulnerability in the imap_do_open function in the IMAP extension (ext/imap/php_imap.c) in PHP 5.2 before 5.2.15 and 5.3 before 5.3.4 allows attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via unspecified vectors. \nPublish Date : 2010-12-07 Last Update Date : 2011-07-18",
+            "summary": "Double free vulnerability in the imap_do_open function in the IMAP extension (ext\/imap\/php_imap.c) in PHP 5.2 before 5.2.15 and 5.3 before 5.3.4 allows attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via unspecified vectors.",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -2545,7 +2545,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4409",
-            "summary": "Integer overflow in the NumberFormatter::getSymbol (aka numfmt_get_symbol) function in PHP 5.3.3 and earlier allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument. \nPublish Date : 2010-12-06 Last Update Date : 2012-06-22",
+            "summary": "Integer overflow in the NumberFormatter::getSymbol (aka numfmt_get_symbol) function in PHP 5.3.3 and earlier allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2560,7 +2560,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4645",
-            "summary": "strtod.c, as used in the zend_strtod function in PHP 5.2 before 5.2.17 and 5.3 before 5.3.5, and other products, allows context-dependent attackers to cause a denial of service (infinite loop) via a certain floating-point value in scientific notation, which is not properly handled in x87 FPU registers, as demonstrated using 2.2250738585072011e-308. \nPublish Date : 2011-01-10 Last Update Date : 2012-08-13",
+            "summary": "strtod.c, as used in the zend_strtod function in PHP 5.2 before 5.2.17 and 5.3 before 5.3.5, and other products, allows context-dependent attackers to cause a denial of service (infinite loop) via a certain floating-point value in scientific notation, which is not properly handled in x87 FPU registers, as demonstrated using 2.2250738585072011e-308.",
             "fixVersions": {
                 "base": [
                     "5.2.17",
@@ -2571,7 +2571,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-4697",
-            "summary": "Use-after-free vulnerability in the Zend engine in PHP before 5.2.15 and 5.3.x before 5.3.4 might allow context-dependent attackers to cause a denial of service (heap memory corruption) or have unspecified other impact via vectors related to use of __set, __get, __isset, and __unset methods on objects accessed by a reference. \nPublish Date : 2011-01-18 Last Update Date : 2011-07-18",
+            "summary": "Use-after-free vulnerability in the Zend engine in PHP before 5.2.15 and 5.3.x before 5.3.4 might allow context-dependent attackers to cause a denial of service (heap memory corruption) or have unspecified other impact via vectors related to use of __set, __get, __isset, and __unset methods on objects accessed by a reference.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2589,7 +2589,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4698",
-            "summary": "Stack-based buffer overflow in the GD extension in PHP before 5.2.15 and 5.3.x before 5.3.4 allows context-dependent attackers to cause a denial of service (application crash) via a large number of anti-aliasing steps in an argument to the imagepstext function. \nPublish Date : 2011-01-18 Last Update Date : 2011-08-01",
+            "summary": "Stack-based buffer overflow in the GD extension in PHP before 5.2.15 and 5.3.x before 5.3.4 allows context-dependent attackers to cause a denial of service (application crash) via a large number of anti-aliasing steps in an argument to the imagepstext function.",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -2600,7 +2600,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2010-4699",
-            "summary": "The iconv_mime_decode_headers function in the Iconv extension in PHP before 5.3.4 does not properly handle encodings that are unrecognized by the iconv and mbstring (aka Multibyte String) implementations, which allows remote attackers to trigger an incomplete output array, and possibly bypass spam detection or have unspecified other impact, via a crafted Subject header in an e-mail message, as demonstrated by the ks_c_5601-1987 character set. \nPublish Date : 2011-01-18 Last Update Date : 2011-07-18",
+            "summary": "The iconv_mime_decode_headers function in the Iconv extension in PHP before 5.3.4 does not properly handle encodings that are unrecognized by the iconv and mbstring (aka Multibyte String) implementations, which allows remote attackers to trigger an incomplete output array, and possibly bypass spam detection or have unspecified other impact, via a crafted Subject header in an e-mail message, as demonstrated by the ks_c_5601-1987 character set.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2618,7 +2618,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2010-4700",
-            "summary": "The set_magic_quotes_runtime function in PHP 5.3.2 and 5.3.3, when the MySQLi extension is used, does not properly interact with use of the mysqli_fetch_assoc function, which might make it easier for context-dependent attackers to conduct SQL injection attacks via crafted input that had been properly handled in earlier PHP versions. \nPublish Date : 2011-01-18 Last Update Date : 2011-07-18",
+            "summary": "The set_magic_quotes_runtime function in PHP 5.3.2 and 5.3.3, when the MySQLi extension is used, does not properly interact with use of the mysqli_fetch_assoc function, which might make it easier for context-dependent attackers to conduct SQL injection attacks via crafted input that had been properly handled in earlier PHP versions.",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -2628,7 +2628,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-0420",
-            "summary": "The grapheme_extract function in the Internationalization extension (Intl) for ICU for PHP 5.3.5 allows context-dependent attackers to cause a denial of service (crash) via an invalid size argument, which triggers a NULL pointer dereference. \nPublish Date : 2011-02-18 Last Update Date : 2013-09-07",
+            "summary": "The grapheme_extract function in the Internationalization extension (Intl) for ICU for PHP 5.3.5 allows context-dependent attackers to cause a denial of service (crash) via an invalid size argument, which triggers a NULL pointer dereference.",
             "fixVersions": {
                 "base": [
                     "5.3.6"
@@ -2638,7 +2638,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-0421",
-            "summary": "The _zip_name_locate function in zip_name_locate.c in the Zip extension in PHP before 5.3.6 does not properly handle a ZIPARCHIVE::FL_UNCHANGED argument, which might allow context-dependent attackers to cause a denial of service (NULL pointer dereference) via an empty ZIP archive that is processed with a (1) locateName or (2) statName operation. \nPublish Date : 2011-03-19 Last Update Date : 2014-02-20",
+            "summary": "The _zip_name_locate function in zip_name_locate.c in the Zip extension in PHP before 5.3.6 does not properly handle a ZIPARCHIVE::FL_UNCHANGED argument, which might allow context-dependent attackers to cause a denial of service (NULL pointer dereference) via an empty ZIP archive that is processed with a (1) locateName or (2) statName operation.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2656,7 +2656,7 @@
         {
             "threat": "6.3",
             "cveid": "CVE-2011-0441",
-            "summary": "The Debian GNU/Linux /etc/cron.d/php5 cron job for PHP 5.3.5 allows local users to delete arbitrary files via a symlink attack on a directory under /var/lib/php5/. \nPublish Date : 2011-03-29 Last Update Date : 2011-04-20",
+            "summary": "The Debian GNU\/Linux \/etc\/cron.d\/php5 cron job for PHP 5.3.5 allows local users to delete arbitrary files via a symlink attack on a directory under \/var\/lib\/php5\/.",
             "fixVersions": {
                 "base": [
                     "5.3.6"
@@ -2666,7 +2666,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-0708",
-            "summary": "exif.c in the Exif extension in PHP before 5.3.6 on 64-bit platforms performs an incorrect cast, which allows remote attackers to cause a denial of service (application crash) via an image with a crafted Image File Directory (IFD) that triggers a buffer over-read. \nPublish Date : 2011-03-19 Last Update Date : 2012-11-05",
+            "summary": "exif.c in the Exif extension in PHP before 5.3.6 on 64-bit platforms performs an incorrect cast, which allows remote attackers to cause a denial of service (application crash) via an image with a crafted Image File Directory (IFD) that triggers a buffer over-read.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2684,7 +2684,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-0752",
-            "summary": "The extract function in PHP before 5.2.15 does not prevent use of the EXTR_OVERWRITE parameter to overwrite (1) the GLOBALS superglobal array and (2) the this variable, which allows context-dependent attackers to bypass intended access restrictions by modifying data structures that were not intended to depend on external input, a related issue to CVE-2005-2691 and CVE-2006-3758. \nPublish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "summary": "The extract function in PHP before 5.2.15 does not prevent use of the EXTR_OVERWRITE parameter to overwrite (1) the GLOBALS superglobal array and (2) the this variable, which allows context-dependent attackers to bypass intended access restrictions by modifying data structures that were not intended to depend on external input, a related issue to CVE-2005-2691 and CVE-2006-3758.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2701,7 +2701,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-0753",
-            "summary": "Race condition in the PCNTL extension in PHP before 5.3.4, when a user-defined signal handler exists, might allow context-dependent attackers to cause a denial of service (memory corruption) via a large number of concurrent signals. \nPublish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "summary": "Race condition in the PCNTL extension in PHP before 5.3.4, when a user-defined signal handler exists, might allow context-dependent attackers to cause a denial of service (memory corruption) via a large number of concurrent signals.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2716,7 +2716,7 @@
         {
             "threat": "4.4",
             "cveid": "CVE-2011-0754",
-            "summary": "The SplFileInfo::getType function in the Standard PHP Library (SPL) extension in PHP before 5.3.4 on Windows does not properly detect symbolic links, which might make it easier for local users to conduct symlink attacks by leveraging cross-platform differences in the stat structure, related to lack of a FILE_ATTRIBUTE_REPARSE_POINT check. \nPublish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "summary": "The SplFileInfo::getType function in the Standard PHP Library (SPL) extension in PHP before 5.3.4 on Windows does not properly detect symbolic links, which might make it easier for local users to conduct symlink attacks by leveraging cross-platform differences in the stat structure, related to lack of a FILE_ATTRIBUTE_REPARSE_POINT check.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2731,7 +2731,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-0755",
-            "summary": "Integer overflow in the mt_rand function in PHP before 5.3.4 might make it easier for context-dependent attackers to predict the return values by leveraging a script's use of a large max parameter, as demonstrated by a value that exceeds mt_getrandmax. \nPublish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "summary": "Integer overflow in the mt_rand function in PHP before 5.3.4 might make it easier for context-dependent attackers to predict the return values by leveraging a script's use of a large max parameter, as demonstrated by a value that exceeds mt_getrandmax.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2749,7 +2749,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1092",
-            "summary": "Integer overflow in ext/shmop/shmop.c in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (crash) and possibly read sensitive memory via a large third argument to the shmop_read function. \nPublish Date : 2011-03-15 Last Update Date : 2011-10-20",
+            "summary": "Integer overflow in ext\/shmop\/shmop.c in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (crash) and possibly read sensitive memory via a large third argument to the shmop_read function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2767,7 +2767,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1148",
-            "summary": "Use-after-free vulnerability in the substr_replace function in PHP 5.3.6 and earlier allows context-dependent attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact by using the same variable for multiple arguments. \nPublish Date : 2011-03-18 Last Update Date : 2012-02-03",
+            "summary": "Use-after-free vulnerability in the substr_replace function in PHP 5.3.6 and earlier allows context-dependent attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact by using the same variable for multiple arguments.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2782,7 +2782,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1153",
-            "summary": "Multiple format string vulnerabilities in phar_object.c in the phar extension in PHP 5.3.5 and earlier allow context-dependent attackers to obtain sensitive information from process memory, cause a denial of service (memory corruption), or possibly execute arbitrary code via format string specifiers in an argument to a class method, leading to an incorrect zend_throw_exception_ex call. \nPublish Date : 2011-03-16 Last Update Date : 2011-10-20",
+            "summary": "Multiple format string vulnerabilities in phar_object.c in the phar extension in PHP 5.3.5 and earlier allow context-dependent attackers to obtain sensitive information from process memory, cause a denial of service (memory corruption), or possibly execute arbitrary code via format string specifiers in an argument to a class method, leading to an incorrect zend_throw_exception_ex call.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2800,7 +2800,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1398",
-            "summary": "The sapi_header_op function in main/SAPI.c in PHP before 5.3.11 and 5.4.x before 5.4.0RC2 does not check for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome. \nPublish Date : 2012-08-30 Last Update Date : 2013-10-10",
+            "summary": "The sapi_header_op function in main\/SAPI.c in PHP before 5.3.11 and 5.4.x before 5.4.0RC2 does not check for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.",
             "fixVersions": {
                 "base": [
                     "5.3.11"
@@ -2810,7 +2810,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1464",
-            "summary": "Buffer overflow in the strval function in PHP before 5.3.6, when the precision configuration option has a large value, might allow context-dependent attackers to cause a denial of service (application crash) via a small numerical value in the argument. \nPublish Date : 2011-03-19 Last Update Date : 2011-04-08",
+            "summary": "Buffer overflow in the strval function in PHP before 5.3.6, when the precision configuration option has a large value, might allow context-dependent attackers to cause a denial of service (application crash) via a small numerical value in the argument.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2828,7 +2828,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-1466",
-            "summary": "Integer overflow in the SdnToJulian function in the Calendar extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a large integer in the first argument to the cal_from_jd function. \nPublish Date : 2011-03-19 Last Update Date : 2012-11-05",
+            "summary": "Integer overflow in the SdnToJulian function in the Calendar extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a large integer in the first argument to the cal_from_jd function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2846,7 +2846,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-1467",
-            "summary": "Unspecified vulnerability in the NumberFormatter::setSymbol (aka numfmt_set_symbol) function in the Intl extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument, a related issue to CVE-2010-4409. \nPublish Date : 2011-03-19 Last Update Date : 2011-10-20",
+            "summary": "Unspecified vulnerability in the NumberFormatter::setSymbol (aka numfmt_set_symbol) function in the Intl extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument, a related issue to CVE-2010-4409.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2864,7 +2864,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1468",
-            "summary": "Multiple memory leaks in the OpenSSL extension in PHP before 5.3.6 might allow remote attackers to cause a denial of service (memory consumption) via (1) plaintext data to the openssl_encrypt function or (2) ciphertext data to the openssl_decrypt function. \nPublish Date : 2011-03-19 Last Update Date : 2012-01-18",
+            "summary": "Multiple memory leaks in the OpenSSL extension in PHP before 5.3.6 might allow remote attackers to cause a denial of service (memory consumption) via (1) plaintext data to the openssl_encrypt function or (2) ciphertext data to the openssl_decrypt function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2882,7 +2882,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1469",
-            "summary": "Unspecified vulnerability in the Streams component in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) by accessing an ftp:// URL during use of an HTTP proxy with the FTP wrapper. \nPublish Date : 2011-03-19 Last Update Date : 2012-01-18",
+            "summary": "Unspecified vulnerability in the Streams component in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) by accessing an ftp:\/\/ URL during use of an HTTP proxy with the FTP wrapper.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2900,7 +2900,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1470",
-            "summary": "The Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a ziparchive stream that is not properly handled by the stream_get_contents function. \nPublish Date : 2011-03-19 Last Update Date : 2011-10-20",
+            "summary": "The Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a ziparchive stream that is not properly handled by the stream_get_contents function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2918,7 +2918,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-1471",
-            "summary": "Integer signedness error in zip_stream.c in the Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (CPU consumption) via a malformed archive file that triggers errors in zip_fread function calls. \nPublish Date : 2011-03-19 Last Update Date : 2013-08-31",
+            "summary": "Integer signedness error in zip_stream.c in the Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (CPU consumption) via a malformed archive file that triggers errors in zip_fread function calls.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2933,7 +2933,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-1657",
-            "summary": "The (1) ZipArchive::addGlob and (2) ZipArchive::addPattern functions in ext/zip/php_zip.c in PHP 5.3.6 allow context-dependent attackers to cause a denial of service (application crash) via certain flags arguments, as demonstrated by (a) GLOB_ALTDIRFUNC and (b) GLOB_APPEND. \nPublish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "summary": "The (1) ZipArchive::addGlob and (2) ZipArchive::addPattern functions in ext\/zip\/php_zip.c in PHP 5.3.6 allow context-dependent attackers to cause a denial of service (application crash) via certain flags arguments, as demonstrated by (a) GLOB_ALTDIRFUNC and (b) GLOB_APPEND.",
             "fixVersions": {
                 "base": [
                     "5.3.7"
@@ -2943,7 +2943,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-1938",
-            "summary": "Stack-based buffer overflow in the socket_connect function in ext/sockets/sockets.c in PHP 5.3.3 through 5.3.6 might allow context-dependent attackers to execute arbitrary code via a long pathname for a UNIX socket. \nPublish Date : 2011-05-31 Last Update Date : 2012-02-08",
+            "summary": "Stack-based buffer overflow in the socket_connect function in ext\/sockets\/sockets.c in PHP 5.3.3 through 5.3.6 might allow context-dependent attackers to execute arbitrary code via a long pathname for a UNIX socket.",
             "fixVersions": {
                 "base": [
                     "5.3.7"
@@ -2953,7 +2953,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2011-2202",
-            "summary": "The rfc1867_post_handler function in main/rfc1867.c in PHP before 5.3.7 does not properly restrict filenames in multipart/form-data POST requests, which allows remote attackers to conduct absolute path traversal attacks, and possibly create or overwrite arbitrary files, via a crafted upload request, related to a \"file path injection vulnerability.\" \nPublish Date : 2011-06-16 Last Update Date : 2012-11-05",
+            "summary": "The rfc1867_post_handler function in main\/rfc1867.c in PHP before 5.3.7 does not properly restrict filenames in multipart\/form-data POST requests, which allows remote attackers to conduct absolute path traversal attacks, and possibly create or overwrite arbitrary files, via a crafted upload request, related to a \"file path injection vulnerability.\"",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2968,7 +2968,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-2483",
-            "summary": "crypt_blowfish before 1.1, as used in PHP before 5.3.7 on certain platforms, PostgreSQL before 8.4.9, and other products, does not properly handle 8-bit characters, which makes it easier for context-dependent attackers to determine a cleartext password by leveraging knowledge of a password hash. \nPublish Date : 2011-08-25 Last Update Date : 2012-02-08",
+            "summary": "crypt_blowfish before 1.1, as used in PHP before 5.3.7 on certain platforms, PostgreSQL before 8.4.9, and other products, does not properly handle 8-bit characters, which makes it easier for context-dependent attackers to determine a cleartext password by leveraging knowledge of a password hash.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2986,7 +2986,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-3182",
-            "summary": "PHP before 5.3.7 does not properly check the return values of the malloc, calloc, and realloc library functions, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger a buffer overflow by leveraging the ability to provide an arbitrary value for a function argument, related to (1) ext/curl/interface.c, (2) ext/date/lib/parse_date.c, (3) ext/date/lib/parse_iso_intervals.c, (4) ext/date/lib/parse_tz.c, (5) ext/date/lib/timelib.c, (6) ext/pdo_odbc/pdo_odbc.c, (7) ext/reflection/php_reflection.c, (8) ext/soap/php_sdl.c, (9) ext/xmlrpc/libxmlrpc/base64.c, (10) TSRM/tsrm_win32.c, and (11) the strtotime function. \nPublish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "summary": "PHP before 5.3.7 does not properly check the return values of the malloc, calloc, and realloc library functions, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger a buffer overflow by leveraging the ability to provide an arbitrary value for a function argument, related to (1) ext\/curl\/interface.c, (2) ext\/date\/lib\/parse_date.c, (3) ext\/date\/lib\/parse_iso_intervals.c, (4) ext\/date\/lib\/parse_tz.c, (5) ext\/date\/lib\/timelib.c, (6) ext\/pdo_odbc\/pdo_odbc.c, (7) ext\/reflection\/php_reflection.c, (8) ext\/soap\/php_sdl.c, (9) ext\/xmlrpc\/libxmlrpc\/base64.c, (10) TSRM\/tsrm_win32.c, and (11) the strtotime function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3004,7 +3004,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2011-3189",
-            "summary": "The crypt function in PHP 5.3.7, when the MD5 hash type is used, returns the value of the salt argument instead of the hashed string, which might allow remote attackers to bypass authentication via an arbitrary password, a different vulnerability than CVE-2011-2483. \nPublish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "summary": "The crypt function in PHP 5.3.7, when the MD5 hash type is used, returns the value of the salt argument instead of the hashed string, which might allow remote attackers to bypass authentication via an arbitrary password, a different vulnerability than CVE-2011-2483.",
             "fixVersions": {
                 "base": [
                     "5.3.8"
@@ -3014,7 +3014,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-3267",
-            "summary": "PHP before 5.3.7 does not properly implement the error_log function, which allows context-dependent attackers to cause a denial of service (application crash) via unspecified vectors. \nPublish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "summary": "PHP before 5.3.7 does not properly implement the error_log function, which allows context-dependent attackers to cause a denial of service (application crash) via unspecified vectors.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3032,7 +3032,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2011-3268",
-            "summary": "Buffer overflow in the crypt function in PHP before 5.3.7 allows context-dependent attackers to have an unspecified impact via a long salt argument, a different vulnerability than CVE-2011-2483. \nPublish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "summary": "Buffer overflow in the crypt function in PHP before 5.3.7 allows context-dependent attackers to have an unspecified impact via a long salt argument, a different vulnerability than CVE-2011-2483.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3050,7 +3050,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2011-3379",
-            "summary": "The is_a function in PHP 5.3.7 and 5.3.8 triggers a call to the __autoload function, which makes it easier for remote attackers to execute arbitrary code by providing a crafted URL and leveraging potentially unsafe behavior in certain PEAR packages and custom autoloaders. \nPublish Date : 2011-11-03 Last Update Date : 2012-07-03",
+            "summary": "The is_a function in PHP 5.3.7 and 5.3.8 triggers a call to the __autoload function, which makes it easier for remote attackers to execute arbitrary code by providing a crafted URL and leveraging potentially unsafe behavior in certain PEAR packages and custom autoloaders.",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3060,7 +3060,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-4153",
-            "summary": "PHP 5.3.8 does not always check the return value of the zend_strndup function, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that performs strndup operations on untrusted string data, as demonstrated by the define function in zend_builtin_functions.c, and unspecified functions in ext/soap/php_sdl.c, ext/standard/syslog.c, ext/standard/browscap.c, ext/oci8/oci8.c, ext/com_dotnet/com_typeinfo.c, and main/php_open_temporary_file.c. \nPublish Date : 2012-01-18 Last Update Date : 2012-07-21",
+            "summary": "PHP 5.3.8 does not always check the return value of the zend_strndup function, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that performs strndup operations on untrusted string data, as demonstrated by the define function in zend_builtin_functions.c, and unspecified functions in ext\/soap\/php_sdl.c, ext\/standard\/syslog.c, ext\/standard\/browscap.c, ext\/oci8\/oci8.c, ext\/com_dotnet\/com_typeinfo.c, and main\/php_open_temporary_file.c.",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3070,7 +3070,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2011-4566",
-            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in the exif extension in PHP 5.4.0beta2 on 32-bit platforms allows remote attackers to read the contents of arbitrary memory locations or cause a denial of service via a crafted offset_val value in an EXIF header in a JPEG file, a different vulnerability than CVE-2011-0708. \nPublish Date : 2011-11-28 Last Update Date : 2012-11-06",
+            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in the exif extension in PHP 5.4.0beta2 on 32-bit platforms allows remote attackers to read the contents of arbitrary memory locations or cause a denial of service via a crafted offset_val value in an EXIF header in a JPEG file, a different vulnerability than CVE-2011-0708.",
             "fixVersions": {
                 "base": [
                     "5.4.1"
@@ -3080,7 +3080,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2011-4718",
-            "summary": "Session fixation vulnerability in the Sessions subsystem in PHP before 5.5.2 allows remote attackers to hijack web sessions by specifying a session ID. \nPublish Date : 2013-08-13 Last Update Date : 2013-08-13",
+            "summary": "Session fixation vulnerability in the Sessions subsystem in PHP before 5.5.2 allows remote attackers to hijack web sessions by specifying a session ID.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3095,7 +3095,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2011-4885",
-            "summary": "PHP before 5.3.9 computes hash values for form parameters without restricting the ability to trigger hash collisions predictably, which allows remote attackers to cause a denial of service (CPU consumption) by sending many crafted parameters. \nPublish Date : 2011-12-29 Last Update Date : 2013-10-10",
+            "summary": "PHP before 5.3.9 computes hash values for form parameters without restricting the ability to trigger hash collisions predictably, which allows remote attackers to cause a denial of service (CPU consumption) by sending many crafted parameters.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3108,7 +3108,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2012-0057",
-            "summary": "PHP before 5.3.9 has improper libxslt security settings, which allows remote attackers to create arbitrary files via a crafted XSLT stylesheet that uses the libxslt output extension. \nPublish Date : 2012-02-01 Last Update Date : 2012-07-03",
+            "summary": "PHP before 5.3.9 has improper libxslt security settings, which allows remote attackers to create arbitrary files via a crafted XSLT stylesheet that uses the libxslt output extension.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3121,7 +3121,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-0781",
-            "summary": "The tidy_diagnose function in PHP 5.3.8 might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that attempts to perform Tidy::diagnose operations on invalid objects, a different vulnerability than CVE-2011-4153. \nPublish Date : 2012-01-18 Last Update Date : 2012-06-27",
+            "summary": "The tidy_diagnose function in PHP 5.3.8 might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that attempts to perform Tidy::diagnose operations on invalid objects, a different vulnerability than CVE-2011-4153.",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3131,7 +3131,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-0788",
-            "summary": "The PDORow implementation in PHP before 5.3.9 does not properly interact with the session feature, which allows remote attackers to cause a denial of service (application crash) via a crafted application that uses a PDO driver for a fetch and then calls the session_start function, as demonstrated by a crash of the Apache HTTP Server. \nPublish Date : 2012-02-14 Last Update Date : 2012-06-27",
+            "summary": "The PDORow implementation in PHP before 5.3.9 does not properly interact with the session feature, which allows remote attackers to cause a denial of service (application crash) via a crafted application that uses a PDO driver for a fetch and then calls the session_start function, as demonstrated by a crash of the Apache HTTP Server.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3144,7 +3144,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-0789",
-            "summary": "Memory leak in the timezone functionality in PHP before 5.3.9 allows remote attackers to cause a denial of service (memory consumption) by triggering many strtotime function calls, which are not properly handled by the php_date_parse_tzfile cache. \nPublish Date : 2012-02-14 Last Update Date : 2012-06-27",
+            "summary": "Memory leak in the timezone functionality in PHP before 5.3.9 allows remote attackers to cause a denial of service (memory consumption) by triggering many strtotime function calls, which are not properly handled by the php_date_parse_tzfile cache.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3157,7 +3157,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-0830",
-            "summary": "The php_register_variable_ex function in php_variables.c in PHP 5.3.9 allows remote attackers to execute arbitrary code via a request containing a large number of variables, related to improper handling of array variables. NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-4885. \nPublish Date : 2012-02-06 Last Update Date : 2012-07-21",
+            "summary": "The php_register_variable_ex function in php_variables.c in PHP 5.3.9 allows remote attackers to execute arbitrary code via a request containing a large number of variables, related to improper handling of array variables.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-4885.",
             "fixVersions": {
                 "base": [
                     "5.3.10"
@@ -3167,7 +3167,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2012-0831",
-            "summary": "PHP before 5.3.10 does not properly perform a temporary change to the magic_quotes_gpc directive during the importing of environment variables, which makes it easier for remote attackers to conduct SQL injection attacks via a crafted request, related to main/php_variables.c, sapi/cgi/cgi_main.c, and sapi/fpm/fpm/fpm_main.c. \nPublish Date : 2012-02-10 Last Update Date : 2013-10-10",
+            "summary": "PHP before 5.3.10 does not properly perform a temporary change to the magic_quotes_gpc directive during the importing of environment variables, which makes it easier for remote attackers to conduct SQL injection attacks via a crafted request, related to main\/php_variables.c, sapi\/cgi\/cgi_main.c, and sapi\/fpm\/fpm\/fpm_main.c.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3185,7 +3185,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-1171",
-            "summary": "The libxml RSHUTDOWN function in PHP 5.x allows remote attackers to bypass the open_basedir protection mechanism and read arbitrary files via vectors involving a stream_close method call during use of a custom stream wrapper. \nPublish Date : 2014-02-15 Last Update Date : 2014-02-18",
+            "summary": "The libxml RSHUTDOWN function in PHP 5.x allows remote attackers to bypass the open_basedir protection mechanism and read arbitrary files via vectors involving a stream_close method call during use of a custom stream wrapper.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3200,7 +3200,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2012-1172",
-            "summary": "The file-upload implementation in rfc1867.c in PHP before 5.4.0 does not properly handle invalid [ (open square bracket) characters in name values, which makes it easier for remote attackers to cause a denial of service (malformed $_FILES indexes) or conduct directory traversal attacks during multi-file uploads by leveraging a script that lacks its own filename restrictions. \nPublish Date : 2012-05-23 Last Update Date : 2012-09-21",
+            "summary": "The file-upload implementation in rfc1867.c in PHP before 5.4.0 does not properly handle invalid [ (open square bracket) characters in name values, which makes it easier for remote attackers to cause a denial of service (malformed $_FILES indexes) or conduct directory traversal attacks during multi-file uploads by leveraging a script that lacks its own filename restrictions.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3213,7 +3213,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-1823",
-            "summary": "sapi/cgi/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case. \nPublish Date : 2012-05-11 Last Update Date : 2013-07-19",
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3227,7 +3227,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2012-2143",
-            "summary": "The crypt_des (aka DES-based crypt) function in FreeBSD before 9.0-RELEASE-p2, as used in PHP, PostgreSQL, and other products, does not process the complete cleartext password if this password contains a 0x80 character, which makes it easier for context-dependent attackers to obtain access via an authentication attempt with an initial substring of the intended password, as demonstrated by a Unicode password. \nPublish Date : 2012-07-05 Last Update Date : 2013-06-10",
+            "summary": "The crypt_des (aka DES-based crypt) function in FreeBSD before 9.0-RELEASE-p2, as used in PHP, PostgreSQL, and other products, does not process the complete cleartext password if this password contains a 0x80 character, which makes it easier for context-dependent attackers to obtain access via an authentication attempt with an initial substring of the intended password, as demonstrated by a Unicode password.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3245,7 +3245,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-2311",
-            "summary": "sapi/cgi/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that contain a %3D sequence but no = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case. NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823. \nPublish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that contain a %3D sequence but no = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3264,7 +3264,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-2329",
-            "summary": "Buffer overflow in the apache_request_headers function in sapi/cgi/cgi_main.c in PHP 5.4.x before 5.4.3 allows remote attackers to cause a denial of service (application crash) via a long string in the header of an HTTP request. \nPublish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "summary": "Buffer overflow in the apache_request_headers function in sapi\/cgi\/cgi_main.c in PHP 5.4.x before 5.4.3 allows remote attackers to cause a denial of service (application crash) via a long string in the header of an HTTP request.",
             "fixVersions": {
                 "base": [
                     "5.4.3"
@@ -3274,7 +3274,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-2335",
-            "summary": "php-wrapper.fcgi does not properly handle command-line arguments, which allows remote attackers to bypass a protection mechanism in PHP 5.3.12 and 5.4.2 and execute arbitrary code by leveraging improper interaction between the PHP sapi/cgi/cgi_main.c component and a query string beginning with a +- sequence. \nPublish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "summary": "php-wrapper.fcgi does not properly handle command-line arguments, which allows remote attackers to bypass a protection mechanism in PHP 5.3.12 and 5.4.2 and execute arbitrary code by leveraging improper interaction between the PHP sapi\/cgi\/cgi_main.c component and a query string beginning with a +- sequence.",
             "fixVersions": {
                 "base": [
                     "5.3.13",
@@ -3285,7 +3285,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-2336",
-            "summary": "sapi/cgi/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to cause a denial of service (resource consumption) by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'T' case. NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823. \nPublish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to cause a denial of service (resource consumption) by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'T' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3304,7 +3304,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2012-2376",
-            "summary": "Buffer overflow in the com_print_typeinfo function in PHP 5.4.3 and earlier on Windows allows remote attackers to execute arbitrary code via crafted arguments that trigger incorrect handling of COM object VARIANT types, as exploited in the wild in May 2012. \nPublish Date : 2012-05-21 Last Update Date : 2012-08-16",
+            "summary": "Buffer overflow in the com_print_typeinfo function in PHP 5.4.3 and earlier on Windows allows remote attackers to execute arbitrary code via crafted arguments that trigger incorrect handling of COM object VARIANT types, as exploited in the wild in May 2012.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3323,7 +3323,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2012-2386",
-            "summary": "Integer overflow in the phar_parse_tarfile function in tar.c in the phar extension in PHP before 5.3.14 and 5.4.x before 5.4.4 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted tar file that triggers a heap-based buffer overflow. \nPublish Date : 2012-07-07 Last Update Date : 2012-09-21",
+            "summary": "Integer overflow in the phar_parse_tarfile function in tar.c in the phar extension in PHP before 5.3.14 and 5.4.x before 5.4.4 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted tar file that triggers a heap-based buffer overflow.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3342,7 +3342,7 @@
         {
             "threat": "10.0",
             "cveid": "CVE-2012-2688",
-            "summary": "Unspecified vulnerability in the _php_stream_scandir function in the stream implementation in PHP before 5.3.15 and 5.4.x before 5.4.5 has unknown impact and remote attack vectors, related to an \"overflow.\" \nPublish Date : 2012-07-20 Last Update Date : 2013-10-10",
+            "summary": "Unspecified vulnerability in the _php_stream_scandir function in the stream implementation in PHP before 5.3.15 and 5.4.x before 5.4.5 has unknown impact and remote attack vectors, related to an \"overflow.\"",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3361,7 +3361,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-3365",
-            "summary": "The SQLite functionality in PHP before 5.3.15 allows remote attackers to bypass the open_basedir protection mechanism via unspecified vectors. \nPublish Date : 2012-07-20 Last Update Date : 2013-06-25",
+            "summary": "The SQLite functionality in PHP before 5.3.15 allows remote attackers to bypass the open_basedir protection mechanism via unspecified vectors.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3379,7 +3379,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2012-3450",
-            "summary": "pdo_sql_parser.re in the PDO extension in PHP before 5.3.14 and 5.4.x before 5.4.4 does not properly determine the end of the query string during parsing of prepared statements, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted parameter value. \nPublish Date : 2012-08-06 Last Update Date : 2013-04-18",
+            "summary": "pdo_sql_parser.re in the PDO extension in PHP before 5.3.14 and 5.4.x before 5.4.4 does not properly determine the end of the query string during parsing of prepared statements, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted parameter value.",
             "fixVersions": {
                 "base": [
                     "5.3.14",
@@ -3390,7 +3390,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2012-4388",
-            "summary": "The sapi_header_op function in main/SAPI.c in PHP 5.4.0RC2 through 5.4.0 does not properly determine a pointer during checks for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome. NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-1398. \nPublish Date : 2012-09-07 Last Update Date : 2013-09-11",
+            "summary": "The sapi_header_op function in main\/SAPI.c in PHP 5.4.0RC2 through 5.4.0 does not properly determine a pointer during checks for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-1398.",
             "fixVersions": {
                 "base": [
                     "5.4.1"
@@ -3400,7 +3400,7 @@
         {
             "threat": "6.0",
             "cveid": "CVE-2012-5381",
-            "summary": "** DISPUTED ** Untrusted search path vulnerability in the installation functionality in PHP 5.3.17, when installed in the top-level C:\\ directory, might allow local users to gain privileges via a Trojan horse DLL in the C:\\PHP directory, which may be added to the PATH system environment variable by an administrator, as demonstrated by a Trojan horse wlbsctrl.dll file used by the \"IKE and AuthIP IPsec Keying Modules\" system service in Windows Vista SP1, Windows Server 2008 SP2, Windows 7 SP1, and Windows 8 Release Preview. NOTE: CVE disputes this issue because the unsafe PATH is established only by a separate administrative action that is not a default part of the PHP installation. \nPublish Date : 2012-10-11 Last Update Date : 2013-03-01",
+            "summary": "** DISPUTED ** Untrusted search path vulnerability in the installation functionality in PHP 5.3.17, when installed in the top-level C:\\ directory, might allow local users to gain privileges via a Trojan horse DLL in the C:\\PHP directory, which may be added to the PATH system environment variable by an administrator, as demonstrated by a Trojan horse wlbsctrl.dll file used by the \"IKE and AuthIP IPsec Keying Modules\" system service in Windows Vista SP1, Windows Server 2008 SP2, Windows 7 SP1, and Windows 8 Release Preview.  NOTE: CVE disputes this issue because the unsafe PATH is established only by a separate administrative action that is not a default part of the PHP installation.",
             "fixVersions": {
                 "base": [
                     "5.3.18"
@@ -3410,7 +3410,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2012-6113",
-            "summary": "The openssl_encrypt function in ext/openssl/openssl.c in PHP 5.3.9 through 5.3.13 does not initialize a certain variable, which allows remote attackers to obtain sensitive information from process memory by providing zero bytes of input data. \nPublish Date : 2013-01-19 Last Update Date : 2013-02-02",
+            "summary": "The openssl_encrypt function in ext\/openssl\/openssl.c in PHP 5.3.9 through 5.3.13 does not initialize a certain variable, which allows remote attackers to obtain sensitive information from process memory by providing zero bytes of input data.",
             "fixVersions": {
                 "base": [
                     "5.3.14"
@@ -3420,7 +3420,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2013-1635",
-            "summary": "ext/soap/soap.c in PHP before 5.3.22 and 5.4.x before 5.4.13 does not validate the relationship between the soap.wsdl_cache_dir directive and the open_basedir directive, which allows remote attackers to bypass intended access restrictions by triggering the creation of cached SOAP WSDL files in an arbitrary directory. \nPublish Date : 2013-03-06 Last Update Date : 2014-01-27",
+            "summary": "ext\/soap\/soap.c in PHP before 5.3.22 and 5.4.x before 5.4.13 does not validate the relationship between the soap.wsdl_cache_dir directive and the open_basedir directive, which allows remote attackers to bypass intended access restrictions by triggering the creation of cached SOAP WSDL files in an arbitrary directory.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3439,7 +3439,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-1643",
-            "summary": "The SOAP parser in PHP before 5.3.23 and 5.4.x before 5.4.13 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions. NOTE: this vulnerability exists because of an incorrect fix for CVE-2013-1824. \nPublish Date : 2013-03-06 Last Update Date : 2014-01-27",
+            "summary": "The SOAP parser in PHP before 5.3.23 and 5.4.x before 5.4.13 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2013-1824.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3458,7 +3458,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2013-1824",
-            "summary": "The SOAP parser in PHP before 5.3.22 and 5.4.x before 5.4.12 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions. \nPublish Date : 2013-09-16 Last Update Date : 2013-09-18",
+            "summary": "The SOAP parser in PHP before 5.3.22 and 5.4.x before 5.4.12 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.",
             "fixVersions": {
                 "base": [
                     "5.3.22",
@@ -3469,7 +3469,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-2110",
-            "summary": "Heap-based buffer overflow in the php_quot_print_encode function in ext/standard/quot_print.c in PHP before 5.3.26 and 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted argument to the quoted_printable_encode function. \nPublish Date : 2013-06-21 Last Update Date : 2013-09-17",
+            "summary": "Heap-based buffer overflow in the php_quot_print_encode function in ext\/standard\/quot_print.c in PHP before 5.3.26 and 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted argument to the quoted_printable_encode function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3488,7 +3488,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-3735",
-            "summary": "** DISPUTED ** The Zend Engine in PHP before 5.4.16 RC1, and 5.5.0 before RC2, does not properly determine whether a parser error occurred, which allows context-dependent attackers to cause a denial of service (memory consumption and application crash) via a crafted function definition, as demonstrated by an attack within a shared web-hosting environment. NOTE: the vendor's http://php.net/security-note.php page says \"for critical security situations you should be using OS-level security by running multiple web servers each as their own user id.\" \nPublish Date : 2013-05-31 Last Update Date : 2013-06-03",
+            "summary": "** DISPUTED ** The Zend Engine in PHP before 5.4.16 RC1, and 5.5.0 before RC2, does not properly determine whether a parser error occurred, which allows context-dependent attackers to cause a denial of service (memory consumption and application crash) via a crafted function definition, as demonstrated by an attack within a shared web-hosting environment.  NOTE: the vendor's http:\/\/php.net\/security-note.php page says \"for critical security situations you should be using OS-level security by running multiple web servers each as their own user id.\"",
             "fixVersions": {
                 "base": [
                     "5.4.16",
@@ -3499,7 +3499,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2013-4113",
-            "summary": "ext/xml/xml.c in PHP before 5.3.27 does not properly consider parsing depth, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted document that is processed by the xml_parse_into_struct function. \nPublish Date : 2013-07-13 Last Update Date : 2014-03-05",
+            "summary": "ext\/xml\/xml.c in PHP before 5.3.27 does not properly consider parsing depth, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted document that is processed by the xml_parse_into_struct function.",
             "fixVersions": {
                 "base": [
                     "5.3.27"
@@ -3509,7 +3509,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2013-4248",
-            "summary": "The openssl_x509_parse function in openssl.c in the OpenSSL module in PHP before 5.4.18 and 5.5.x before 5.5.2 does not properly handle a '\\0' character in a domain name in the Subject Alternative Name field of an X.509 certificate, which allows man-in-the-middle attackers to spoof arbitrary SSL servers via a crafted certificate issued by a legitimate Certification Authority, a related issue to CVE-2009-2408. \nPublish Date : 2013-08-17 Last Update Date : 2014-07-17",
+            "summary": "The openssl_x509_parse function in openssl.c in the OpenSSL module in PHP before 5.4.18 and 5.5.x before 5.5.2 does not properly handle a '\\0' character in a domain name in the Subject Alternative Name field of an X.509 certificate, which allows man-in-the-middle attackers to spoof arbitrary SSL servers via a crafted certificate issued by a legitimate Certification Authority, a related issue to CVE-2009-2408.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3524,7 +3524,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-4635",
-            "summary": "Integer overflow in the SdnToJewish function in jewish.c in the Calendar component in PHP before 5.3.26 and 5.4.x before 5.4.16 allows context-dependent attackers to cause a denial of service (application hang) via a large argument to the jdtojewish function. \nPublish Date : 2013-06-21 Last Update Date : 2013-09-11",
+            "summary": "Integer overflow in the SdnToJewish function in jewish.c in the Calendar component in PHP before 5.3.26 and 5.4.x before 5.4.16 allows context-dependent attackers to cause a denial of service (application hang) via a large argument to the jdtojewish function.",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3543,7 +3543,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2013-4636",
-            "summary": "The mget function in libmagic/softmagic.c in the Fileinfo component in PHP 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (invalid pointer dereference and application crash) via an MP3 file that triggers incorrect MIME type detection during access to an finfo object. \nPublish Date : 2013-06-21 Last Update Date : 2013-06-24",
+            "summary": "The mget function in libmagic\/softmagic.c in the Fileinfo component in PHP 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (invalid pointer dereference and application crash) via an MP3 file that triggers incorrect MIME type detection during access to an finfo object.",
             "fixVersions": {
                 "base": [
                     "5.4.16"
@@ -3553,7 +3553,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2013-6420",
-            "summary": "The asn1_time_to_time_t function in ext/openssl/openssl.c in PHP before 5.3.28, 5.4.x before 5.4.23, and 5.5.x before 5.5.7 does not properly parse (1) notBefore and (2) notAfter timestamps in X.509 certificates, which allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted certificate that is not properly handled by the openssl_x509_parse function. \nPublish Date : 2013-12-16 Last Update Date : 2014-07-17",
+            "summary": "The asn1_time_to_time_t function in ext\/openssl\/openssl.c in PHP before 5.3.28, 5.4.x before 5.4.23, and 5.5.x before 5.5.7 does not properly parse (1) notBefore and (2) notAfter timestamps in X.509 certificates, which allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted certificate that is not properly handled by the openssl_x509_parse function.",
             "fixVersions": {
                 "base": [
                     "5.3.28",
@@ -3565,7 +3565,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2013-6712",
-            "summary": "The scan function in ext/date/lib/parse_iso_intervals.c in PHP through 5.5.6 does not properly restrict creation of DateInterval objects, which might allow remote attackers to cause a denial of service (heap-based buffer over-read) via a crafted interval specification. \nPublish Date : 2013-11-27 Last Update Date : 2014-01-03",
+            "summary": "The scan function in ext\/date\/lib\/parse_iso_intervals.c in PHP through 5.5.6 does not properly restrict creation of DateInterval objects, which might allow remote attackers to cause a denial of service (heap-based buffer over-read) via a crafted interval specification.",
             "fixVersions": {
                 "base": [
                     "5.5.7"
@@ -3575,7 +3575,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2013-7226",
-            "summary": "Integer overflow in the gdImageCrop function in ext/gd/gd.c in PHP 5.5.x before 5.5.9 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via an imagecrop function call with a large x dimension value, leading to a heap-based buffer overflow. \nPublish Date : 2014-02-18 Last Update Date : 2014-03-13",
+            "summary": "Integer overflow in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via an imagecrop function call with a large x dimension value, leading to a heap-based buffer overflow.",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -3585,7 +3585,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2013-7327",
-            "summary": "The gdImageCrop function in ext/gd/gd.c in PHP 5.5.x before 5.5.9 does not check return values, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via invalid imagecrop arguments that lead to use of a NULL pointer as a return value, a different vulnerability than CVE-2013-7226. \nPublish Date : 2014-02-18 Last Update Date : 2014-03-08",
+            "summary": "The gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check return values, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via invalid imagecrop arguments that lead to use of a NULL pointer as a return value, a different vulnerability than CVE-2013-7226.",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -3595,7 +3595,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2013-7328",
-            "summary": "Multiple integer signedness errors in the gdImageCrop function in ext/gd/gd.c in PHP 5.5.x before 5.5.9 allow remote attackers to cause a denial of service (application crash) or obtain sensitive information via an imagecrop function call with a negative value for the (1) x or (2) y dimension, a different vulnerability than CVE-2013-7226. \nPublish Date : 2014-02-18 Last Update Date : 2014-03-08",
+            "summary": "Multiple integer signedness errors in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allow remote attackers to cause a denial of service (application crash) or obtain sensitive information via an imagecrop function call with a negative value for the (1) x or (2) y dimension, a different vulnerability than CVE-2013-7226.",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -3617,7 +3617,7 @@
         {
             "threat": "7.2",
             "cveid": "CVE-2014-0185",
-            "summary": "sapi/fpm/fpm/fpm_unix.c in the FastCGI Process Manager (FPM) in PHP before 5.4.28 and 5.5.x before 5.5.12 uses 0666 permissions for the UNIX socket, which allows local users to gain privileges via a crafted FastCGI client. \nPublish Date : 2014-05-06 Last Update Date : 2014-05-06",
+            "summary": "sapi\/fpm\/fpm\/fpm_unix.c in the FastCGI Process Manager (FPM) in PHP before 5.4.28 and 5.5.x before 5.5.12 uses 0666 permissions for the UNIX socket, which allows local users to gain privileges via a crafted FastCGI client.",
             "fixVersions": {
                 "base": [
                     "5.4.28",
@@ -3628,7 +3628,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-0207",
-            "summary": "The cdf_read_short_sector function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (assertion failure and application exit) via a crafted CDF file. \nPublish Date : 2014-07-09 Last Update Date : 2014-07-18",
+            "summary": "The cdf_read_short_sector function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (assertion failure and application exit) via a crafted CDF file.",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -3639,7 +3639,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-0237",
-            "summary": "The cdf_unpack_summary_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (performance degradation) by triggering many file_printf calls. \nPublish Date : 2014-06-01 Last Update Date : 2014-07-17",
+            "summary": "The cdf_unpack_summary_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (performance degradation) by triggering many file_printf calls.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3654,7 +3654,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-0238",
-            "summary": "The cdf_read_property_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (infinite loop or out-of-bounds memory access) via a vector that (1) has zero length or (2) is too long. \nPublish Date : 2014-06-01 Last Update Date : 2014-07-17",
+            "summary": "The cdf_read_property_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (infinite loop or out-of-bounds memory access) via a vector that (1) has zero length or (2) is too long.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3680,7 +3680,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-2020",
-            "summary": "ext/gd/gd.c in PHP 5.5.x before 5.5.9 does not check data types, which might allow remote attackers to obtain sensitive information by using a (1) string or (2) array data type in place of a numeric data type, as demonstrated by an imagecrop function call with a string for the x dimension value, a different vulnerability than CVE-2013-7226. \nPublish Date : 2014-02-18 Last Update Date : 2014-03-08",
+            "summary": "ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check data types, which might allow remote attackers to obtain sensitive information by using a (1) string or (2) array data type in place of a numeric data type, as demonstrated by an imagecrop function call with a string for the x dimension value, a different vulnerability than CVE-2013-7226.",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -3690,7 +3690,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-2497",
-            "summary": "The gdImageCreateFromXpm function in gdxpm.c in libgd, as used in PHP 5.4.26 and earlier, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted color table in an XPM file. \nPublish Date : 2014-03-21 Last Update Date : 2014-07-17",
+            "summary": "The gdImageCreateFromXpm function in gdxpm.c in libgd, as used in PHP 5.4.26 and earlier, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted color table in an XPM file.",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3704,7 +3704,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-3478",
-            "summary": "Buffer overflow in the mconvert function in softmagic.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (application crash) via a crafted Pascal string in a FILE_PSTRING conversion. \nPublish Date : 2014-07-09 Last Update Date : 2014-07-18",
+            "summary": "Buffer overflow in the mconvert function in softmagic.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (application crash) via a crafted Pascal string in a FILE_PSTRING conversion.",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -3715,7 +3715,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3479",
-            "summary": "The cdf_check_stream_offset function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, relies on incorrect sector-size data, which allows remote attackers to cause a denial of service (application crash) via a crafted stream offset in a CDF file. \nPublish Date : 2014-07-09 Last Update Date : 2014-07-18",
+            "summary": "The cdf_check_stream_offset function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, relies on incorrect sector-size data, which allows remote attackers to cause a denial of service (application crash) via a crafted stream offset in a CDF file.",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -3726,7 +3726,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3480",
-            "summary": "The cdf_count_chain function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate sector-count data, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file. \nPublish Date : 2014-07-09 Last Update Date : 2014-07-18",
+            "summary": "The cdf_count_chain function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate sector-count data, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -3737,7 +3737,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3487",
-            "summary": "The cdf_read_property_info function in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate a stream offset, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file. \nPublish Date : 2014-07-09 Last Update Date : 2014-07-18",
+            "summary": "The cdf_read_property_info function in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate a stream offset, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -3748,7 +3748,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-3515",
-            "summary": "The SPL component in PHP before 5.4.30 and 5.5.x before 5.5.14 incorrectly anticipates that certain data structures will have the array data type after unserialization, which allows remote attackers to execute arbitrary code via a crafted string that triggers use of a Hashtable destructor, related to \"type confusion\" issues in (1) ArrayObject and (2) SPLObjectStorage. \nPublish Date : 2014-07-09 Last Update Date : 2014-07-18",
+            "summary": "The SPL component in PHP before 5.4.30 and 5.5.x before 5.5.14 incorrectly anticipates that certain data structures will have the array data type after unserialization, which allows remote attackers to execute arbitrary code via a crafted string that triggers use of a Hashtable destructor, related to \"type confusion\" issues in (1) ArrayObject and (2) SPLObjectStorage.",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -3769,7 +3769,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2014-3587",
-            "summary": "Integer overflow in the cdf_read_property_info function in cdf.c in file through 5.19, as used in the Fileinfo component in PHP before 5.4.32 and 5.5.x before 5.5.16, allows remote attackers to cause a denial of service (application crash) via a crafted CDF file. NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1571. \nPublish Date : 2014-08-22 Last Update Date : 2014-08-27",
+            "summary": "Integer overflow in the cdf_read_property_info function in cdf.c in file through 5.19, as used in the Fileinfo component in PHP before 5.4.32 and 5.5.x before 5.5.16, allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1571.",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -3780,7 +3780,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2014-3597",
-            "summary": "Multiple buffer overflows in the php_parserr function in ext/standard/dns.c in PHP before 5.4.32 and 5.5.x before 5.5.16 allow remote DNS servers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted DNS record, related to the dns_get_record function and the dn_expand function. NOTE: this issue exists because of an incomplete fix for CVE-2014-4049. \nPublish Date : 2014-08-22 Last Update Date : 2014-08-27",
+            "summary": "Multiple buffer overflows in the php_parserr function in ext\/standard\/dns.c in PHP before 5.4.32 and 5.5.x before 5.5.16 allow remote DNS servers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted DNS record, related to the dns_get_record function and the dn_expand function.  NOTE: this issue exists because of an incomplete fix for CVE-2014-4049.",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -3791,7 +3791,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-3668",
-            "summary": "Buffer overflow in the date_from_ISO8601 function in the mkgmtime implementation in libxmlrpc/xmlrpc.c in the XMLRPC extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) via (1) a crafted first argument to the xmlrpc_set_type function or (2) a crafted argument to the xmlrpc_decode function, related to an out-of-bounds read operation.",
+            "summary": "Buffer overflow in the date_from_ISO8601 function in the mkgmtime implementation in libxmlrpc\/xmlrpc.c in the XMLRPC extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) via (1) a crafted first argument to the xmlrpc_set_type function or (2) a crafted argument to the xmlrpc_decode function, related to an out-of-bounds read operation.",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -3803,7 +3803,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-3669",
-            "summary": "Integer overflow in the object_custom function in ext/standard/var_unserializer.c in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an argument to the unserialize function that triggers calculation of a large length value.",
+            "summary": "Integer overflow in the object_custom function in ext\/standard\/var_unserializer.c in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an argument to the unserialize function that triggers calculation of a large length value.",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -3839,7 +3839,7 @@
         {
             "threat": "3.3",
             "cveid": "CVE-2014-3981",
-            "summary": "acinclude.m4, as used in the configure script in PHP 5.5.13 and earlier, allows local users to overwrite arbitrary files via a symlink attack on the /tmp/phpglibccheck file. \nPublish Date : 2014-06-08 Last Update Date : 2014-06-09",
+            "summary": "acinclude.m4, as used in the configure script in PHP 5.5.13 and earlier, allows local users to overwrite arbitrary files via a symlink attack on the \/tmp\/phpglibccheck file.",
             "fixVersions": {
                 "base": [
                     "5.5.14"
@@ -3849,7 +3849,7 @@
         {
             "threat": "5.1",
             "cveid": "CVE-2014-4049",
-            "summary": "Heap-based buffer overflow in the php_parserr function in ext/standard/dns.c in PHP 5.6.0beta4 and earlier allows remote servers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted DNS TXT record, related to the dns_get_record function. \nPublish Date : 2014-06-18 Last Update Date : 2014-07-17",
+            "summary": "Heap-based buffer overflow in the php_parserr function in ext\/standard\/dns.c in PHP 5.6.0beta4 and earlier allows remote servers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted DNS TXT record, related to the dns_get_record function.",
             "fixVersions": {
                 "base": [
                     "5.6.1"
@@ -3859,7 +3859,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2014-4670",
-            "summary": "Use-after-free vulnerability in ext/spl/spl_dllist.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted iterator usage within applications in certain web-hosting environments. \nPublish Date : 2014-07-10 Last Update Date : 2014-08-27",
+            "summary": "Use-after-free vulnerability in ext\/spl\/spl_dllist.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted iterator usage within applications in certain web-hosting environments.",
             "fixVersions": {
                 "base": [
                     "5.5.15"
@@ -3869,7 +3869,7 @@
         {
             "threat": "4.6",
             "cveid": "CVE-2014-4698",
-            "summary": "Use-after-free vulnerability in ext/spl/spl_array.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted ArrayIterator usage within applications in certain web-hosting environments. \nPublish Date : 2014-07-10 Last Update Date : 2014-07-18",
+            "summary": "Use-after-free vulnerability in ext\/spl\/spl_array.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted ArrayIterator usage within applications in certain web-hosting environments.",
             "fixVersions": {
                 "base": [
                     "5.5.15"
@@ -3879,7 +3879,7 @@
         {
             "threat": "2.6",
             "cveid": "CVE-2014-4721",
-            "summary": "The phpinfo implementation in ext/standard/info.c in PHP before 5.4.30 and 5.5.x before 5.5.14 does not ensure use of the string data type for the PHP_AUTH_PW, PHP_AUTH_TYPE, PHP_AUTH_USER, and PHP_SELF variables, which might allow context-dependent attackers to obtain sensitive information from process memory by using the integer data type with crafted values, related to a \"type confusion\" vulnerability, as demonstrated by reading a private SSL key in an Apache HTTP Server web-hosting environment with mod_ssl and a PHP 5.3.x mod_php. \nPublish Date : 2014-07-06 Last Update Date : 2014-07-18",
+            "summary": "The phpinfo implementation in ext\/standard\/info.c in PHP before 5.4.30 and 5.5.x before 5.5.14 does not ensure use of the string data type for the PHP_AUTH_PW, PHP_AUTH_TYPE, PHP_AUTH_USER, and PHP_SELF variables, which might allow context-dependent attackers to obtain sensitive information from process memory by using the integer data type with crafted values, related to a \"type confusion\" vulnerability, as demonstrated by reading a private SSL key in an Apache HTTP Server web-hosting environment with mod_ssl and a PHP 5.3.x mod_php.",
             "fixVersions": {
                 "base": [
                     "5.3.29",
@@ -3891,7 +3891,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2014-5120",
-            "summary": "gd_ctx.c in the GD component in PHP 5.4.x before 5.4.32 and 5.5.x before 5.5.16 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to overwrite arbitrary files via crafted input to an application that calls the (1) imagegd, (2) imagegd2, (3) imagegif, (4) imagejpeg, (5) imagepng, (6) imagewbmp, or (7) imagewebp function. \nPublish Date : 2014-08-22 Last Update Date : 2014-08-27",
+            "summary": "gd_ctx.c in the GD component in PHP 5.4.x before 5.4.32 and 5.5.x before 5.5.16 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to overwrite arbitrary files via crafted input to an application that calls the (1) imagegd, (2) imagegd2, (3) imagegif, (4) imagejpeg, (5) imagepng, (6) imagewbmp, or (7) imagewebp function.",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -3902,7 +3902,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2014-8142",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext/standard/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019.",
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019.",
             "fixVersions": {
                 "base": [
                     "5.4.36",
@@ -3925,7 +3925,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-9426",
-            "summary": "The apprentice_load function in libmagic/apprentice.c in the Fileinfo component in PHP through 5.6.4 attempts to perform a free operation on a stack-based character array, which allows remote attackers to cause a denial of service (memory corruption or application crash) or possibly have unspecified other impact via unknown vectors.",
+            "summary": "** DISPUTED ** The apprentice_load function in libmagic\/apprentice.c in the Fileinfo component in PHP through 5.6.4 attempts to perform a free operation on a stack-based character array, which allows remote attackers to cause a denial of service (memory corruption or application crash) or possibly have unspecified other impact via unknown vectors.  NOTE: this is disputed by the vendor because the standard erealloc behavior makes the free operation unreachable.",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -3937,7 +3937,7 @@
         {
             "threat": "6.4",
             "cveid": "CVE-2014-9427",
-            "summary": "sapi/cgi/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping.",
+            "summary": "sapi\/cgi\/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping.",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -3949,7 +3949,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2014-9705",
-            "summary": "heap buffer overflow in enchant_broker_request_dict()",
+            "summary": "Heap-based buffer overflow in the enchant_broker_request_dict function in ext\/enchant\/enchant.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allows remote attackers to execute arbitrary code via vectors that trigger creation of multiple dictionaries.",
             "fixVersions": {
                 "base": [
                     "5.4.38",
@@ -3961,7 +3961,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2014-9709",
-            "summary": "buffer read overflow in gd_gif_in.c",
+            "summary": "The GetCode_ function in gd_gif_in.c in GD 2.1.1 and earlier, as used in PHP before 5.5.21 and 5.6.x before 5.6.5, allows remote attackers to cause a denial of service (buffer over-read and application crash) via a crafted GIF image that is improperly handled by the gdImageCreateFromGif function.",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -3973,7 +3973,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-0231",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext/standard/var_unserializer.re in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate numerical keys within the serialized properties of an object. NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-8142.",
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate numerical keys within the serialized properties of an object.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-8142.",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -3985,7 +3985,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2015-0232",
-            "summary": "The exif_process_unicode function in ext/exif/exif.c in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized pointer free and application crash) via crafted EXIF data in a JPEG image.",
+            "summary": "The exif_process_unicode function in ext\/exif\/exif.c in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized pointer free and application crash) via crafted EXIF data in a JPEG image.",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4021,7 +4021,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-1351",
-            "summary": "Use After Free in OPcache",
+            "summary": "Use-after-free vulnerability in the _zend_shared_memdup function in zend_shared_alloc.c in the OPcache extension in PHP through 5.6.7 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors.",
             "fixVersions": {
                 "base": [
                     "5.5.24",
@@ -4032,7 +4032,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-1352",
-            "summary": "Null pointer dereference",
+            "summary": "The build_tablename function in pgsql.c in the PostgreSQL (aka pgsql) extension in PHP through 5.6.7 does not validate token extraction for table names, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted name.",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4044,7 +4044,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-2301",
-            "summary": "use after free in phar_rename_archive()",
+            "summary": "Use-after-free vulnerability in the phar_rename_archive function in phar_object.c in PHP before 5.5.22 and 5.6.x before 5.6.6 allows remote attackers to cause a denial of service or possibly have unspecified other impact via vectors that trigger an attempted renaming of a Phar archive to the name of an existing file.",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4068,7 +4068,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-2331",
-            "summary": "ZIP Integer Overflow leads to writing past heap boundary",
+            "summary": "Integer overflow in the _zip_cdir_new function in zip_dirent.c in libzip 0.11.2 and earlier, as used in the ZIP extension in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 and other products, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a ZIP archive that contains many entries, leading to a heap-based buffer overflow.",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -4080,7 +4080,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-2348",
-            "summary": "move_uploaded_file allows nulls in path",
+            "summary": "The move_uploaded_file implementation in ext\/standard\/basic_functions.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 truncates a pathname upon encountering a \\x00 character, which allows remote attackers to bypass intended extension restrictions and create files with unexpected names via a crafted second argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -4092,7 +4092,7 @@
         {
             "threat": "5.8",
             "cveid": "CVE-2015-2783",
-            "summary": "Buffer Over-read in unserialize when parsing Phar",
+            "summary": "ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (buffer over-read and application crash) via a crafted length value in conjunction with crafted serialized data in a phar archive, related to the phar_parse_metadata and phar_parse_pharfile functions.",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4104,7 +4104,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-2787",
-            "summary": "Use After Free Vulnerability in unserialize()",
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages use of the unset function within an __wakeup function, a related issue to CVE-2015-0231.",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -4116,7 +4116,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-3329",
-            "summary": "Buffer Overflow when parsing tar/zip/phar in phar_set_inode",
+            "summary": "Multiple stack-based buffer overflows in the phar_set_inode function in phar_internal.h in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allow remote attackers to execute arbitrary code via a crafted length value in a (1) tar, (2) phar, or (3) ZIP archive.",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4128,7 +4128,7 @@
         {
             "threat": "6.8",
             "cveid": "CVE-2015-3330",
-            "summary": "The php_handler function in sapi/apache2handler/sapi_apache2.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, when the Apache HTTP Server 2.4.x is used, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via pipelined HTTP requests that result in a &quot;deconfigured interpreter.&quot;",
+            "summary": "The php_handler function in sapi\/apache2handler\/sapi_apache2.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, when the Apache HTTP Server 2.4.x is used, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via pipelined HTTP requests that result in a \"deconfigured interpreter.\"",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4152,7 +4152,7 @@
         {
             "threat": "7.5",
             "cveid": "CVE-2015-4147",
-            "summary": "SoapClient's __call() type confusion through unserialize()",
+            "summary": "The SoapClient::__call method in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that __default_headers is an array, which allows remote attackers to execute arbitrary code by providing crafted serialized data with an unexpected data type, related to a \"type confusion\" issue.",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -4164,7 +4164,7 @@
         {
             "threat": "5.0",
             "cveid": "CVE-2015-4148",
-            "summary": "SoapClient's __call() type confusion through unserialize()",
+            "summary": "The do_soap_call function in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that the uri property is a string, which allows remote attackers to obtain sensitive information by providing crafted serialized data with an int data type, related to a \"type confusion\" issue.",
             "fixVersions": {
                 "base": [
                     "5.4.39",


### PR DESCRIPTION
 - Standardized all summaries
   - Escaped certain characters according to how PHP's `json_encode()` method encodes them
   - ~~Removed the Publish and Update dates~~
     - ~~If we really want these, we should probably expose them as separate keys instead~~
 - Fixed a couple incorrect threat scores and version numbers
 - Added several other CVEs