### PR TITLE
Add support for Symfony Console 3 (fixes #26)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     ],
     "require":{
         "php":">=5.3.1",
+        "sunra/php-simple-html-dom-parser": "v1.5.0",
         "symfony/console": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",
-        "kherge/box": "~2.4",
-        "sunra/php-simple-html-dom-parser": "v1.5.0"
+        "kherge/box": "~2.4"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require":{
         "php":">=5.3.1",
-        "symfony/console": "~2.1"
+        "symfony/console": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",

--- a/src/Psecio/Versionscan/Command/ScanCommand/Output/Console.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand/Output/Console.php
@@ -16,7 +16,12 @@ class Console extends Output
 
         $output->writeLn('Executing against version: ' . $phpVersion);
 
-        $table = $command->getHelper('table');
+        if (class_exists('\Symfony\Component\Console\Helper\Table')) {
+            $table = new \Symfony\Component\Console\Helper\Table($output);
+        } else {
+            $table = $command->getHelper('table');
+        }
+
         $table->setHeaders(array('Status', 'CVE ID', 'Risk', 'Summary'));
 
         $columnSize = 100;


### PR DESCRIPTION
To make this work, we must use the Table class if it exists. This class was
introduced in Symfony 2.5 as the successor to the table helper, which has been
removed in Symfony 3.0.