### PR TITLE
Improve add missing workflow, update CVE checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ before_script:
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install --dev
 php:
-  - 5.3
+  - 5.4
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ before_script:
   - php composer.phar install --dev
 php:
   - 5.4
+  - 7.3
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,10 @@
         }
     ],
     "require":{
-        "php":">=5.3.1",
-        "sunra/php-simple-html-dom-parser": "~1.5.0",
-        "symfony/console": "~2.1|~3.0"
+        "php":">=5.4.0",
+        "ext-json": "*",
+        "symfony/console": "~2.1|~3.0",
+        "kub-at/php-simple-html-dom-parser": "^1.9"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",

--- a/src/Psecio/Versionscan/Command/MissingCommand.php
+++ b/src/Psecio/Versionscan/Command/MissingCommand.php
@@ -167,6 +167,13 @@ class MissingCommand extends Command
             }
             return strnatcmp($row1Parts[2], $row2Parts[2]);
         });
+
+        foreach ($allChecks as $index => $check) {
+            $versions = $allChecks[$index]['fixVersions']['base'];
+            sort($versions);
+            $allChecks[$index]['fixVersions']['base'] = $versions;
+        }
+
         $output = [
             'checks' => $allChecks,
             'updatedAt' => Date('c')

--- a/src/Psecio/Versionscan/Command/MissingCommand.php
+++ b/src/Psecio/Versionscan/Command/MissingCommand.php
@@ -39,7 +39,7 @@ class MissingCommand extends Command
         $saveResults = $input->getOption('save-results');
 
         // Get our current checks
-        $this->checksFileContents = json_decode(file_get_contents(__DIR__.'/../../../Psecio/Versionscan/checks.json'), true);
+        $this->checksFileContents = json_decode(file_get_contents($this->checksFilePath), true);
         $this->checksList = [];
         foreach ($this->checksFileContents['checks'] as $check) {
             if (!in_array($check['cveid'], $this->checksList)) {

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -5058,9 +5058,9 @@
             "summary": "Oracle MySQL before 5.7.3, Oracle MySQL Connector\/C (aka libmysqlclient) before 6.1.3, and MariaDB before 5.5.44 use the --ssl option to mean that SSL is optional, which allows man-in-the-middle attackers to spoof servers via a cleartext-downgrade attack, aka a &quot;BACKRONYM&quot; attack.",
             "fixVersions": {
                 "base": [
-                    "5.6.11",
+                    "5.4.43",
                     "5.5.27",
-                    "5.4.43"
+                    "5.6.11"
                 ]
             }
         },
@@ -6651,9 +6651,9 @@
             "summary": "Integer underflow in the _gdContributionsAlloc function in gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.2.4 allows remote attackers to have unspecified impact via vectors related to decrementing the u variable.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
+                    "7.1.26",
                     "7.2.14",
-                    "7.1.26"
+                    "7.3.1"
                 ]
             }
         },
@@ -7204,9 +7204,9 @@
             "fixVersions": {
                 "base": [
                     "7.0.33",
-                    "7.3.0",
+                    "7.1.25",
                     "7.2.13",
-                    "7.1.25"
+                    "7.3.0"
                 ]
             }
         },
@@ -7236,9 +7236,9 @@
             "fixVersions": {
                 "base": [
                     "7.0.33",
-                    "7.3.0",
+                    "7.1.25",
                     "7.2.13",
-                    "7.1.25"
+                    "7.3.0"
                 ]
             }
         },
@@ -7248,9 +7248,9 @@
             "summary": "gdImageColorMatch in gd_color_match.c in the GD Graphics Library (aka LibGD) 2.2.5, as used in the imagecolormatch function in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1, has a heap-based buffer overflow. This can be exploited by an attacker who is able to trigger imagecolormatch calls with crafted image data.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
+                    "7.1.26",
                     "7.2.14",
-                    "7.1.26"
+                    "7.3.1"
                 ]
             }
         },
@@ -7260,9 +7260,9 @@
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. Invalid input to the function xmlrpc_decode() can lead to an invalid memory access (heap out of bounds read or read after free). This is related to xml_elem_parse_buf in ext\/xmlrpc\/libxmlrpc\/xml_element.c.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
+                    "7.1.26",
                     "7.2.14",
-                    "7.1.26"
+                    "7.3.1"
                 ]
             }
         },
@@ -7272,9 +7272,9 @@
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A heap-based buffer over-read in PHAR reading functions in the PHAR extension may allow an attacker to read allocated or unallocated memory past the actual data when trying to parse the file name, a different vulnerability than CVE-2018-20783. This is related to phar_detect_phar_fname_ext in ext\/phar\/phar.c.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
+                    "7.1.26",
                     "7.2.14",
-                    "7.1.26"
+                    "7.3.1"
                 ]
             }
         },
@@ -7284,9 +7284,9 @@
             "summary": "An issue was discovered in PHP 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.2. dns_get_record misparses a DNS response, which can allow a hostile DNS server to cause PHP to misuse memcpy, leading to read operations going past the buffer allocated for DNS data. This affects php_parserr in ext\/standard\/dns.c for DNS_CAA and DNS_ANY queries.",
             "fixVersions": {
                 "base": [
-                    "7.3.2",
+                    "7.1.26",
                     "7.2.14",
-                    "7.1.26"
+                    "7.3.2"
                 ]
             }
         },
@@ -7296,9 +7296,9 @@
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A number of heap-based buffer over-read instances are present in mbstring regular expression functions when supplied with invalid multibyte data. These occur in ext\/mbstring\/oniguruma\/regcomp.c, ext\/mbstring\/oniguruma\/regexec.c, ext\/mbstring\/oniguruma\/regparse.c, ext\/mbstring\/oniguruma\/enc\/unicode.c, and ext\/mbstring\/oniguruma\/src\/utf32_be.c when a multibyte regular expression pattern contains invalid multibyte sequences.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
+                    "7.1.26",
                     "7.2.14",
-                    "7.1.26"
+                    "7.3.1"
                 ]
             }
         },
@@ -7308,9 +7308,9 @@
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. xmlrpc_decode() can allow a hostile XMLRPC server to cause PHP to read memory outside of allocated areas in base64_decode_xmlrpc in ext\/xmlrpc\/libxmlrpc\/base64.c.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
+                    "7.1.26",
                     "7.2.14",
-                    "7.1.26"
+                    "7.3.1"
                 ]
             }
         },
@@ -7391,8 +7391,8 @@
             "fixVersions": {
                 "base": [
                     "7.1.28",
-                    "7.3.4",
-                    "7.2.17"
+                    "7.2.17",
+                    "7.3.4"
                 ]
             }
         },
@@ -7403,8 +7403,8 @@
             "fixVersions": {
                 "base": [
                     "7.1.28",
-                    "7.3.4",
-                    "7.2.17"
+                    "7.2.17",
+                    "7.3.4"
                 ]
             }
         },
@@ -7414,9 +7414,9 @@
             "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.29, 7.2.x below 7.2.18 and 7.3.x below 7.3.5 can be caused to read past allocated buffer in exif_process_IFD_TAG function. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.5",
+                    "7.1.29",
                     "7.2.18",
-                    "7.1.29"
+                    "7.3.5"
                 ]
             }
         },
@@ -7426,9 +7426,9 @@
             "summary": "When PHP EXIF extension is parsing EXIF information from an image, e.g. via exif_read_data() function, in PHP versions 7.1.x below 7.1.30, 7.2.x below 7.2.19 and 7.3.x below 7.3.6 it is possible to supply it with data what will cause it to read past the allocated buffer. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.6",
+                    "7.1.30",
                     "7.2.19",
-                    "7.1.30"
+                    "7.3.6"
                 ]
             }
         },
@@ -7438,9 +7438,9 @@
             "summary": "When PHP EXIF extension is parsing EXIF information from an image, e.g. via exif_read_data() function, in PHP versions 7.1.x below 7.1.31, 7.2.x below 7.2.21 and 7.3.x below 7.3.8 it is possible to supply it with data what will cause it to read past the allocated buffer. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.8",
+                    "7.1.31",
                     "7.2.21",
-                    "7.1.31"
+                    "7.3.8"
                 ]
             }
         },
@@ -7455,5 +7455,5 @@
             }
         }
     ],
-    "updatedAt": "2019-08-29T16:21:39+00:00"
+    "updatedAt": "2019-08-29T17:16:23+00:00"
 }

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -4446,7 +4446,6 @@
                 ]
             }
         },
-
         {
             "threat": "5.0",
             "cveid": "CVE-2013-7345",
@@ -4455,6 +4454,16 @@
                 "base": [
                     "5.4.27",
                     "5.5.11"
+                ]
+            }
+        },
+        {
+            "threat": "6.8",
+            "cveid": "CVE-2013-7456",
+            "summary": "gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.1.1, as used in PHP before 5.5.36, 5.6.x before 5.6.22, and 7.x before 7.0.7, allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a crafted image that is mishandled by the imagescale function.",
+            "fixVersions": {
+                "base": [
+                    "7.0.7"
                 ]
             }
         },
@@ -5044,6 +5053,18 @@
             }
         },
         {
+            "threat": "4.3",
+            "cveid": "CVE-2015-3152",
+            "summary": "Oracle MySQL before 5.7.3, Oracle MySQL Connector\/C (aka libmysqlclient) before 6.1.3, and MariaDB before 5.5.44 use the --ssl option to mean that SSL is optional, which allows man-in-the-middle attackers to spoof servers via a cleartext-downgrade attack, aka a &quot;BACKRONYM&quot; attack.",
+            "fixVersions": {
+                "base": [
+                    "5.6.11",
+                    "5.5.27",
+                    "5.4.43"
+                ]
+            }
+        },
+        {
             "threat": "7.5",
             "cveid": "CVE-2015-3307",
             "summary": "The phar_parse_metadata function in ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (heap metadata corruption) or possibly have unspecified other impact via a crafted tar archive. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
@@ -5075,6 +5096,16 @@
                 "base": [
                     "5.4.40",
                     "5.5.24",
+                    "5.6.8"
+                ]
+            }
+        },
+        {
+            "threat": "6.4",
+            "cveid": "CVE-2015-3411",
+            "summary": "PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to read or write to arbitrary files via crafted input to an application that calls (1) a DOMDocument load method, (2) the xmlwriter_open_uri function, (3) the finfo_file function, or (4) the hash_hmac_file function, as demonstrated by a filename\\0.xml attack that bypasses an intended configuration in which client users may read only .xml files.",
+            "fixVersions": {
+                "base": [
                     "5.6.8"
                 ]
             }
@@ -5489,6 +5520,16 @@
                 "base": [
                     "5.5.30",
                     "5.6.14"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2015-8383",
+            "summary": "PCRE before 8.38 mishandles certain repeated conditional groups, which allows remote attackers to cause a denial of service (buffer overflow) or possibly have unspecified other impact via a crafted regular expression, as demonstrated by a JavaScript RegExp object encountered by Konqueror.",
+            "fixVersions": {
+                "base": [
+                    "7.0.3"
                 ]
             }
         },
@@ -6054,6 +6095,16 @@
             }
         },
         {
+            "threat": "6.8",
+            "cveid": "CVE-2016-5766",
+            "summary": "Integer overflow in the _gd2GetHeader function in gd_gd2.c in the GD Graphics Library (aka libgd) before 2.2.3, as used in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8, allows remote attackers to cause a denial of service (heap-based buffer overflow and application crash) or possibly have unspecified other impact via crafted chunk dimensions in an image.",
+            "fixVersions": {
+                "base": [
+                    "7.0.8"
+                ]
+            }
+        },
+        {
             "threat": "7.5",
             "cveid": "CVE-2016-5768",
             "summary": "Double free vulnerability in the _php_mb_regex_ereg_replace_exec function in php_mbregex.c in the mbstring extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 allows remote attackers to execute arbitrary code or cause a denial of service (application crash) by leveraging a callback exception. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
@@ -6497,6 +6548,16 @@
         },
         {
             "threat": "5.0",
+            "cveid": "CVE-2016-9933",
+            "summary": "Stack consumption vulnerability in the gdImageFillToBorder function in gd.c in the GD Graphics Library (aka libgd) before 2.2.2, as used in PHP before 5.6.28 and 7.x before 7.0.13, allows remote attackers to cause a denial of service (segmentation violation) via a crafted imagefilltoborder call that triggers use of a negative color value.",
+            "fixVersions": {
+                "base": [
+                    "7.0.13"
+                ]
+            }
+        },
+        {
+            "threat": "5.0",
             "cveid": "CVE-2016-9934",
             "summary": "ext\/wddx\/wddx.c in PHP before 5.6.28 and 7.x before 7.0.13 allows remote attackers to cause a denial of service (NULL pointer dereference) via crafted serialized data in a wddxPacket XML document, as demonstrated by a PDORow string. \n Publish Date : 2017-01-04 Last Update Date : 2017-01-17",
             "fixVersions": {
@@ -6581,6 +6642,18 @@
                 "base": [
                     "7.0.15",
                     "7.1.1"
+                ]
+            }
+        },
+        {
+            "threat": "9.8",
+            "cveid": "CVE-2016-10166",
+            "summary": "Integer underflow in the _gdContributionsAlloc function in gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.2.4 allows remote attackers to have unspecified impact via vectors related to decrementing the u variable.",
+            "fixVersions": {
+                "base": [
+                    "7.3.1",
+                    "7.2.14",
+                    "7.1.26"
                 ]
             }
         },
@@ -6945,7 +7018,7 @@
         {
             "threat": "4.3",
             "cveid": "CVE-2018-10547",
-            "summary": "An issue was discovered in ext/phar/phar_object.c in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. There is Reflected XSS on the PHAR 403 and 404 error pages via request data of a request for a .phar file. NOTE: this vulnerability exists because of an incomplete fix for CVE-2018-5712.",
+            "summary": "An issue was discovered in ext\/phar\/phar_object.c in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. There is Reflected XSS on the PHAR 403 and 404 error pages via request data of a request for a .phar file. NOTE: this vulnerability exists because of an incomplete fix for CVE-2018-5712.",
             "fixVersions": {
                 "base": [
                     "5.6.36",
@@ -7125,6 +7198,19 @@
             }
         },
         {
+            "threat": "7.5",
+            "cveid": "CVE-2018-19518",
+            "summary": "University of Washington IMAP Toolkit 2007f on UNIX, as used in imap_open() in PHP and other products, launches an rsh command (by means of the imap_rimap function in c-client\/imap4r1.c and the tcp_aopen function in osdep\/unix\/tcp_unix.c) without preventing argument injection, which might allow remote attackers to execute arbitrary OS commands if the IMAP server name is untrusted input (e.g., entered by a user of a web application) and if rsh has been replaced by a program with different argument semantics. For example, if rsh is a link to ssh (as seen on Debian and Ubuntu systems), then the attack can use an IMAP server name containing a \"-oProxyCommand\" argument.",
+            "fixVersions": {
+                "base": [
+                    "7.0.33",
+                    "7.3.0",
+                    "7.2.13",
+                    "7.1.25"
+                ]
+            }
+        },
+        {
             "threat": "5.0",
             "cveid": "CVE-2018-19935",
             "summary": "ext\/imap\/php_imap.c in PHP 5.x and 7.x before 7.3.0 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via an empty string in the message argument to the imap_mail function. \n Publish Date : 2018-12-07 Last Update Date : 2018-12-31",
@@ -7144,26 +7230,97 @@
             }
         },
         {
-            "threat": "9.1",
-            "cveid": "CVE-2019-11034",
-            "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.28, 7.2.x below 7.2.17 and 7.3.x below 7.3.4 can be caused to read past allocated buffer in exif_process_IFD_TAG function. This may lead to information disclosure or crash.",
+            "threat": "7.5",
+            "cveid": "CVE-2018-20783",
+            "summary": "In PHP before 5.6.39, 7.x before 7.0.33, 7.1.x before 7.1.25, and 7.2.x before 7.2.13, a buffer over-read in PHAR reading functions may allow an attacker to read allocated or unallocated memory past the actual data when trying to parse a .phar file. This is related to phar_parse_pharfile in ext\/phar\/phar.c.",
             "fixVersions": {
                 "base": [
-                    "7.1.28",
-                    "7.3.4",
-                    "7.2.17"
+                    "7.0.33",
+                    "7.3.0",
+                    "7.2.13",
+                    "7.1.25"
                 ]
             }
         },
         {
-            "threat": "9.1",
-            "cveid": "CVE-2019-11035",
-            "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.28, 7.2.x below 7.2.17 and 7.3.x below 7.3.4 can be caused to read past allocated buffer in exif_iif_add_value function. This may lead to information disclosure or crash.",
+            "threat": "8.8",
+            "cveid": "CVE-2019-6977",
+            "summary": "gdImageColorMatch in gd_color_match.c in the GD Graphics Library (aka LibGD) 2.2.5, as used in the imagecolormatch function in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1, has a heap-based buffer overflow. This can be exploited by an attacker who is able to trigger imagecolormatch calls with crafted image data.",
             "fixVersions": {
                 "base": [
-                    "7.1.28",
-                    "7.3.4",
-                    "7.2.17"
+                    "7.3.1",
+                    "7.2.14",
+                    "7.1.26"
+                ]
+            }
+        },
+        {
+            "threat": "9.8",
+            "cveid": "CVE-2019-9020",
+            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. Invalid input to the function xmlrpc_decode() can lead to an invalid memory access (heap out of bounds read or read after free). This is related to xml_elem_parse_buf in ext\/xmlrpc\/libxmlrpc\/xml_element.c.",
+            "fixVersions": {
+                "base": [
+                    "7.3.1",
+                    "7.2.14",
+                    "7.1.26"
+                ]
+            }
+        },
+        {
+            "threat": "9.8",
+            "cveid": "CVE-2019-9021",
+            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A heap-based buffer over-read in PHAR reading functions in the PHAR extension may allow an attacker to read allocated or unallocated memory past the actual data when trying to parse the file name, a different vulnerability than CVE-2018-20783. This is related to phar_detect_phar_fname_ext in ext\/phar\/phar.c.",
+            "fixVersions": {
+                "base": [
+                    "7.3.1",
+                    "7.2.14",
+                    "7.1.26"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2019-9022",
+            "summary": "An issue was discovered in PHP 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.2. dns_get_record misparses a DNS response, which can allow a hostile DNS server to cause PHP to misuse memcpy, leading to read operations going past the buffer allocated for DNS data. This affects php_parserr in ext\/standard\/dns.c for DNS_CAA and DNS_ANY queries.",
+            "fixVersions": {
+                "base": [
+                    "7.3.2",
+                    "7.2.14",
+                    "7.1.26"
+                ]
+            }
+        },
+        {
+            "threat": "9.8",
+            "cveid": "CVE-2019-9023",
+            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A number of heap-based buffer over-read instances are present in mbstring regular expression functions when supplied with invalid multibyte data. These occur in ext\/mbstring\/oniguruma\/regcomp.c, ext\/mbstring\/oniguruma\/regexec.c, ext\/mbstring\/oniguruma\/regparse.c, ext\/mbstring\/oniguruma\/enc\/unicode.c, and ext\/mbstring\/oniguruma\/src\/utf32_be.c when a multibyte regular expression pattern contains invalid multibyte sequences.",
+            "fixVersions": {
+                "base": [
+                    "7.3.1",
+                    "7.2.14",
+                    "7.1.26"
+                ]
+            }
+        },
+        {
+            "threat": "7.5",
+            "cveid": "CVE-2019-9024",
+            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. xmlrpc_decode() can allow a hostile XMLRPC server to cause PHP to read memory outside of allocated areas in base64_decode_xmlrpc in ext\/xmlrpc\/libxmlrpc\/base64.c.",
+            "fixVersions": {
+                "base": [
+                    "7.3.1",
+                    "7.2.14",
+                    "7.1.26"
+                ]
+            }
+        },
+        {
+            "threat": "9.8",
+            "cveid": "CVE-2019-9025",
+            "summary": "An issue was discovered in PHP 7.3.x before 7.3.1. An invalid multibyte string supplied as an argument to the mb_split() function in ext\/mbstring\/php_mbregex.c can cause PHP to execute memcpy() with a negative argument, which could read and write past buffers allocated for the data.",
+            "fixVersions": {
+                "base": [
+                    "7.3.1"
                 ]
             }
         },
@@ -7171,30 +7328,6 @@
             "threat": "7.5",
             "cveid": "CVE-2019-9637",
             "summary": "An issue was discovered in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. Due to the way rename() across filesystems is implemented, it is possible that file being renamed is briefly available with wrong permissions while the rename is ongoing, thus enabling unauthorized users to access the data.",
-            "fixVersions": {
-                "base": [
-                    "7.1.27",
-                    "7.2.16",
-                    "7.3.3"
-                ]
-            }
-        },
-        {
-            "threat": "9.8",
-            "cveid": "CVE-2019-9641",
-            "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an uninitialized read in exif_process_IFD_in_TIFF.",
-            "fixVersions": {
-                "base": [
-                    "7.1.27",
-                    "7.2.16",
-                    "7.3.3"
-                ]
-            }
-        },
-        {
-            "threat": "7.5",
-            "cveid": "CVE-2019-9640",
-            "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an Invalid Read in exif_process_SOFn.",
             "fixVersions": {
                 "base": [
                     "7.1.27",
@@ -7229,123 +7362,98 @@
         },
         {
             "threat": "7.5",
-            "cveid": "CVE-2019-9022",
-            "summary": "An issue was discovered in PHP 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.2. dns_get_record misparses a DNS response, which can allow a hostile DNS server to cause PHP to misuse memcpy, leading to read operations going past the buffer allocated for DNS data. This affects php_parserr in ext/standard/dns.c for DNS_CAA and DNS_ANY queries.",
+            "cveid": "CVE-2019-9640",
+            "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an Invalid Read in exif_process_SOFn.",
             "fixVersions": {
                 "base": [
-                    "7.3.2",
-                    "7.2.14",
-                    "7.1.26"
+                    "7.1.27",
+                    "7.2.16",
+                    "7.3.3"
                 ]
             }
         },
         {
             "threat": "9.8",
-            "cveid": "CVE-2016-10166",
-            "summary": "Integer underflow in the _gdContributionsAlloc function in gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.2.4 allows remote attackers to have unspecified impact via vectors related to decrementing the u variable.",
+            "cveid": "CVE-2019-9641",
+            "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an uninitialized read in exif_process_IFD_in_TIFF.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
-                    "7.2.14",
-                    "7.1.26"
+                    "7.1.27",
+                    "7.2.16",
+                    "7.3.3"
                 ]
             }
         },
         {
-            "threat": "8.8",
-            "cveid": "CVE-2019-6977",
-            "summary": "gdImageColorMatch in gd_color_match.c in the GD Graphics Library (aka LibGD) 2.2.5, as used in the imagecolormatch function in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1, has a heap-based buffer overflow. This can be exploited by an attacker who is able to trigger imagecolormatch calls with crafted image data.",
+            "threat": "9.1",
+            "cveid": "CVE-2019-11034",
+            "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.28, 7.2.x below 7.2.17 and 7.3.x below 7.3.4 can be caused to read past allocated buffer in exif_process_IFD_TAG function. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
-                    "7.2.14",
-                    "7.1.26"
+                    "7.1.28",
+                    "7.3.4",
+                    "7.2.17"
                 ]
             }
         },
         {
-            "threat": "9.8",
-            "cveid": "CVE-2019-9025",
-            "summary": "An issue was discovered in PHP 7.3.x before 7.3.1. An invalid multibyte string supplied as an argument to the mb_split() function in ext/mbstring/php_mbregex.c can cause PHP to execute memcpy() with a negative argument, which could read and write past buffers allocated for the data.",
+            "threat": "9.1",
+            "cveid": "CVE-2019-11035",
+            "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.28, 7.2.x below 7.2.17 and 7.3.x below 7.3.4 can be caused to read past allocated buffer in exif_iif_add_value function. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.1"
+                    "7.1.28",
+                    "7.3.4",
+                    "7.2.17"
                 ]
             }
         },
         {
-            "threat": "9.8",
-            "cveid": "CVE-2019-9023",
-            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A number of heap-based buffer over-read instances are present in mbstring regular expression functions when supplied with invalid multibyte data. These occur in ext/mbstring/oniguruma/regcomp.c, ext/mbstring/oniguruma/regexec.c, ext/mbstring/oniguruma/regparse.c, ext/mbstring/oniguruma/enc/unicode.c, and ext/mbstring/oniguruma/src/utf32_be.c when a multibyte regular expression pattern contains invalid multibyte sequences.",
+            "threat": "6.4",
+            "cveid": "CVE-2019-11036",
+            "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.29, 7.2.x below 7.2.18 and 7.3.x below 7.3.5 can be caused to read past allocated buffer in exif_process_IFD_TAG function. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
-                    "7.2.14",
-                    "7.1.26"
+                    "7.3.5",
+                    "7.2.18",
+                    "7.1.29"
                 ]
             }
         },
         {
-            "threat": "9.8",
-            "cveid": "CVE-2019-9021",
-            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A heap-based buffer over-read in PHAR reading functions in the PHAR extension may allow an attacker to read allocated or unallocated memory past the actual data when trying to parse the file name, a different vulnerability than CVE-2018-20783. This is related to phar_detect_phar_fname_ext in ext/phar/phar.c.",
+            "threat": "6.4",
+            "cveid": "CVE-2019-11040",
+            "summary": "When PHP EXIF extension is parsing EXIF information from an image, e.g. via exif_read_data() function, in PHP versions 7.1.x below 7.1.30, 7.2.x below 7.2.19 and 7.3.x below 7.3.6 it is possible to supply it with data what will cause it to read past the allocated buffer. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
-                    "7.2.14",
-                    "7.1.26"
+                    "7.3.6",
+                    "7.2.19",
+                    "7.1.30"
                 ]
             }
         },
         {
-            "threat": "9.8",
-            "cveid": "CVE-2019-9020",
-            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. Invalid input to the function xmlrpc_decode() can lead to an invalid memory access (heap out of bounds read or read after free). This is related to xml_elem_parse_buf in ext/xmlrpc/libxmlrpc/xml_element.c.",
+            "threat": "6.8",
+            "cveid": "CVE-2019-11042",
+            "summary": "When PHP EXIF extension is parsing EXIF information from an image, e.g. via exif_read_data() function, in PHP versions 7.1.x below 7.1.31, 7.2.x below 7.2.21 and 7.3.x below 7.3.8 it is possible to supply it with data what will cause it to read past the allocated buffer. This may lead to information disclosure or crash.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
-                    "7.2.14",
-                    "7.1.26"
+                    "7.3.8",
+                    "7.2.21",
+                    "7.1.31"
                 ]
             }
         },
         {
             "threat": "7.5",
-            "cveid": "CVE-2019-9024",
-            "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. xmlrpc_decode() can allow a hostile XMLRPC server to cause PHP to read memory outside of allocated areas in base64_decode_xmlrpc in ext/xmlrpc/libxmlrpc/base64.c.",
+            "cveid": "CVE-2019-13224",
+            "summary": "A use-after-free in onig_new_deluxe() in regext.c in Oniguruma 6.9.2 allows attackers to potentially cause information disclosure, denial of service, or possibly code execution by providing a crafted regular expression. The attacker provides a pair of a regex pattern and a string, with a multi-byte encoding that gets handled by onig_new_deluxe(). Oniguruma issues often affect Ruby, as well as common optional libraries for PHP and Rust.",
             "fixVersions": {
                 "base": [
-                    "7.3.1",
-                    "7.2.14",
-                    "7.1.26"
-                ]
-            }
-        },
-        {
-            "threat": "7.5",
-            "cveid": "CVE-2018-19518",
-            "summary": "University of Washington IMAP Toolkit 2007f on UNIX, as used in imap_open() in PHP and other products, launches an rsh command (by means of the imap_rimap function in c-client/imap4r1.c and the tcp_aopen function in osdep/unix/tcp_unix.c) without preventing argument injection, which might allow remote attackers to execute arbitrary OS commands if the IMAP server name is untrusted input (e.g., entered by a user of a web application) and if rsh has been replaced by a program with different argument semantics. For example, if rsh is a link to ssh (as seen on Debian and Ubuntu systems), then the attack can use an IMAP server name containing a \"-oProxyCommand\" argument.",
-            "fixVersions": {
-                "base": [
-                    "7.0.33",
-                    "7.3.0",
-                    "7.2.13",
-                    "7.1.25"
-                ]
-            }
-        },
-        {
-            "threat": "7.5",
-            "cveid": "CVE-2018-20783",
-            "summary": "In PHP before 5.6.39, 7.x before 7.0.33, 7.1.x before 7.1.25, and 7.2.x before 7.2.13, a buffer over-read in PHAR reading functions may allow an attacker to read allocated or unallocated memory past the actual data when trying to parse a .phar file. This is related to phar_parse_pharfile in ext/phar/phar.c.",
-            "fixVersions": {
-                "base": [
-                    "7.0.33",
-                    "7.3.0",
-                    "7.2.13",
-                    "7.1.25"
+                    "7.3.9"
                 ]
             }
         }
-    ]
+    ],
+    "updatedAt": "2019-08-29T16:21:39+00:00"
 }

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -7450,10 +7450,11 @@
             "summary": "A use-after-free in onig_new_deluxe() in regext.c in Oniguruma 6.9.2 allows attackers to potentially cause information disclosure, denial of service, or possibly code execution by providing a crafted regular expression. The attacker provides a pair of a regex pattern and a string, with a multi-byte encoding that gets handled by onig_new_deluxe(). Oniguruma issues often affect Ruby, as well as common optional libraries for PHP and Rust.",
             "fixVersions": {
                 "base": [
+                    "7.1.32",
                     "7.3.9"
                 ]
             }
         }
     ],
-    "updatedAt": "2019-08-29T17:16:23+00:00"
+    "updatedAt": "2019-08-30T16:14:47+00:00"
 }

--- a/tests/Psecio/Versionscan/CheckFormatTest.php
+++ b/tests/Psecio/Versionscan/CheckFormatTest.php
@@ -14,8 +14,9 @@ class CheckFormatTest extends \PHPUnit_Framework_TestCase
 
     public function testEverythingIsUnderTheChecksKey()
     {
-        $this->assertCount(1, $this->checks);
+        $this->assertCount(2, $this->checks);
         $this->assertArrayHasKey('checks', $this->checks);
+        $this->assertArrayHasKey('updatedAt', $this->checks);
     }
 
     public function testStructureOfEachEntry()


### PR DESCRIPTION
The 'missing' command is great for updates, but needs some TLC to make it easier to use.

* Added option 'save-results' to allow the results to be automatically added to the checks.json
* Enforce sorting of the checks.json file every time the missing command is ran
* Save the timestamp to checks.json as 'updatedAt' to give a reference period for how old the checks are
* Add php7 changelog to the missing checker
* 'sunra/php-simple-html-dom-parser' is dead and throwing a ton of errors for newer versions of PHP. Replace it with an updated fork 'kub-at/php-simple-html-dom-parser'
* Bump min php version since the array syntax is not avaliable before php 5.4
* Add ext-json as a dependency
* Fix unit tests (broken in master branch)
* Add travis tests for php 7.3

Finally, I ran the 'missing' command with the changes I made and committed the updated checks.