### PR TITLE
Refactor the 'missing' command to pull CVE details from NIST data feeds.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "require":{
         "php":">=5.4.0",
         "ext-json": "*",
-        "symfony/console": "~2.1|~3.0",
-        "kub-at/php-simple-html-dom-parser": "^1.9"
+        "symfony/console": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*",

--- a/src/Psecio/Versionscan/Command/ScanCommand.php
+++ b/src/Psecio/Versionscan/Command/ScanCommand.php
@@ -79,8 +79,8 @@ class ScanCommand extends Command
 
                     return $r1 > $r2 ? -1 : 1;
                 } elseif ($sort == 'risk') {
-                    $r1 = (integer) $row1['risk'];
-                    $r2 = (integer) $row2['risk'];
+                    $r1 = (float) $row1['risk'];
+                    $r2 = (float) $row2['risk'];
 
                     return $r1 > $r2 ? -1 : 1;
                 }

--- a/src/Psecio/Versionscan/checks.json
+++ b/src/Psecio/Versionscan/checks.json
@@ -1,9 +1,11 @@
 {
     "checks": [
         {
-            "threat": "5.0",
             "cveid": "CVE-2000-0860",
-            "summary": "The file upload capability in PHP versions 3 and 4 allows remote attackers to read arbitrary files by setting hidden form fields whose names match the names of internal PHP script variables. \nPublish Date : 2000-11-14 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "The file upload capability in PHP versions 3 and 4 allows remote attackers to read arbitrary files by setting hidden form fields whose names match the names of internal PHP script variables.",
+            "lastModifiedDate": "2017-10-10T01:29:00+0000",
+            "publishedDate": "2000-11-14T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.1"
@@ -11,9 +13,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2000-0967",
-            "summary": "PHP 3 and 4 do not properly cleanse user-injected format strings, which allows remote attackers to execute arbitrary commands by triggering error messages that are improperly written to the error logs. \nPublish Date : 2000-12-19 Last Update Date : 2008-09-05",
+            "threat": 10,
+            "summary": "PHP 3 and 4 do not properly cleanse user-injected format strings, which allows remote attackers to execute arbitrary commands by triggering error messages that are improperly written to the error logs.",
+            "lastModifiedDate": "2018-05-03T01:29:00+0000",
+            "publishedDate": "2000-12-19T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.1"
@@ -21,9 +25,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2001-0108",
-            "summary": "PHP Apache module 4.0.4 and earlier allows remote attackers to bypass .htaccess access restrictions via a malformed HTTP request on an unrestricted page that causes PHP to use those access controls on the next page that is requested. \n Publish Date : 2001-03-12 Last Update Date : 2008-09-10",
+            "threat": 5,
+            "summary": "PHP Apache module 4.0.4 and earlier allows remote attackers to bypass .htaccess access restrictions via a malformed HTTP request on an unrestricted page that causes PHP to use those access controls on the next page that is requested.",
+            "lastModifiedDate": "2017-10-10T01:29:00+0000",
+            "publishedDate": "2001-03-12T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.5"
@@ -31,9 +37,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2001-1246",
-            "summary": "PHP 4.0.5 through 4.1.0 in safe mode does not properly cleanse the 5th parameter to the mail() function, which allows local users and possibly remote attackers to execute arbitrary commands via shell metacharacters. \n Publish Date : 2001-06-30 Last Update Date : 2008-09-10",
+            "threat": 7.5,
+            "summary": "PHP 4.0.5 through 4.1.0 in safe mode does not properly cleanse the 5th parameter to the mail() function, which allows local users and possibly remote attackers to execute arbitrary commands via shell metacharacters.",
+            "lastModifiedDate": "2008-09-10T19:10:00+0000",
+            "publishedDate": "2001-06-30T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.6"
@@ -41,9 +49,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2001-1247",
-            "summary": "PHP 4.0.4pl1 and 4.0.5 in safe mode allows remote attackers to read and write files owned by the web server UID by uploading a PHP script that uses the error_log function to access the files. \n Publish Date : 2001-12-06 Last Update Date : 2012-06-25",
+            "threat": 6.4,
+            "summary": "PHP 4.0.4pl1 and 4.0.5 in safe mode allows remote attackers to read and write files owned by the web server UID by uploading a PHP script that uses the error_log function to access the files.",
+            "lastModifiedDate": "2012-06-25T04:00:00+0000",
+            "publishedDate": "2001-12-06T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.6"
@@ -51,9 +61,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2001-1385",
-            "summary": "The Apache module for PHP 4.0.0 through PHP 4.0.4, when disabled with the 'engine = off' option for a virtual host, may disable PHP for other virtual hosts, which could cause Apache to serve the source code of PHP scripts. \n Publish Date : 2001-01-12 Last Update Date : 2008-09-10",
+            "threat": 5,
+            "summary": "The Apache module for PHP 4.0.0 through PHP 4.0.4, when disabled with the 'engine = off' option for a virtual host, may disable PHP for other virtual hosts, which could cause Apache to serve the source code of PHP scripts.",
+            "lastModifiedDate": "2016-10-18T02:14:00+0000",
+            "publishedDate": "2001-01-12T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.5"
@@ -61,9 +73,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2002-0081",
-            "summary": "Buffer overflows in (1) php_mime_split in PHP 4.1.0, 4.1.1, and 4.0.6 and earlier, and (2) php3_mime_split in PHP 3.0.x allows remote attackers to execute arbitrary code via a multipart\/form-data HTTP POST request when file_uploads is enabled. \n Publish Date : 2002-03-08 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Buffer overflows in (1) php_mime_split in PHP 4.1.0, 4.1.1, and 4.0.6 and earlier, and (2) php3_mime_split in PHP 3.0.x allows remote attackers to execute arbitrary code via a multipart\/form-data HTTP POST request when file_uploads is enabled.",
+            "lastModifiedDate": "2016-10-18T02:15:00+0000",
+            "publishedDate": "2002-03-08T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -72,9 +86,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2002-0121",
-            "summary": "PHP 4.0 through 4.1.1 stores session IDs in temporary files whose name contains the session ID, which allows local users to hijack web connections. \n Publish Date : 2002-03-25 Last Update Date : 2008-09-10",
+            "threat": 2.1,
+            "summary": "PHP 4.0 through 4.1.1 stores session IDs in temporary files whose name contains the session ID, which allows local users to hijack web connections.",
+            "lastModifiedDate": "2008-09-11T00:00:00+0000",
+            "publishedDate": "2002-03-25T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -83,9 +99,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2002-0229",
-            "summary": "Safe Mode feature (safe_mode) in PHP 3.0 through 4.1.0 allows attackers with access to the MySQL database to bypass Safe Mode access restrictions and read arbitrary files using \"LOAD DATA INFILE LOCAL\" SQL statements. \n Publish Date : 2002-05-16 Last Update Date : 2008-09-10",
+            "threat": 7.5,
+            "summary": "Safe Mode feature (safe_mode) in PHP 3.0 through 4.1.0 allows attackers with access to the MySQL database to bypass Safe Mode access restrictions and read arbitrary files using \"LOAD DATA INFILE LOCAL\" SQL statements.",
+            "lastModifiedDate": "2016-10-18T02:17:00+0000",
+            "publishedDate": "2002-05-16T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -94,9 +112,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2002-0253",
-            "summary": "PHP, when not configured with the \"display_errors = Off\" setting in php.ini, allows remote attackers to obtain the physical path for an include file via a trailing slash in a request to a directly accessible PHP program, which modifies the base path, causes the include directive to fail, and produces an error message that contains the path. \n Publish Date : 2002-05-29 Last Update Date : 2008-09-10",
+            "threat": 5,
+            "summary": "PHP, when not configured with the \"display_errors = Off\" setting in php.ini, allows remote attackers to obtain the physical path for an include file via a trailing slash in a request to a directly accessible PHP program, which modifies the base path, causes the include directive to fail, and produces an error message that contains the path.",
+            "lastModifiedDate": "2016-10-18T02:17:00+0000",
+            "publishedDate": "2002-05-29T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -105,9 +125,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2002-0484",
-            "summary": "move_uploaded_file in PHP does not does not check for the base directory (open_basedir), which could allow remote attackers to upload files to unintended locations on the system. \n Publish Date : 2002-08-12 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "move_uploaded_file in PHP does not does not check for the base directory (open_basedir), which could allow remote attackers to upload files to unintended locations on the system.",
+            "lastModifiedDate": "2016-10-18T02:20:00+0000",
+            "publishedDate": "2002-08-12T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -116,9 +138,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2002-0717",
-            "summary": "PHP 4.2.0 and 4.2.1 allows remote attackers to cause a denial of service and possibly execute arbitrary code via an HTTP POST request with certain arguments in a multipart\/form-data form, which generates an error condition that is not properly handled and causes improper memory to be freed. \n Publish Date : 2002-07-26 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "PHP 4.2.0 and 4.2.1 allows remote attackers to cause a denial of service and possibly execute arbitrary code via an HTTP POST request with certain arguments in a multipart\/form-data form, which generates an error condition that is not properly handled and causes improper memory to be freed.",
+            "lastModifiedDate": "2016-10-18T02:21:00+0000",
+            "publishedDate": "2002-07-26T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.2.2"
@@ -126,9 +150,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2002-0985",
-            "summary": "Argument injection vulnerability in the mail function for PHP 4.x to 4.2.2 may allow attackers to bypass safe mode restrictions and modify command line arguments to the MTA (e.g. sendmail) in the 5th argument to mail(), altering MTA behavior and possibly executing commands. \n Publish Date : 2002-09-24 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Argument injection vulnerability in the mail function for PHP 4.x to 4.2.2 may allow attackers to bypass safe mode restrictions and modify command line arguments to the MTA (e.g. sendmail) in the 5th argument to mail(), altering MTA behavior and possibly executing commands.",
+            "lastModifiedDate": "2017-10-10T01:30:00+0000",
+            "publishedDate": "2002-09-24T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -138,9 +164,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2002-0986",
-            "summary": "The mail function in PHP 4.x to 4.2.2 does not filter ASCII control characters from its arguments, which could allow remote attackers to modify mail message content, including mail headers, and possibly use PHP as a \"spam proxy.\" \n Publish Date : 2002-09-24 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "The mail function in PHP 4.x to 4.2.2 does not filter ASCII control characters from its arguments, which could allow remote attackers to modify mail message content, including mail headers, and possibly use PHP as a \"spam proxy.\"",
+            "lastModifiedDate": "2017-10-10T01:30:00+0000",
+            "publishedDate": "2002-09-24T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -150,9 +178,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2002-1396",
-            "summary": "Heap-based buffer overflow in the wordwrap function in PHP after 4.1.2 and before 4.3.0 may allow attackers to cause a denial of service or execute arbitrary code. \n Publish Date : 2003-01-17 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Heap-based buffer overflow in the wordwrap function in PHP after 4.1.2 and before 4.3.0 may allow attackers to cause a denial of service or execute arbitrary code.",
+            "lastModifiedDate": "2018-05-03T01:29:00+0000",
+            "publishedDate": "2003-01-17T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.1.3",
@@ -161,9 +191,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2002-1783",
-            "summary": "CRLF injection vulnerability in PHP 4.2.1 through 4.2.3, when allow_url_fopen is enabled, allows remote attackers to modify HTTP headers for outgoing requests by causing CRLF sequences to be injected into arguments that are passed to the (1) fopen or (2) file functions. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "CRLF injection vulnerability in PHP 4.2.1 through 4.2.3, when allow_url_fopen is enabled, allows remote attackers to modify HTTP headers for outgoing requests by causing CRLF sequences to be injected into arguments that are passed to the (1) fopen or (2) file functions.",
+            "lastModifiedDate": "2017-07-11T01:29:00+0000",
+            "publishedDate": "2002-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -173,9 +205,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2002-1954",
-            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.2.3 allows remote attackers to inject arbitrary web script or HTML via the query string argument, as demonstrated using soinfo.php. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "threat": 4.3,
+            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.2.3 allows remote attackers to inject arbitrary web script or HTML via the query string argument, as demonstrated using soinfo.php.",
+            "lastModifiedDate": "2008-09-05T20:31:00+0000",
+            "publishedDate": "2002-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.2.4"
@@ -183,9 +217,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2002-2214",
-            "summary": "The php_if_imap_mime_header_decode function in the IMAP functionality in PHP before 4.2.2 allows remote attackers to cause a denial of service (crash) via an e-mail header with a long \"To\" header. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "The php_if_imap_mime_header_decode function in the IMAP functionality in PHP before 4.2.2 allows remote attackers to cause a denial of service (crash) via an e-mail header with a long \"To\" header.",
+            "lastModifiedDate": "2008-09-05T20:32:00+0000",
+            "publishedDate": "2002-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.2.2"
@@ -193,9 +229,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2002-2215",
-            "summary": "The imap_header function in the IMAP functionality for PHP before 4.3.0 allows remote attackers to cause a denial of service via an e-mail message with a large number of \"To\" addresses, which triggers an error in the rfc822_write_address function. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "The imap_header function in the IMAP functionality for PHP before 4.3.0 allows remote attackers to cause a denial of service via an e-mail message with a large number of \"To\" addresses, which triggers an error in the rfc822_write_address function.",
+            "lastModifiedDate": "2008-09-05T20:32:00+0000",
+            "publishedDate": "2002-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -205,9 +243,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2002-2309",
-            "summary": "php.exe in PHP 3.0 through 4.2.2, when running on Apache, does not terminate properly, which allows remote attackers to cause a denial of service via a direct request without arguments. \n Publish Date : 2002-12-31 Last Update Date : 2008-09-05",
+            "threat": 7.8,
+            "summary": "php.exe in PHP 3.0 through 4.2.2, when running on Apache, does not terminate properly, which allows remote attackers to cause a denial of service via a direct request without arguments.",
+            "lastModifiedDate": "2008-09-05T20:32:00+0000",
+            "publishedDate": "2002-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -217,9 +257,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2003-0097",
-            "summary": "Unknown vulnerability in CGI module for PHP 4.3.0 allows attackers to access arbitrary files as the PHP user, and possibly execute PHP code, by bypassing the CGI force redirect settings (cgi.force_redirect or --enable-force-cgi-redirect). \nPublish Date : 2003-03-03 Last Update Date : 2008-09-10",
+            "threat": 7.5,
+            "summary": "Unknown vulnerability in CGI module for PHP 4.3.0 allows attackers to access arbitrary files as the PHP user, and possibly execute PHP code, by bypassing the CGI force redirect settings (cgi.force_redirect or --enable-force-cgi-redirect).",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2003-03-03T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.1"
@@ -227,9 +269,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2003-0166",
-            "summary": "Integer signedness error in emalloc() function for PHP before 4.3.2 allow remote attackers to cause a denial of service (memory consumption) and possibly execute arbitrary code via negative arguments to functions such as (1) socket_recv, (2) socket_recvfrom, and possibly other functions. \n Publish Date : 2003-04-02 Last Update Date : 2008-09-10",
+            "threat": 7.5,
+            "summary": "Integer signedness error in emalloc() function for PHP before 4.3.2 allow remote attackers to cause a denial of service (memory consumption) and possibly execute arbitrary code via negative arguments to functions such as (1) socket_recv, (2) socket_recvfrom, and possibly other functions.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2003-04-02T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -240,9 +284,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2003-0172",
-            "summary": "Buffer overflow in openlog function for PHP 4.3.1 on Windows operating system, and possibly other OSes, allows remote attackers to cause a crash and possibly execute arbitrary code via a long filename argument. \n Publish Date : 2003-04-02 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Buffer overflow in openlog function for PHP 4.3.1 on Windows operating system, and possibly other OSes, allows remote attackers to cause a crash and possibly execute arbitrary code via a long filename argument.",
+            "lastModifiedDate": "2017-07-11T01:29:00+0000",
+            "publishedDate": "2003-04-02T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.2"
@@ -250,9 +296,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2003-0249",
-            "summary": "** DISPUTED **  PHP treats unknown methods such as \"PoSt\" as a GET request, which could allow attackers to intended access restrictions if PHP is running on a server that passes on all methods, such as Apache httpd 2.0, as demonstrated using a Limit directive.  NOTE: this issue has been disputed by the Apache security team, saying \"It is by design that PHP allows scripts to process any request method.  A script which does not explicitly verify the request method will hence be processed as normal for arbitrary methods.  It is therefore expected behaviour that one cannot implement per-method access control using the Apache configuration alone, which is the assumption made in this report.\" \n Publish Date : 2003-12-31 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "** DISPUTED **  PHP treats unknown methods such as \"PoSt\" as a GET request, which could allow attackers to intended access restrictions if PHP is running on a server that passes on all methods, such as Apache httpd 2.0, as demonstrated using a Limit directive.  NOTE: this issue has been disputed by the Apache security team, saying \"It is by design that PHP allows scripts to process any request method.  A script which does not explicitly verify the request method will hence be processed as normal for arbitrary methods.  It is therefore expected behaviour that one cannot implement per-method access control using the Apache configuration alone, which is the assumption made in this report.\"",
+            "lastModifiedDate": "2008-09-05T20:33:00+0000",
+            "publishedDate": "2003-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -260,9 +308,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2003-0442",
-            "summary": "Cross-site scripting (XSS) vulnerability in the transparent SID support capability for PHP before 4.3.2 (session.use_trans_sid) allows remote attackers to insert arbitrary script via the PHPSESSID parameter. \n Publish Date : 2003-07-24 Last Update Date : 2008-09-10",
+            "threat": 4.3,
+            "summary": "Cross-site scripting (XSS) vulnerability in the transparent SID support capability for PHP before 4.3.2 (session.use_trans_sid) allows remote attackers to insert arbitrary script via the PHPSESSID parameter.",
+            "lastModifiedDate": "2018-05-03T01:29:00+0000",
+            "publishedDate": "2003-07-24T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.2"
@@ -270,9 +320,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2003-0860",
-            "summary": "Buffer overflows in PHP before 4.3.3 have unknown impact and unknown attack vectors. \n Publish Date : 2003-11-17 Last Update Date : 2008-09-05",
+            "threat": 10,
+            "summary": "Buffer overflows in PHP before 4.3.3 have unknown impact and unknown attack vectors.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2003-11-17T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -283,9 +335,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2003-0861",
-            "summary": "Integer overflows in (1) base64_encode and (2) the GD library for PHP before 4.3.3 have unknown impact and unknown attack vectors. \n Publish Date : 2003-11-17 Last Update Date : 2008-09-10",
+            "threat": 10,
+            "summary": "Integer overflows in (1) base64_encode and (2) the GD library for PHP before 4.3.3 have unknown impact and unknown attack vectors.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2003-11-17T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -296,9 +350,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2003-0863",
-            "summary": "The php_check_safe_mode_include_dir function in fopen_wrappers.c of PHP 4.3.x returns a success value (0) when the safe_mode_include_dir variable is not specified in configuration, which differs from the previous failure value and may allow remote attackers to exploit file include vulnerabilities in PHP applications. \n Publish Date : 2003-11-17 Last Update Date : 2008-09-10",
+            "threat": 7.5,
+            "summary": "The php_check_safe_mode_include_dir function in fopen_wrappers.c of PHP 4.3.x returns a success value (0) when the safe_mode_include_dir variable is not specified in configuration, which differs from the previous failure value and may allow remote attackers to exploit file include vulnerabilities in PHP applications.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2003-11-17T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.3"
@@ -306,9 +362,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2003-1302",
-            "summary": "The IMAP functionality in PHP before 4.3.1 allows remote attackers to cause a denial of service via an e-mail message with a (1) To or (2) From header with an address that contains a large number of \"\\\" (backslash) characters. \n Publish Date : 2003-12-31 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "The IMAP functionality in PHP before 4.3.1 allows remote attackers to cause a denial of service via an e-mail message with a (1) To or (2) From header with an address that contains a large number of \"\\\" (backslash) characters.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2003-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.2.4",
@@ -317,9 +375,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2003-1303",
-            "summary": "Buffer overflow in the imap_fetch_overview function in the IMAP functionality (php_imap.c) in PHP before 4.3.3 allows remote attackers to cause a denial of service (segmentation fault) and possibly execute arbitrary code via a long e-mail address in a (1) To or (2) From header. \n Publish Date : 2003-12-31 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "Buffer overflow in the imap_fetch_overview function in the IMAP functionality (php_imap.c) in PHP before 4.3.3 allows remote attackers to cause a denial of service (segmentation fault) and possibly execute arbitrary code via a long e-mail address in a (1) To or (2) From header.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2003-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.3"
@@ -327,9 +387,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2004-0542",
-            "summary": "PHP before 4.3.7 on Win32 platforms does not properly filter all shell metacharacters, which allows local or remote attackers to execute arbitrary code, overwrite files, and access internal environment variables via (1) the \"%\", \"|\", or \">\" characters to the escapeshellcmd function, or (2) the \"%\" character to the escapeshellarg function. \n Publish Date : 2004-08-06 Last Update Date : 2008-09-05",
+            "threat": 10,
+            "summary": "PHP before 4.3.7 on Win32 platforms does not properly filter all shell metacharacters, which allows local or remote attackers to execute arbitrary code, overwrite files, and access internal environment variables via (1) the \"%\", \"|\", or \">\" characters to the escapeshellcmd function, or (2) the \"%\" character to the escapeshellarg function.",
+            "lastModifiedDate": "2017-07-11T01:30:00+0000",
+            "publishedDate": "2004-08-06T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -337,9 +399,11 @@
             }
         },
         {
-            "threat": "5.1",
             "cveid": "CVE-2004-0594",
-            "summary": "The memory_limit functionality in PHP 4.x up to 4.3.7, and 5.x up to 5.0.0RC3, under certain conditions such as when register_globals is enabled, allows remote attackers to execute arbitrary code by triggering a memory_limit abort during execution of the zend_hash_init function and overwriting a HashTable destructor pointer before the initialization of key data structures is complete. \nPublish Date : 2004-07-27 Last Update Date : 2010-08-21",
+            "threat": 5.1,
+            "summary": "The memory_limit functionality in PHP 4.x up to 4.3.7, and 5.x up to 5.0.0RC3, under certain conditions such as when register_globals is enabled, allows remote attackers to execute arbitrary code by triggering a memory_limit abort during execution of the zend_hash_init function and overwriting a HashTable destructor pointer before the initialization of key data structures is complete.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2004-07-27T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -351,9 +415,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2004-0595",
-            "summary": "The strip_tags function in PHP 4.x up to 4.3.7, and 5.x up to 5.0.0RC3, does not filter null (\\0) characters within tag names when restricting input to allowed tags, which allows dangerous tags to be processed by web browsers such as Internet Explorer and Safari, which ignore null characters and facilitate the exploitation of cross-site scripting (XSS) vulnerabilities. \nPublish Date : 2004-07-27 Last Update Date : 2010-08-21",
+            "threat": 6.8,
+            "summary": "The strip_tags function in PHP 4.x up to 4.3.7, and 5.x up to 5.0.0RC3, does not filter null (\\0) characters within tag names when restricting input to allowed tags, which allows dangerous tags to be processed by web browsers such as Internet Explorer and Safari, which ignore null characters and facilitate the exploitation of cross-site scripting (XSS) vulnerabilities.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2004-07-27T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -365,9 +431,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2004-0958",
-            "summary": "php_variables.c in PHP before 5.0.2 allows remote attackers to read sensitive memory contents via (1) GET, (2) POST, or (3) COOKIE GPC variables that end in an open bracket character, which causes PHP to calculate an incorrect string length. \n Publish Date : 2004-11-03 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "php_variables.c in PHP before 5.0.2 allows remote attackers to read sensitive memory contents via (1) GET, (2) POST, or (3) COOKIE GPC variables that end in an open bracket character, which causes PHP to calculate an incorrect string length.",
+            "lastModifiedDate": "2017-10-11T01:29:00+0000",
+            "publishedDate": "2004-11-03T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.3"
@@ -375,9 +443,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2004-0959",
-            "summary": "rfc1867.c in PHP before 5.0.2 allows local users to upload files to arbitrary locations via a PHP script with a certain MIME header that causes the \"$_FILES\" array to be modified. \n Publish Date : 2004-11-03 Last Update Date : 2013-09-11",
+            "threat": 2.1,
+            "summary": "rfc1867.c in PHP before 5.0.2 allows local users to upload files to arbitrary locations via a PHP script with a certain MIME header that causes the \"$_FILES\" array to be modified.",
+            "lastModifiedDate": "2017-10-11T01:29:00+0000",
+            "publishedDate": "2004-11-03T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.3"
@@ -385,9 +455,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2004-1019",
-            "summary": "The deserialization code in PHP before 4.3.10 and PHP 5.x up to 5.0.2 allows remote attackers to cause a denial of service and execute arbitrary code via untrusted data to the unserialize function that may trigger \"information disclosure, double-free and negative reference index array underflow\" results. \nPublish Date : 2005-01-10 Last Update Date : 2010-08-21",
+            "threat": 10,
+            "summary": "The deserialization code in PHP before 4.3.10 and PHP 5.x up to 5.0.2 allows remote attackers to cause a denial of service and execute arbitrary code via untrusted data to the unserialize function that may trigger \"information disclosure, double-free and negative reference index array underflow\" results.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-01-10T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -399,9 +471,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2004-1020",
-            "summary": "The addslashes function in PHP 4.3.9 does not properly escape a NULL (\/0) character, which may allow remote attackers to read arbitrary files in PHP applications that contain a directory traversal vulnerability in require or include statements, but are otherwise protected by the magic_quotes_gpc mechanism.  NOTE: this issue was originally REJECTed by its CNA before publication, but that decision is in active dispute.  This candidate may change significantly in the future as a result of further discussion. \n Publish Date : 2005-01-10 Last Update Date : 2008-09-10",
+            "threat": 5,
+            "summary": "The addslashes function in PHP 4.3.9 does not properly escape a NULL (\/0) character, which may allow remote attackers to read arbitrary files in PHP applications that contain a directory traversal vulnerability in require or include statements, but are otherwise protected by the magic_quotes_gpc mechanism.  NOTE: this issue was originally REJECTed by its CNA before publication, but that decision is in active dispute.  This candidate may change significantly in the future as a result of further discussion.",
+            "lastModifiedDate": "2017-07-11T01:30:00+0000",
+            "publishedDate": "2005-01-10T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.10",
@@ -410,9 +484,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2004-1065",
-            "summary": "Buffer overflow in the exif_read_data function in PHP before 4.3.10 and PHP 5.x up to 5.0.2 allows remote attackers to execute arbitrary code via a long section name in an image file. \nPublish Date : 2005-01-10 Last Update Date : 2010-08-21",
+            "threat": 10,
+            "summary": "Buffer overflow in the exif_read_data function in PHP before 4.3.10 and PHP 5.x up to 5.0.2 allows remote attackers to execute arbitrary code via a long section name in an image file.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-01-10T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -424,9 +500,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2004-1392",
-            "summary": "PHP 4.0 with cURL functions allows remote attackers to bypass the open_basedir setting and read arbitrary files via a file: URL argument to the curl_init function. \n Publish Date : 2004-12-31 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "PHP 4.0 with cURL functions allows remote attackers to bypass the open_basedir setting and read arbitrary files via a file: URL argument to the curl_init function.",
+            "lastModifiedDate": "2017-10-11T01:29:00+0000",
+            "publishedDate": "2004-12-31T05:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8"
@@ -434,9 +512,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2005-0524",
-            "summary": "The php_handle_iff function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a -8 size value. \n Publish Date : 2005-05-02 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "The php_handle_iff function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a -8 size value.",
+            "lastModifiedDate": "2018-05-03T01:29:00+0000",
+            "publishedDate": "2005-05-02T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.2.3",
@@ -446,9 +526,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2005-0525",
-            "summary": "The php_next_marker function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a JPEG image with an invalid marker value, which causes a negative length value to be passed to php_stream_seek. \n Publish Date : 2005-05-02 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "The php_next_marker function in image.c for PHP 4.2.2, 4.3.9, 4.3.10 and 5.0.3, as reachable by the getimagesize PHP function, allows remote attackers to cause a denial of service (infinite loop) via a JPEG image with an invalid marker value, which causes a negative length value to be passed to php_stream_seek.",
+            "lastModifiedDate": "2018-05-03T01:29:00+0000",
+            "publishedDate": "2005-05-02T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.2.3",
@@ -458,9 +540,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2005-0596",
-            "summary": "PHP 4 (PHP4) allows attackers to cause a denial of service (daemon crash) by using the readfile function on a file whose size is a multiple of the page size. \nPublish Date : 2005-05-02 Last Update Date : 2008-09-05",
+            "threat": 2.1,
+            "summary": "PHP 4 (PHP4) allows attackers to cause a denial of service (daemon crash) by using the readfile function on a file whose size is a multiple of the page size.",
+            "lastModifiedDate": "2008-09-05T20:46:00+0000",
+            "publishedDate": "2005-05-02T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.1"
@@ -468,9 +552,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2005-1042",
-            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in PHP before 4.3.11 may allow remote attackers to execute arbitrary code via an IFD tag that leads to a negative byte count. \n Publish Date : 2005-05-02 Last Update Date : 2010-08-21",
+            "threat": 7.5,
+            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in PHP before 4.3.11 may allow remote attackers to execute arbitrary code via an IFD tag that leads to a negative byte count.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-05-02T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.11"
@@ -478,9 +564,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2005-1043",
-            "summary": "exif.c in PHP before 4.3.11 allows remote attackers to cause a denial of service (memory consumption and crash) via an EXIF header with a large IFD nesting level, which causes significant stack recursion. \nPublish Date : 2005-04-14 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "exif.c in PHP before 4.3.11 allows remote attackers to cause a denial of service (memory consumption and crash) via an EXIF header with a large IFD nesting level, which causes significant stack recursion.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-04-14T04:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.11"
@@ -488,9 +576,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2005-3054",
-            "summary": "fopen_wrappers.c in PHP 4.4.0, and possibly other versions, does not properly restrict access to other directories when the open_basedir directive includes a trailing slash, which allows PHP scripts in one directory to access files in other directories whose names are substrings of the original directory. \n Publish Date : 2005-09-26 Last Update Date : 2010-04-02",
+            "threat": 2.1,
+            "summary": "fopen_wrappers.c in PHP 4.4.0, and possibly other versions, does not properly restrict access to other directories when the open_basedir directive includes a trailing slash, which allows PHP scripts in one directory to access files in other directories whose names are substrings of the original directory.",
+            "lastModifiedDate": "2018-10-03T21:31:00+0000",
+            "publishedDate": "2005-09-26T19:03:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.1"
@@ -498,9 +588,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2005-3319",
-            "summary": "The apache2handler SAPI (sapi_apache2.c) in the Apache module (mod_php) for PHP 5.x before 5.1.0 final and 4.4 before 4.4.1 final allows attackers to cause a denial of service (segmentation fault) via the session.save_path option in a .htaccess file or VirtualHost. \n Publish Date : 2005-10-27 Last Update Date : 2010-04-02",
+            "threat": 2.1,
+            "summary": "The apache2handler SAPI (sapi_apache2.c) in the Apache module (mod_php) for PHP 5.x before 5.1.0 final and 4.4 before 4.4.1 final allows attackers to cause a denial of service (segmentation fault) via the session.save_path option in a .htaccess file or VirtualHost.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-10-27T10:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -513,9 +605,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2005-3353",
-            "summary": "The exif_read_data function in the Exif module in PHP before 4.4.1 allows remote attackers to cause a denial of service (infinite loop) via a malformed JPEG image. \n Publish Date : 2005-11-18 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "The exif_read_data function in the Exif module in PHP before 4.4.1 allows remote attackers to cause a denial of service (infinite loop) via a malformed JPEG image.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-11-18T23:03:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -527,9 +621,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2005-3388",
-            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5 allows remote attackers to inject arbitrary web script or HTML via a crafted URL with a \"stacked array assignment.\" \n Publish Date : 2005-11-01 Last Update Date : 2010-08-21",
+            "threat": 4.3,
+            "summary": "Cross-site scripting (XSS) vulnerability in the phpinfo function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5 allows remote attackers to inject arbitrary web script or HTML via a crafted URL with a \"stacked array assignment.\"",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-11-01T12:47:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -542,9 +638,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2005-3389",
-            "summary": "The parse_str function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when called with only one parameter, allows remote attackers to enable the register_globals directive via inputs that cause a request to be terminated due to the memory_limit setting, which causes PHP to set an internal flag that enables register_globals and allows attackers to exploit vulnerabilities in PHP applications that would otherwise be protected. \n Publish Date : 2005-11-01 Last Update Date : 2013-07-05",
+            "threat": 5,
+            "summary": "The parse_str function in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when called with only one parameter, allows remote attackers to enable the register_globals directive via inputs that cause a request to be terminated due to the memory_limit setting, which causes PHP to set an internal flag that enables register_globals and allows attackers to exploit vulnerabilities in PHP applications that would otherwise be protected.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-11-01T12:47:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -557,9 +655,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2005-3390",
-            "summary": "The RFC1867 file upload feature in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when register_globals is enabled, allows remote attackers to modify the GLOBALS array and bypass security protections of PHP applications via a multipart\/form-data POST request with a \"GLOBALS\" fileupload field. \n Publish Date : 2005-11-01 Last Update Date : 2010-08-21",
+            "threat": 7.5,
+            "summary": "The RFC1867 file upload feature in PHP 4.x up to 4.4.0 and 5.x up to 5.0.5, when register_globals is enabled, allows remote attackers to modify the GLOBALS array and bypass security protections of PHP applications via a multipart\/form-data POST request with a \"GLOBALS\" fileupload field.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-11-01T12:47:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -572,9 +672,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2005-3391",
-            "summary": "Multiple vulnerabilities in PHP before 4.4.1 allow remote attackers to bypass safe_mode and open_basedir restrictions via unknown attack vectors in (1) ext\/curl and (2) ext\/gd. \n Publish Date : 2005-11-01 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Multiple vulnerabilities in PHP before 4.4.1 allow remote attackers to bypass safe_mode and open_basedir restrictions via unknown attack vectors in (1) ext\/curl and (2) ext\/gd.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-11-01T12:47:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -586,9 +688,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2005-3392",
-            "summary": "Unspecified vulnerability in PHP before 4.4.1, when using the virtual function on Apache 2, allows remote attackers to bypass safe_mode and open_basedir directives. \n Publish Date : 2005-11-01 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Unspecified vulnerability in PHP before 4.4.1, when using the virtual function on Apache 2, allows remote attackers to bypass safe_mode and open_basedir directives.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-11-01T12:47:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -600,9 +704,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2005-3883",
-            "summary": "CRLF injection vulnerability in the mb_send_mail function in PHP before 5.1.0 might allow remote attackers to inject arbitrary e-mail headers via line feeds (LF) in the \"To\" address argument. \n Publish Date : 2005-11-29 Last Update Date : 2013-08-18",
+            "threat": 5,
+            "summary": "CRLF injection vulnerability in the mb_send_mail function in PHP before 5.1.0 might allow remote attackers to inject arbitrary e-mail headers via line feeds (LF) in the \"To\" address argument.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2005-11-29T11:03:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -615,9 +721,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2006-0097",
-            "summary": "Stack-based buffer overflow in the create_named_pipe function in libmysql.c in PHP 4.3.10 and 4.4.x before 4.4.3 for Windows allows attackers to execute arbitrary code via a long (1) arg_host or (2) arg_unix_socket argument, as demonstrated by a long named pipe variable in the host argument to the mysql_connect function. \n Publish Date : 2006-01-06 Last Update Date : 2011-08-01",
+            "threat": 7.5,
+            "summary": "Stack-based buffer overflow in the create_named_pipe function in libmysql.c in PHP 4.3.10 and 4.4.x before 4.4.3 for Windows allows attackers to execute arbitrary code via a long (1) arg_host or (2) arg_unix_socket argument, as demonstrated by a long named pipe variable in the host argument to the mysql_connect function.",
+            "lastModifiedDate": "2018-10-19T15:42:00+0000",
+            "publishedDate": "2006-01-06T11:03:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.11",
@@ -626,9 +734,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2006-0200",
-            "summary": "Format string vulnerability in the error-reporting feature in the mysqli extension in PHP 5.1.0 and 5.1.1 might allow remote attackers to execute arbitrary code via format string specifiers in MySQL error messages. \n Publish Date : 2006-01-13 Last Update Date : 2008-09-05",
+            "threat": 9.3,
+            "summary": "Format string vulnerability in the error-reporting feature in the mysqli extension in PHP 5.1.0 and 5.1.1 might allow remote attackers to execute arbitrary code via format string specifiers in MySQL error messages.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-01-13T23:03:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.2"
@@ -636,9 +746,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2006-0207",
-            "summary": "Multiple HTTP response splitting vulnerabilities in PHP 5.1.1 allow remote attackers to inject arbitrary HTTP headers via a crafted Set-Cookie header, related to the (1) session extension (aka ext\/session) and the (2) header function. \n Publish Date : 2006-01-13 Last Update Date : 2011-09-09",
+            "threat": 5,
+            "summary": "Multiple HTTP response splitting vulnerabilities in PHP 5.1.1 allow remote attackers to inject arbitrary HTTP headers via a crafted Set-Cookie header, related to the (1) session extension (aka ext\/session) and the (2) header function.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-01-13T23:03:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -647,9 +759,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2006-0208",
-            "summary": "Multiple cross-site scripting (XSS) vulnerabilities in PHP 4.4.1 and 5.1.1, when display_errors and html_errors are on, allow remote attackers to inject arbitrary web script or HTML via inputs to PHP applications that are not filtered when they are included in the resulting error message. \n Publish Date : 2006-01-13 Last Update Date : 2011-09-13",
+            "threat": 2.6,
+            "summary": "Multiple cross-site scripting (XSS) vulnerabilities in PHP 4.4.1 and 5.1.1, when display_errors and html_errors are on, allow remote attackers to inject arbitrary web script or HTML via inputs to PHP applications that are not filtered when they are included in the resulting error message.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-01-13T23:03:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.7",
@@ -663,9 +777,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2006-0996",
-            "summary": "Cross-site scripting (XSS) vulnerability in phpinfo (info.c) in PHP 5.1.2 and 4.4.2 allows remote attackers to inject arbitrary web script or HTML via long array variables, including (1) a large number of dimensions or (2) long values, which prevents HTML tags from being removed. \n Publish Date : 2006-04-10 Last Update Date : 2010-08-21",
+            "threat": 4.3,
+            "summary": "Cross-site scripting (XSS) vulnerability in phpinfo (info.c) in PHP 5.1.2 and 4.4.2 allows remote attackers to inject arbitrary web script or HTML via long array variables, including (1) a large number of dimensions or (2) long values, which prevents HTML tags from being removed.",
+            "lastModifiedDate": "2017-10-11T01:30:00+0000",
+            "publishedDate": "2006-04-10T18:06:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -674,9 +790,11 @@
             }
         },
         {
-            "threat": "3.2",
             "cveid": "CVE-2006-1014",
-            "summary": "Argument injection vulnerability in certain PHP 4.x and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mb_send_mail function, allows context-dependent attackers to read and create arbitrary files by providing extra -C and -X arguments to sendmail.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE. \n Publish Date : 2006-03-06 Last Update Date : 2008-09-05",
+            "threat": 3.2,
+            "summary": "Argument injection vulnerability in certain PHP 4.x and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mb_send_mail function, allows context-dependent attackers to read and create arbitrary files by providing extra -C and -X arguments to sendmail.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE.",
+            "lastModifiedDate": "2018-10-18T16:30:00+0000",
+            "publishedDate": "2006-03-07T00:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -689,9 +807,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2006-1015",
-            "summary": "Argument injection vulnerability in certain PHP 3.x, 4.x, and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mail function, allows remote attackers to read and create arbitrary files via the sendmail -C and -X arguments.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE. \n Publish Date : 2006-03-06 Last Update Date : 2008-09-05",
+            "threat": 6.4,
+            "summary": "Argument injection vulnerability in certain PHP 3.x, 4.x, and 5.x applications, when used with sendmail and when accepting remote input for the additional_parameters argument to the mail function, allows remote attackers to read and create arbitrary files via the sendmail -C and -X arguments.  NOTE: it could be argued that this is a class of technology-specific vulnerability, instead of a particular instance; if so, then this should not be included in CVE.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-03-07T00:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -705,9 +825,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2006-1017",
-            "summary": "The c-client library 2000, 2001, or 2004 for PHP before 4.4.4 and 5.x before 5.1.5 do not check the (1) safe_mode or (2) open_basedir functions, and when used in applications that accept user-controlled input for the mailbox argument to the imap_open function, allow remote attackers to obtain access to an IMAP stream data structure and conduct unauthorized IMAP actions. \n Publish Date : 2006-03-06 Last Update Date : 2011-07-14",
+            "threat": 9.3,
+            "summary": "The c-client library 2000, 2001, or 2004 for PHP before 4.4.4 and 5.x before 5.1.5 do not check the (1) safe_mode or (2) open_basedir functions, and when used in applications that accept user-controlled input for the mailbox argument to the imap_open function, allow remote attackers to obtain access to an IMAP stream data structure and conduct unauthorized IMAP actions.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-03-07T00:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -721,9 +843,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2006-1490",
-            "summary": "PHP before 5.1.3-RC1 might allow remote attackers to obtain portions of memory via crafted binary data sent to a script that processes user input in the html_entity_decode function and sends the encoded results back to the client, aka a \"binary safety\" issue.  NOTE: this issue has been referred to as a \"memory leak,\" but it is an information leak that discloses memory contents. \n Publish Date : 2006-03-29 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "PHP before 5.1.3-RC1 might allow remote attackers to obtain portions of memory via crafted binary data sent to a script that processes user input in the html_entity_decode function and sends the encoded results back to the client, aka a \"binary safety\" issue.  NOTE: this issue has been referred to as a \"memory leak,\" but it is an information leak that discloses memory contents.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-03-29T21:06:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -737,9 +861,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2006-1494",
-            "summary": "Directory traversal vulnerability in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass open_basedir restrictions allows remote attackers to create files in arbitrary directories via the tempnam function. \n Publish Date : 2006-04-10 Last Update Date : 2010-08-21",
+            "threat": 2.6,
+            "summary": "Directory traversal vulnerability in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass open_basedir restrictions allows remote attackers to create files in arbitrary directories via the tempnam function.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-04-10T19:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -753,9 +879,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2006-1549",
-            "summary": "PHP 4.4.2 and 5.1.2 allows local users to cause a crash (segmentation fault) by defining and executing a recursive function.  NOTE: it has been reported by a reliable third party that some later versions are also affected. \n Publish Date : 2006-04-10 Last Update Date : 2011-08-23",
+            "threat": 2.1,
+            "summary": "PHP 4.4.2 and 5.1.2 allows local users to cause a crash (segmentation fault) by defining and executing a recursive function.  NOTE: it has been reported by a reliable third party that some later versions are also affected.",
+            "lastModifiedDate": "2018-10-18T16:33:00+0000",
+            "publishedDate": "2006-04-10T22:58:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -764,9 +892,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2006-1608",
-            "summary": "The copy function in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass safe mode and read arbitrary files via a source argument containing a compress.zlib:\/\/ URI. \n Publish Date : 2006-04-10 Last Update Date : 2010-04-02",
+            "threat": 2.1,
+            "summary": "The copy function in file.c in PHP 4.4.2 and 5.1.2 allows local users to bypass safe mode and read arbitrary files via a source argument containing a compress.zlib:\/\/ URI.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-04-10T19:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -780,9 +910,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2006-1990",
-            "summary": "Integer overflow in the wordwrap function in string.c in PHP 4.4.2 and 5.1.2 might allow context-dependent attackers to execute arbitrary code via certain long arguments that cause a small buffer to be allocated, which triggers a heap-based buffer overflow in a memcpy function call, a different vulnerability than CVE-2002-1396. \n Publish Date : 2006-04-24 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "Integer overflow in the wordwrap function in string.c in PHP 4.4.2 and 5.1.2 might allow context-dependent attackers to execute arbitrary code via certain long arguments that cause a small buffer to be allocated, which triggers a heap-based buffer overflow in a memcpy function call, a different vulnerability than CVE-2002-1396.",
+            "lastModifiedDate": "2018-10-18T16:37:00+0000",
+            "publishedDate": "2006-04-24T23:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -791,9 +923,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2006-1991",
-            "summary": "The substr_compare function in string.c in PHP 5.1.2 allows context-dependent attackers to cause a denial of service (memory access violation) via an out-of-bounds offset argument. \n Publish Date : 2006-04-24 Last Update Date : 2011-06-13",
+            "threat": 6.4,
+            "summary": "The substr_compare function in string.c in PHP 5.1.2 allows context-dependent attackers to cause a denial of service (memory access violation) via an out-of-bounds offset argument.",
+            "lastModifiedDate": "2017-07-20T01:31:00+0000",
+            "publishedDate": "2006-04-24T23:02:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.3"
@@ -801,9 +935,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2006-2563",
-            "summary": "The cURL library (libcurl) in PHP 4.4.2 and 5.1.4 allows attackers to bypass safe mode and read files via a file:\/\/ request containing null characters. \n Publish Date : 2006-05-29 Last Update Date : 2010-04-02",
+            "threat": 2.1,
+            "summary": "The cURL library (libcurl) in PHP 4.4.2 and 5.1.4 allows attackers to bypass safe mode and read files via a file:\/\/ request containing null characters.",
+            "lastModifiedDate": "2017-07-20T01:31:00+0000",
+            "publishedDate": "2006-05-29T16:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.3",
@@ -812,9 +948,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2006-2660",
-            "summary": "Buffer consumption vulnerability in the tempnam function in PHP 5.1.4 and 4.x before 4.4.3 allows local users to bypass restrictions and create PHP files with fixed names in other directories via a pathname argument longer than MAXPATHLEN, which prevents a unique string from being appended to the filename. \n Publish Date : 2006-06-13 Last Update Date : 2010-04-02",
+            "threat": 2.1,
+            "summary": "Buffer consumption vulnerability in the tempnam function in PHP 5.1.4 and 4.x before 4.4.3 allows local users to bypass restrictions and create PHP files with fixed names in other directories via a pathname argument longer than MAXPATHLEN, which prevents a unique string from being appended to the filename.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-06-13T18:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.6",
@@ -827,9 +965,11 @@
             }
         },
         {
-            "threat": "4.6",
             "cveid": "CVE-2006-3011",
-            "summary": "The error_log function in basic_functions.c in PHP before 4.4.4 and 5.x before 5.1.5 allows local users to bypass safe mode and open_basedir restrictions via a \"php:\/\/\" or other scheme in the third argument, which disables safe mode. \n Publish Date : 2006-06-26 Last Update Date : 2011-07-11",
+            "threat": 4.6,
+            "summary": "The error_log function in basic_functions.c in PHP before 4.4.4 and 5.x before 5.1.5 allows local users to bypass safe mode and open_basedir restrictions via a \"php:\/\/\" or other scheme in the third argument, which disables safe mode.",
+            "lastModifiedDate": "2017-07-20T01:31:00+0000",
+            "publishedDate": "2006-06-26T21:05:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -843,9 +983,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2006-3017",
-            "summary": "zend_hash_del_key_or_index in zend_hash.c in PHP before 4.4.3 and 5.x before 5.1.3 can cause zend_hash_del to delete the wrong element, which prevents a variable from being unset even when the PHP unset function is called, which might cause the variable's value to be used in security-relevant operations. \nPublish Date : 2006-06-14 Last Update Date : 2010-09-15",
+            "threat": 9.3,
+            "summary": "zend_hash_del_key_or_index in zend_hash.c in PHP before 4.4.3 and 5.x before 5.1.3 can cause zend_hash_del to delete the wrong element, which prevents a variable from being unset even when the PHP unset function is called, which might cause the variable's value to be used in security-relevant operations.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-06-14T23:02:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -859,9 +1001,11 @@
             }
         },
         {
-            "threat": "4.6",
             "cveid": "CVE-2006-4020",
-            "summary": "scanf.c in PHP 5.1.4 and earlier, and 4.4.3 and earlier, allows context-dependent attackers to execute arbitrary code via a sscanf PHP function call that performs argument swapping, which increments an index past the end of an array and triggers a buffer over-read. \n Publish Date : 2006-08-08 Last Update Date : 2010-08-21",
+            "threat": 4.6,
+            "summary": "scanf.c in PHP 5.1.4 and earlier, and 4.4.3 and earlier, allows context-dependent attackers to execute arbitrary code via a sscanf PHP function call that performs argument swapping, which increments an index past the end of an array and triggers a buffer over-read.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-08T20:04:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -875,9 +1019,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2006-4023",
-            "summary": "The ip2long function in PHP 5.1.4 and earlier may incorrectly validate an arbitrary string and return a valid network IP address, which allows remote attackers to obtain network information and facilitate other attacks, as demonstrated using SQL injection in the X-FORWARDED-FOR Header in index.php in MiniBB 2.0.  NOTE: it could be argued that the ip2long behavior represents a risk for security-relevant issues in a way that is similar to strcpy's role in buffer overflows, in which case this would be a class of implementation bugs that would require separate CVE items for each PHP application that uses ip2long in a security-relevant manner. \n Publish Date : 2006-08-08 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "The ip2long function in PHP 5.1.4 and earlier may incorrectly validate an arbitrary string and return a valid network IP address, which allows remote attackers to obtain network information and facilitate other attacks, as demonstrated using SQL injection in the X-FORWARDED-FOR Header in index.php in MiniBB 2.0.  NOTE: it could be argued that the ip2long behavior represents a risk for security-relevant issues in a way that is similar to strcpy's role in buffer overflows, in which case this would be a class of implementation bugs that would require separate CVE items for each PHP application that uses ip2long in a security-relevant manner.",
+            "lastModifiedDate": "2018-10-17T21:32:00+0000",
+            "publishedDate": "2006-08-09T00:04:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.4",
@@ -887,9 +1033,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2006-4433",
-            "summary": "PHP before 4.4.3 and 5.x before 5.1.4 does not limit the character set of the session identifier (PHPSESSID) for third party session handlers, which might make it easier for remote attackers to exploit other vulnerabilities by inserting PHP code into the PHPSESSID, which is stored in the session file.  NOTE: it could be argued that this not a vulnerability in PHP itself, rather a design limitation that enables certain attacks against session handlers that do not account for this limitation. \n Publish Date : 2006-08-28 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "PHP before 4.4.3 and 5.x before 5.1.4 does not limit the character set of the session identifier (PHPSESSID) for third party session handlers, which might make it easier for remote attackers to exploit other vulnerabilities by inserting PHP code into the PHPSESSID, which is stored in the session file.  NOTE: it could be argued that this not a vulnerability in PHP itself, rather a design limitation that enables certain attacks against session handlers that do not account for this limitation.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-29T00:04:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -903,9 +1051,11 @@
             }
         },
         {
-            "threat": "7.2",
             "cveid": "CVE-2006-4481",
-            "summary": "The (1) file_exists and (2) imap_reopen functions in PHP before 5.1.5 do not check for the safe_mode and open_basedir settings, which allows local users to bypass the settings.  NOTE: the error_log function is covered by CVE-2006-3011, and the imap_open function is covered by CVE-2006-1017. \n Publish Date : 2006-08-31 Last Update Date : 2010-09-15",
+            "threat": 7.2,
+            "summary": "The (1) file_exists and (2) imap_reopen functions in PHP before 5.1.5 do not check for the safe_mode and open_basedir settings, which allows local users to bypass the settings.  NOTE: the error_log function is covered by CVE-2006-3011, and the imap_open function is covered by CVE-2006-1017.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-31T21:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -913,9 +1063,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2006-4482",
-            "summary": "Multiple heap-based buffer overflows in the (1) str_repeat and (2) wordwrap functions in ext\/standard\/string.c in PHP before 5.1.5, when used on a 64-bit system, have unspecified impact and attack vectors, a different vulnerability than CVE-2006-1990. \n Publish Date : 2006-08-31 Last Update Date : 2010-08-21",
+            "threat": 9.3,
+            "summary": "Multiple heap-based buffer overflows in the (1) str_repeat and (2) wordwrap functions in ext\/standard\/string.c in PHP before 5.1.5, when used on a 64-bit system, have unspecified impact and attack vectors, a different vulnerability than CVE-2006-1990.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-31T21:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -923,9 +1075,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2006-4483",
-            "summary": "The cURL extension files (1) ext\/curl\/interface.c and (2) ext\/curl\/streams.c in PHP before 5.1.5 permit the CURLOPT_FOLLOWLOCATION option when open_basedir or safe_mode is enabled, which allows attackers to perform unauthorized actions, possibly related to the realpath cache. \n Publish Date : 2006-08-31 Last Update Date : 2008-09-05",
+            "threat": 9.3,
+            "summary": "The cURL extension files (1) ext\/curl\/interface.c and (2) ext\/curl\/streams.c in PHP before 5.1.5 permit the CURLOPT_FOLLOWLOCATION option when open_basedir or safe_mode is enabled, which allows attackers to perform unauthorized actions, possibly related to the realpath cache.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-31T21:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -933,9 +1087,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2006-4484",
-            "summary": "Buffer overflow in the LWZReadByte_ function in ext\/gd\/libgd\/gd_gif_in.c in the GD extension in PHP before 5.1.5 allows remote attackers to have an unknown impact via a GIF file with input_code_size greater than MAX_LWZ_BITS, which triggers an overflow when initializing the table array. \n Publish Date : 2006-08-31 Last Update Date : 2010-09-15",
+            "threat": 2.6,
+            "summary": "Buffer overflow in the LWZReadByte_ function in ext\/gd\/libgd\/gd_gif_in.c in the GD extension in PHP before 5.1.5 allows remote attackers to have an unknown impact via a GIF file with input_code_size greater than MAX_LWZ_BITS, which triggers an overflow when initializing the table array.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-31T21:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -943,9 +1099,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2006-4485",
-            "summary": "The stripos function in PHP before 5.1.5 has unknown impact and attack vectors related to an out-of-bounds read. \n Publish Date : 2006-08-31 Last Update Date : 2010-09-15",
+            "threat": 10,
+            "summary": "The stripos function in PHP before 5.1.5 has unknown impact and attack vectors related to an out-of-bounds read.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-31T21:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.5"
@@ -953,9 +1111,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2006-4486",
-            "summary": "Integer overflow in memory allocation routines in PHP before 5.1.6, when running on a 64-bit system, allows context-dependent attackers to bypass the memory_limit restriction. \n Publish Date : 2006-08-31 Last Update Date : 2010-08-21",
+            "threat": 2.6,
+            "summary": "Integer overflow in memory allocation routines in PHP before 5.1.6, when running on a 64-bit system, allows context-dependent attackers to bypass the memory_limit restriction.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-08-31T21:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.6"
@@ -963,9 +1123,11 @@
             }
         },
         {
-            "threat": "3.6",
             "cveid": "CVE-2006-4625",
-            "summary": "PHP 4.x up to 4.4.4 and PHP 5 up to 5.1.6 allows local users to bypass certain Apache HTTP Server httpd.conf options, such as safe_mode and open_basedir, via the ini_restore function, which resets the values to their php.ini (Master Value) defaults. \n Publish Date : 2006-09-12 Last Update Date : 2010-09-15",
+            "threat": 3.6,
+            "summary": "PHP 4.x up to 4.4.4 and PHP 5 up to 5.1.6 allows local users to bypass certain Apache HTTP Server httpd.conf options, such as safe_mode and open_basedir, via the ini_restore function, which resets the values to their php.ini (Master Value) defaults.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-09-12T16:07:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -979,9 +1141,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2006-4812",
-            "summary": "Integer overflow in PHP 5 up to 5.1.6 and 4 before 4.3.0 allows remote attackers to execute arbitrary code via an argument to the unserialize PHP function with a large value for the number of array elements, which triggers the overflow in the Zend Engine ecalloc function (Zend\/zend_alloc.c). \n Publish Date : 2006-10-10 Last Update Date : 2008-09-05",
+            "threat": 10,
+            "summary": "Integer overflow in PHP 5 up to 5.1.6 and 4 before 4.3.0 allows remote attackers to execute arbitrary code via an argument to the unserialize PHP function with a large value for the number of array elements, which triggers the overflow in the Zend Engine ecalloc function (Zend\/zend_alloc.c).",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-10-10T04:06:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -993,9 +1157,11 @@
             }
         },
         {
-            "threat": "6.2",
             "cveid": "CVE-2006-5178",
-            "summary": "Race condition in the symlink function in PHP 5.1.6 and earlier allows local users to bypass the open_basedir restriction by using a combination of symlink, mkdir, and unlink functions to change the file path after the open_basedir check and before the file is opened by the underlying system, as demonstrated by symlinking a symlink into a subdirectory, to point to a parent directory via .. (dot dot) sequences, and then unlinking the resulting symlink. \n Publish Date : 2006-10-10 Last Update Date : 2010-09-15",
+            "threat": 6.2,
+            "summary": "Race condition in the symlink function in PHP 5.1.6 and earlier allows local users to bypass the open_basedir restriction by using a combination of symlink, mkdir, and unlink functions to change the file path after the open_basedir check and before the file is opened by the underlying system, as demonstrated by symlinking a symlink into a subdirectory, to point to a parent directory via .. (dot dot) sequences, and then unlinking the resulting symlink.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-10-10T04:06:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1009,9 +1175,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2006-5465",
-            "summary": "Buffer overflow in PHP before 5.2.0 allows remote attackers to execute arbitrary code via crafted UTF-8 inputs to the (1) htmlentities or (2) htmlspecialchars functions. \n Publish Date : 2006-11-03 Last Update Date : 2010-09-15",
+            "threat": 7.5,
+            "summary": "Buffer overflow in PHP before 5.2.0 allows remote attackers to execute arbitrary code via crafted UTF-8 inputs to the (1) htmlentities or (2) htmlspecialchars functions.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-11-04T00:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1020,9 +1188,11 @@
             }
         },
         {
-            "threat": "7.2",
             "cveid": "CVE-2006-5706",
-            "summary": "Unspecified vulnerabilities in PHP, probably before 5.2.0, allow local users to bypass open_basedir restrictions and perform unspecified actions via unspecified vectors involving the (1) chdir and (2) tempnam functions.  NOTE: the tempnam vector might overlap CVE-2006-1494. \n Publish Date : 2006-11-03 Last Update Date : 2008-09-05",
+            "threat": 7.2,
+            "summary": "Unspecified vulnerabilities in PHP, probably before 5.2.0, allow local users to bypass open_basedir restrictions and perform unspecified actions via unspecified vectors involving the (1) chdir and (2) tempnam functions.  NOTE: the tempnam vector might overlap CVE-2006-1494.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2006-11-04T01:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1031,9 +1201,11 @@
             }
         },
         {
-            "threat": "4.6",
             "cveid": "CVE-2006-6383",
-            "summary": "PHP 5.2.0 and 4.4 allows local users to bypass safe_mode and open_basedir restrictions via a malicious path and a null byte before a \";\" in a session_save_path argument, followed by an allowed path, which causes a parsing inconsistency in which PHP validates the allowed path but sets session.save_path to the malicious path. \n Publish Date : 2006-12-10 Last Update Date : 2008-11-15",
+            "threat": 4.6,
+            "summary": "PHP 5.2.0 and 4.4 allows local users to bypass safe_mode and open_basedir restrictions via a malicious path and a null byte before a \";\" in a session_save_path argument, followed by an allowed path, which causes a parsing inconsistency in which PHP validates the allowed path but sets session.save_path to the malicious path.",
+            "lastModifiedDate": "2018-10-17T21:47:00+0000",
+            "publishedDate": "2006-12-10T20:28:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1",
@@ -1042,9 +1214,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2006-7204",
-            "summary": "The imap_body function in PHP before 4.4.4 does not implement safemode or open_basedir checks, which allows local users to read arbitrary files or list arbitrary directory contents. \n Publish Date : 2007-05-22 Last Update Date : 2008-09-05",
+            "threat": 2.1,
+            "summary": "The imap_body function in PHP before 4.4.4 does not implement safemode or open_basedir checks, which allows local users to read arbitrary files or list arbitrary directory contents.",
+            "lastModifiedDate": "2008-09-05T21:16:00+0000",
+            "publishedDate": "2007-05-22T19:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.4"
@@ -1052,9 +1226,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2006-7243",
-            "summary": "PHP before 5.3.4 accepts the \\0 character in a pathname, which might allow context-dependent attackers to bypass intended access restrictions by placing a safe file extension after this character, as demonstrated by .php\\0.jpg at the end of the argument to the file_exists function. \n Publish Date : 2011-01-18 Last Update Date : 2014-03-25",
+            "threat": 5,
+            "summary": "PHP before 5.3.4 accepts the \\0 character in a pathname, which might allow context-dependent attackers to bypass intended access restrictions by placing a safe file extension after this character, as demonstrated by .php\\0.jpg at the end of the argument to the file_exists function.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-01-18T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1070,9 +1246,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2007-0448",
-            "summary": "The fopen function in PHP 5.2.0 does not properly handle invalid URI handlers, which allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files via a file path specified with an invalid URI, as demonstrated via the srpath URI. \n Publish Date : 2007-05-24 Last Update Date : 2008-09-10",
+            "threat": 10,
+            "summary": "The fopen function in PHP 5.2.0 does not properly handle invalid URI handlers, which allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files via a file path specified with an invalid URI, as demonstrated via the srpath URI.",
+            "lastModifiedDate": "2008-09-11T00:49:00+0000",
+            "publishedDate": "2007-05-24T18:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1080,9 +1258,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-0905",
-            "summary": "PHP before 5.2.1 allows attackers to bypass safe_mode and open_basedir restrictions via unspecified vectors in the session extension.  NOTE: it is possible that this issue is a duplicate of CVE-2006-6383. \n Publish Date : 2007-02-13 Last Update Date : 2008-11-15",
+            "threat": 7.5,
+            "summary": "PHP before 5.2.1 allows attackers to bypass safe_mode and open_basedir restrictions via unspecified vectors in the session extension.  NOTE: it is possible that this issue is a duplicate of CVE-2006-6383.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-02-13T23:28:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1097,9 +1277,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-0906",
-            "summary": "Multiple buffer overflows in PHP before 5.2.1 allow attackers to cause a denial of service and possibly execute arbitrary code via unspecified vectors in the (1) session, (2) zip, (3) imap, and (4) sqlite extensions; (5) stream filters; and the (6) str_replace, (7) mail, (8) ibase_delete_user, (9) ibase_add_user, and (10) ibase_modify_user functions.  NOTE: vector 6 might actually be an integer overflow (CVE-2007-1885).  NOTE: as of 20070411, vector (3) might involve the imap_mail_compose function (CVE-2007-1825). \n Publish Date : 2007-02-13 Last Update Date : 2011-09-20",
+            "threat": 7.5,
+            "summary": "Multiple buffer overflows in PHP before 5.2.1 allow attackers to cause a denial of service and possibly execute arbitrary code via unspecified vectors in the (1) session, (2) zip, (3) imap, and (4) sqlite extensions; (5) stream filters; and the (6) str_replace, (7) mail, (8) ibase_delete_user, (9) ibase_add_user, and (10) ibase_modify_user functions.  NOTE: vector 6 might actually be an integer overflow (CVE-2007-1885).  NOTE: as of 20070411, vector (3) might involve the imap_mail_compose function (CVE-2007-1825).",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-02-13T23:28:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1114,9 +1296,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-0907",
-            "summary": "Buffer underflow in PHP before 5.2.1 allows attackers to cause a denial of service via unspecified vectors involving the sapi_header_op function. \n Publish Date : 2007-02-13 Last Update Date : 2010-09-15",
+            "threat": 5,
+            "summary": "Buffer underflow in PHP before 5.2.1 allows attackers to cause a denial of service via unspecified vectors involving the sapi_header_op function.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-02-13T23:28:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1131,9 +1315,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-0908",
-            "summary": "The WDDX deserializer in the wddx extension in PHP 5 before 5.2.1 and PHP 4 before 4.4.5 does not properly initialize the key_length variable for a numerical key, which allows context-dependent attackers to read stack memory via a wddxPacket element that contains a variable with a string name before a numerical variable. \n Publish Date : 2007-02-13 Last Update Date : 2011-06-06",
+            "threat": 5,
+            "summary": "The WDDX deserializer in the wddx extension in PHP 5 before 5.2.1 and PHP 4 before 4.4.5 does not properly initialize the key_length variable for a numerical key, which allows context-dependent attackers to read stack memory via a wddxPacket element that contains a variable with a string name before a numerical variable.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2007-02-13T23:28:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1148,9 +1334,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-0909",
-            "summary": "Multiple format string vulnerabilities in PHP before 5.2.1 might allow attackers to execute arbitrary code via format string specifiers to (1) all of the *print functions on 64-bit systems, and (2) the odbc_result_all function. \n Publish Date : 2007-02-13 Last Update Date : 2010-09-15",
+            "threat": 7.5,
+            "summary": "Multiple format string vulnerabilities in PHP before 5.2.1 might allow attackers to execute arbitrary code via format string specifiers to (1) all of the *print functions on 64-bit systems, and (2) the odbc_result_all function.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-02-13T23:28:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1165,9 +1353,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2007-0910",
-            "summary": "Unspecified vulnerability in PHP before 5.2.1 allows attackers to \"clobber\" certain super-global variables via unspecified vectors. \n Publish Date : 2007-02-13 Last Update Date : 2011-03-10",
+            "threat": 10,
+            "summary": "Unspecified vulnerability in PHP before 5.2.1 allows attackers to \"clobber\" certain super-global variables via unspecified vectors.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-02-13T23:28:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1182,9 +1372,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2007-0911",
-            "summary": "Off-by-one error in the str_ireplace function in PHP 5.2.1 might allow context-dependent attackers to cause a denial of service (crash). \n Publish Date : 2007-02-13 Last Update Date : 2008-11-15",
+            "threat": 7.8,
+            "summary": "Off-by-one error in the str_ireplace function in PHP 5.2.1 might allow context-dependent attackers to cause a denial of service (crash).",
+            "lastModifiedDate": "2018-10-16T16:35:00+0000",
+            "publishedDate": "2007-02-13T23:28:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1192,9 +1384,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-0988",
-            "summary": "The zend_hash_init function in PHP 5 before 5.2.1 and PHP 4 before 4.4.5, when running on a 64-bit platform, allows context-dependent attackers to cause a denial of service (infinite loop) by unserializing certain integer expressions, which only cause 32-bit arguments to be used after the check for a negative value, as demonstrated by an \"a:2147483649:{\" argument. \n Publish Date : 2007-02-20 Last Update Date : 2011-05-25",
+            "threat": 4.3,
+            "summary": "The zend_hash_init function in PHP 5 before 5.2.1 and PHP 4 before 4.4.5, when running on a 64-bit platform, allows context-dependent attackers to cause a denial of service (infinite loop) by unserializing certain integer expressions, which only cause 32-bit arguments to be used after the check for a negative value, as demonstrated by an \"a:2147483649:{\" argument.",
+            "lastModifiedDate": "2019-10-09T22:52:00+0000",
+            "publishedDate": "2007-02-20T17:28:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1209,9 +1403,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1001",
-            "summary": "Multiple integer overflows in the (1) createwbmp and (2) readwbmp functions in wbmp.c in the GD library (libgd) in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allow context-dependent attackers to execute arbitrary code via Wireless Bitmap (WBMP) images with large width or height values. \n Publish Date : 2007-04-05 Last Update Date : 2011-09-08",
+            "threat": 6.8,
+            "summary": "Multiple integer overflows in the (1) createwbmp and (2) readwbmp functions in wbmp.c in the GD library (libgd) in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allow context-dependent attackers to execute arbitrary code via Wireless Bitmap (WBMP) images with large width or height values.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-06T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1226,9 +1422,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-1285",
-            "summary": "The Zend Engine in PHP 4.x before 4.4.7, and 5.x before 5.2.2, allows remote attackers to cause a denial of service (stack exhaustion and PHP crash) via deeply nested arrays, which trigger deep recursion in the variable destruction routines. \n Publish Date : 2007-03-06 Last Update Date : 2010-11-30",
+            "threat": 5,
+            "summary": "The Zend Engine in PHP 4.x before 4.4.7, and 5.x before 5.2.2, allows remote attackers to cause a denial of service (stack exhaustion and PHP crash) via deeply nested arrays, which trigger deep recursion in the variable destruction routines.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-06T20:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1243,9 +1441,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1286",
-            "summary": "Integer overflow in PHP 4.4.4 and earlier allows remote context-dependent attackers to execute arbitrary code via a long string to the unserialize function, which triggers the overflow in the ZVAL reference counter. \n Publish Date : 2007-03-06 Last Update Date : 2010-11-30",
+            "threat": 6.8,
+            "summary": "Integer overflow in PHP 4.4.4 and earlier allows remote context-dependent attackers to execute arbitrary code via a long string to the unserialize function, which triggers the overflow in the ZVAL reference counter.",
+            "lastModifiedDate": "2018-10-16T16:37:00+0000",
+            "publishedDate": "2007-03-06T20:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.5"
@@ -1253,9 +1453,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-1287",
-            "summary": "A regression error in the phpinfo function in PHP 4.4.3 to 4.4.6, and PHP 6.0 in CVS, allows remote attackers to conduct cross-site scripting (XSS) attacks via GET, POST, or COOKIE array values, which are not escaped in the phpinfo output, as originally fixed for CVE-2005-3388. \n Publish Date : 2007-03-06 Last Update Date : 2008-09-05",
+            "threat": 4.3,
+            "summary": "A regression error in the phpinfo function in PHP 4.4.3 to 4.4.6, and PHP 6.0 in CVS, allows remote attackers to conduct cross-site scripting (XSS) attacks via GET, POST, or COOKIE array values, which are not escaped in the phpinfo output, as originally fixed for CVE-2005-3388.",
+            "lastModifiedDate": "2011-03-08T02:51:00+0000",
+            "publishedDate": "2007-03-06T20:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1263,9 +1465,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-1375",
-            "summary": "Integer overflow in the substr_compare function in PHP 5.2.1 and earlier allows context-dependent attackers to read sensitive memory via a large value in the length argument, a different vulnerability than CVE-2006-1991. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "Integer overflow in the substr_compare function in PHP 5.2.1 and earlier allows context-dependent attackers to read sensitive memory via a large value in the length argument, a different vulnerability than CVE-2006-1991.",
+            "lastModifiedDate": "2017-10-11T01:31:00+0000",
+            "publishedDate": "2007-03-10T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1273,9 +1477,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1376",
-            "summary": "The shmop functions in PHP before 4.4.5, and before 5.2.1 in the 5.x series, do not verify that their arguments correspond to a shmop resource, which allows context-dependent attackers to read and write arbitrary memory locations via arguments associated with an inappropriate resource, as demonstrated by a GD Image resource. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "The shmop functions in PHP before 4.4.5, and before 5.2.1 in the 5.x series, do not verify that their arguments correspond to a shmop resource, which allows context-dependent attackers to read and write arbitrary memory locations via arguments associated with an inappropriate resource, as demonstrated by a GD Image resource.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-10T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1290,9 +1496,11 @@
             }
         },
         {
-            "threat": "5.1",
             "cveid": "CVE-2007-1378",
-            "summary": "The ovrimos_longreadlen function in the Ovrimos extension for PHP before 4.4.5 allows context-dependent attackers to write to arbitrary memory locations via the result_id and length arguments. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
+            "threat": 5.1,
+            "summary": "The ovrimos_longreadlen function in the Ovrimos extension for PHP before 4.4.5 allows context-dependent attackers to write to arbitrary memory locations via the result_id and length arguments.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-10T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1304,9 +1512,11 @@
             }
         },
         {
-            "threat": "5.1",
             "cveid": "CVE-2007-1379",
-            "summary": "The ovrimos_close function in the Ovrimos extension for PHP before 4.4.5 can trigger efree of an arbitrary address, which might allow context-dependent attackers to execute arbitrary code. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
+            "threat": 5.1,
+            "summary": "The ovrimos_close function in the Ovrimos extension for PHP before 4.4.5 can trigger efree of an arbitrary address, which might allow context-dependent attackers to execute arbitrary code.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-10T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1318,9 +1528,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-1380",
-            "summary": "The php_binary serialization handler in the session extension in PHP before 4.4.5, and 5.x before 5.2.1, allows context-dependent attackers to obtain sensitive information (memory contents) via a serialized variable entry with a large length value, which triggers a buffer over-read. \n Publish Date : 2007-03-09 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "The php_binary serialization handler in the session extension in PHP before 4.4.5, and 5.x before 5.2.1, allows context-dependent attackers to obtain sensitive information (memory contents) via a serialized variable entry with a large length value, which triggers a buffer over-read.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-10T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1335,9 +1547,11 @@
             }
         },
         {
-            "threat": "7.6",
             "cveid": "CVE-2007-1381",
-            "summary": "The wddx_deserialize function in wddx.c 1.119.2.10.2.12 and 1.119.2.10.2.13 in PHP 5, as modified in CVS on 20070224 and fixed on 20070304, calls strlcpy where strlcat was intended and uses improper arguments, which allows context-dependent attackers to execute arbitrary code via a WDDX packet with a malformed overlap of a STRING element, which triggers a buffer overflow. \n Publish Date : 2007-03-09 Last Update Date : 2008-09-05",
+            "threat": 7.6,
+            "summary": "The wddx_deserialize function in wddx.c 1.119.2.10.2.12 and 1.119.2.10.2.13 in PHP 5, as modified in CVS on 20070224 and fixed on 20070304, calls strlcpy where strlcat was intended and uses improper arguments, which allows context-dependent attackers to execute arbitrary code via a WDDX packet with a malformed overlap of a STRING element, which triggers a buffer overflow.",
+            "lastModifiedDate": "2008-09-05T21:20:00+0000",
+            "publishedDate": "2007-03-10T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.1"
@@ -1345,9 +1559,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1396",
-            "summary": "The import_request_variables function in PHP 4.0.7 through 4.4.6, and 5.x before 5.2.2, when called without a prefix, does not prevent the (1) GET, (2) POST, (3) COOKIE, (4) FILES, (5) SERVER, (6) SESSION, and other superglobals from being overwritten, which allows remote attackers to spoof source IP address and Referer data, and have other unspecified impact.  NOTE: it could be argued that this is a design limitation of PHP and that only the misuse of this feature, i.e. implementation bugs in applications, should be included in CVE. However, it has been fixed by the vendor. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "The import_request_variables function in PHP 4.0.7 through 4.4.6, and 5.x before 5.2.2, when called without a prefix, does not prevent the (1) GET, (2) POST, (3) COOKIE, (4) FILES, (5) SERVER, (6) SESSION, and other superglobals from being overwritten, which allows remote attackers to spoof source IP address and Referer data, and have other unspecified impact.  NOTE: it could be argued that this is a design limitation of PHP and that only the misuse of this feature, i.e. implementation bugs in applications, should be included in CVE. However, it has been fixed by the vendor.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-10T22:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1362,9 +1578,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2007-1399",
-            "summary": "Stack-based buffer overflow in the zip:\/\/ URL wrapper in PECL ZIP 1.8.3 and earlier, as bundled with PHP 5.2.0 and 5.2.1, allows remote attackers to execute arbitrary code via a long zip:\/\/ URL, as demonstrated by actively triggering URL access from a remote PHP interpreter via avatar upload or blog pingback. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
+            "threat": 10,
+            "summary": "Stack-based buffer overflow in the zip:\/\/ URL wrapper in PECL ZIP 1.8.3 and earlier, as bundled with PHP 5.2.0 and 5.2.1, allows remote attackers to execute arbitrary code via a long zip:\/\/ URL, as demonstrated by actively triggering URL access from a remote PHP interpreter via avatar upload or blog pingback.",
+            "lastModifiedDate": "2017-07-29T01:30:00+0000",
+            "publishedDate": "2007-03-10T22:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1372,9 +1590,11 @@
             }
         },
         {
-            "threat": "6.9",
             "cveid": "CVE-2007-1401",
-            "summary": "Buffer overflow in the crack extension (CrackLib), as bundled with PHP 4.4.6 and other versions before 5.0.0, might allow local users to gain privileges via a long argument to the crack_opendict function. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
+            "threat": 6.9,
+            "summary": "Buffer overflow in the crack extension (CrackLib), as bundled with PHP 4.4.6 and other versions before 5.0.0, might allow local users to gain privileges via a long argument to the crack_opendict function.",
+            "lastModifiedDate": "2018-10-16T16:38:00+0000",
+            "publishedDate": "2007-03-10T22:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1382,9 +1602,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1411",
-            "summary": "Buffer overflow in PHP 4.4.6 and earlier, and unspecified PHP 5 versions, allows local and possibly remote attackers to execute arbitrary code via long server name arguments to the (1) mssql_connect and (2) mssql_pconnect functions. \n Publish Date : 2007-03-10 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "Buffer overflow in PHP 4.4.6 and earlier, and unspecified PHP 5 versions, allows local and possibly remote attackers to execute arbitrary code via long server name arguments to the (1) mssql_connect and (2) mssql_pconnect functions.",
+            "lastModifiedDate": "2018-10-19T18:18:00+0000",
+            "publishedDate": "2007-03-10T22:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1393,9 +1615,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2007-1412",
-            "summary": "The cpdf_open function in the ClibPDF (cpdf) extension in PHP 4.4.6 allows context-dependent attackers to obtain sensitive information (script source code) via a long string in the second argument. \n Publish Date : 2007-03-12 Last Update Date : 2008-09-05",
+            "threat": 7.8,
+            "summary": "The cpdf_open function in the ClibPDF (cpdf) extension in PHP 4.4.6 allows context-dependent attackers to obtain sensitive information (script source code) via a long string in the second argument.",
+            "lastModifiedDate": "2017-10-11T01:31:00+0000",
+            "publishedDate": "2007-03-12T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1403,9 +1627,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1413",
-            "summary": "Buffer overflow in the snmpget function in the snmp extension in PHP 5.2.3 and earlier, including PHP 4.4.6 and probably other PHP 4 versions, allows context-dependent attackers to execute arbitrary code via a long value in the third argument (object id). \n Publish Date : 2007-03-12 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the snmpget function in the snmp extension in PHP 5.2.3 and earlier, including PHP 4.4.6 and probably other PHP 4 versions, allows context-dependent attackers to execute arbitrary code via a long value in the third argument (object id).",
+            "lastModifiedDate": "2017-10-11T01:31:00+0000",
+            "publishedDate": "2007-03-12T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1414,9 +1640,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-1452",
-            "summary": "The FDF support (ext\/fdf) in PHP 5.2.0 and earlier does not implement the input filtering hooks for ext\/filter, which allows remote attackers to bypass web site filters via an application\/vnd.fdf formatted POST. \n Publish Date : 2007-03-14 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "The FDF support (ext\/fdf) in PHP 5.2.0 and earlier does not implement the input filtering hooks for ext\/filter, which allows remote attackers to bypass web site filters via an application\/vnd.fdf formatted POST.",
+            "lastModifiedDate": "2008-09-05T21:20:00+0000",
+            "publishedDate": "2007-03-14T18:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1426,9 +1654,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1453",
-            "summary": "Buffer underflow in the PHP_FILTER_TRIM_DEFAULT macro in the filtering extension (ext\/filter) in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by calling filter_var with certain modes such as FILTER_VALIDATE_INT, which causes filter to write a null byte in whitespace that precedes the buffer. \n Publish Date : 2007-03-14 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Buffer underflow in the PHP_FILTER_TRIM_DEFAULT macro in the filtering extension (ext\/filter) in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by calling filter_var with certain modes such as FILTER_VALIDATE_INT, which causes filter to write a null byte in whitespace that precedes the buffer.",
+            "lastModifiedDate": "2008-09-05T21:20:00+0000",
+            "publishedDate": "2007-03-14T18:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1436,9 +1666,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-1454",
-            "summary": "ext\/filter in PHP 5.2.0, when FILTER_SANITIZE_STRING is used with the FILTER_FLAG_STRIP_LOW flag, does not properly strip HTML tags, which allows remote attackers to conduct cross-site scripting (XSS) attacks via HTML with a '<' character followed by certain whitespace characters, which passes one filter but is collapsed into a valid tag, as demonstrated using %0b. \n Publish Date : 2007-03-14 Last Update Date : 2008-09-05",
+            "threat": 4.3,
+            "summary": "ext\/filter in PHP 5.2.0, when FILTER_SANITIZE_STRING is used with the FILTER_FLAG_STRIP_LOW flag, does not properly strip HTML tags, which allows remote attackers to conduct cross-site scripting (XSS) attacks via HTML with a '<' character followed by certain whitespace characters, which passes one filter but is collapsed into a valid tag, as demonstrated using %0b.",
+            "lastModifiedDate": "2008-09-05T21:20:00+0000",
+            "publishedDate": "2007-03-14T18:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1446,9 +1678,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-1460",
-            "summary": "The zip:\/\/ URL wrapper provided by the PECL zip extension in PHP before 4.4.7, and 5.2.0 and 5.2.1, does not implement safemode or open_basedir checks, which allows remote attackers to read ZIP archives located outside of the intended directories. \n Publish Date : 2007-03-14 Last Update Date : 2011-05-24",
+            "threat": 5,
+            "summary": "The zip:\/\/ URL wrapper provided by the PECL zip extension in PHP before 4.4.7, and 5.2.0 and 5.2.1, does not implement safemode or open_basedir checks, which allows remote attackers to read ZIP archives located outside of the intended directories.",
+            "lastModifiedDate": "2011-05-24T04:00:00+0000",
+            "publishedDate": "2007-03-14T18:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1461,9 +1695,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2007-1461",
-            "summary": "The compress.bzip2:\/\/ URL wrapper provided by the bz2 extension in PHP before 4.4.7, and 5.x before 5.2.2, does not implement safemode or open_basedir checks, which allows remote attackers to read bzip2 archives located outside of the intended directories. \n Publish Date : 2007-03-14 Last Update Date : 2011-07-13",
+            "threat": 7.8,
+            "summary": "The compress.bzip2:\/\/ URL wrapper provided by the bz2 extension in PHP before 4.4.7, and 5.x before 5.2.2, does not implement safemode or open_basedir checks, which allows remote attackers to read bzip2 archives located outside of the intended directories.",
+            "lastModifiedDate": "2011-07-13T04:00:00+0000",
+            "publishedDate": "2007-03-14T18:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1478,9 +1714,11 @@
             }
         },
         {
-            "threat": "5.4",
             "cveid": "CVE-2007-1475",
-            "summary": "Multiple buffer overflows in the (1) ibase_connect and (2) ibase_pconnect functions in the interbase extension in PHP 4.4.6 and earlier allow context-dependent attackers to execute arbitrary code via a long argument. \n Publish Date : 2007-03-16 Last Update Date : 2008-09-05",
+            "threat": 5.4,
+            "summary": "Multiple buffer overflows in the (1) ibase_connect and (2) ibase_pconnect functions in the interbase extension in PHP 4.4.6 and earlier allow context-dependent attackers to execute arbitrary code via a long argument.",
+            "lastModifiedDate": "2018-10-19T18:18:00+0000",
+            "publishedDate": "2007-03-16T21:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1492,9 +1730,11 @@
             }
         },
         {
-            "threat": "4.6",
             "cveid": "CVE-2007-1484",
-            "summary": "The array_user_key_compare function in PHP 4.4.6 and earlier, and 5.x up to 5.2.1, makes erroneous calls to zval_dtor, which triggers memory corruption and allows local users to bypass safe_mode and execute arbitrary code via a certain unset operation after array_user_key_compare has been called. \n Publish Date : 2007-03-16 Last Update Date : 2008-09-05",
+            "threat": 4.6,
+            "summary": "The array_user_key_compare function in PHP 4.4.6 and earlier, and 5.x up to 5.2.1, makes erroneous calls to zval_dtor, which triggers memory corruption and allows local users to bypass safe_mode and execute arbitrary code via a certain unset operation after array_user_key_compare has been called.",
+            "lastModifiedDate": "2018-10-19T18:18:00+0000",
+            "publishedDate": "2007-03-16T21:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1505,9 +1745,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1521",
-            "summary": "Double free vulnerability in PHP before 4.4.7, and 5.x before 5.2.2, allows context-dependent attackers to execute arbitrary code by interrupting the session_regenerate_id function, as demonstrated by calling a userspace error handler or triggering a memory limit violation. \n Publish Date : 2007-03-20 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "Double free vulnerability in PHP before 4.4.7, and 5.x before 5.2.2, allows context-dependent attackers to execute arbitrary code by interrupting the session_regenerate_id function, as demonstrated by calling a userspace error handler or triggering a memory limit violation.",
+            "lastModifiedDate": "2011-03-08T02:52:00+0000",
+            "publishedDate": "2007-03-20T20:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1516,9 +1758,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1522",
-            "summary": "Double free vulnerability in the session extension in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to execute arbitrary code via illegal characters in a session identifier, which is rejected by an internal session storage module, which calls the session identifier generator with an improper environment, leading to code execution when the generator is interrupted, as demonstrated by triggering a memory limit violation or certain PHP errors. \n Publish Date : 2007-03-20 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "Double free vulnerability in the session extension in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to execute arbitrary code via illegal characters in a session identifier, which is rejected by an internal session storage module, which calls the session identifier generator with an improper environment, leading to code execution when the generator is interrupted, as demonstrated by triggering a memory limit violation or certain PHP errors.",
+            "lastModifiedDate": "2011-03-08T02:52:00+0000",
+            "publishedDate": "2007-03-20T20:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1526,9 +1770,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2007-1581",
-            "summary": "The resource system in PHP 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting the hash_update_file function via a userspace (1) error or (2) stream handler, which can then be used to destroy and modify internal resources.  NOTE: it was later reported that PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 are also affected. \n Publish Date : 2007-03-21 Last Update Date : 2012-11-05",
+            "threat": 9.3,
+            "summary": "The resource system in PHP 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting the hash_update_file function via a userspace (1) error or (2) stream handler, which can then be used to destroy and modify internal resources.  NOTE: it was later reported that PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 are also affected.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-21T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1539,9 +1785,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1582",
-            "summary": "The resource system in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting certain functions in the GD (ext\/gd) extension and unspecified other extensions via a userspace error handler, which can be used to destroy and modify internal resources. \n Publish Date : 2007-03-21 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "The resource system in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to execute arbitrary code by interrupting certain functions in the GD (ext\/gd) extension and unspecified other extensions via a userspace error handler, which can be used to destroy and modify internal resources.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-21T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1556,9 +1804,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1583",
-            "summary": "The mb_parse_str function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 sets the internal register_globals flag and does not disable it in certain cases when a script terminates, which allows remote attackers to invoke available PHP scripts with register_globals functionality that is not detectable by these scripts, as demonstrated by forcing a memory_limit violation. \n Publish Date : 2007-03-21 Last Update Date : 2010-11-30",
+            "threat": 6.8,
+            "summary": "The mb_parse_str function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 sets the internal register_globals flag and does not disable it in certain cases when a script terminates, which allows remote attackers to invoke available PHP scripts with register_globals functionality that is not detectable by these scripts, as demonstrated by forcing a memory_limit violation.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-21T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1573,9 +1823,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1584",
-            "summary": "Buffer underflow in the header function in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by passing an all-whitespace string to this function, which causes it to write '\\0' characters in whitespace that precedes the string. \n Publish Date : 2007-03-21 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "Buffer underflow in the header function in PHP 5.2.0 allows context-dependent attackers to execute arbitrary code by passing an all-whitespace string to this function, which causes it to write '\\0' characters in whitespace that precedes the string.",
+            "lastModifiedDate": "2017-10-11T01:31:00+0000",
+            "publishedDate": "2007-03-21T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1583,9 +1835,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2007-1649",
-            "summary": "PHP 5.2.1 allows context-dependent attackers to read portions of heap memory by executing certain scripts with a serialized data input string beginning with S:, which does not properly track the number of input bytes being processed. \n Publish Date : 2007-03-23 Last Update Date : 2008-09-05",
+            "threat": 7.8,
+            "summary": "PHP 5.2.1 allows context-dependent attackers to read portions of heap memory by executing certain scripts with a serialized data input string beginning with S:, which does not properly track the number of input bytes being processed.",
+            "lastModifiedDate": "2017-07-29T01:30:00+0000",
+            "publishedDate": "2007-03-24T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1593,9 +1847,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1700",
-            "summary": "The session extension in PHP 4 before 4.4.5, and PHP 5 before 5.2.1, calculates the reference count for the session variables without considering the internal pointer from the session globals, which allows context-dependent attackers to execute arbitrary code via a crafted string in the session_register after unsetting HTTP_SESSION_VARS and _SESSION, which destroys the session data Hashtable. \n Publish Date : 2007-03-26 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "The session extension in PHP 4 before 4.4.5, and PHP 5 before 5.2.1, calculates the reference count for the session variables without considering the internal pointer from the session globals, which allows context-dependent attackers to execute arbitrary code via a crafted string in the session_register after unsetting HTTP_SESSION_VARS and _SESSION, which destroys the session data Hashtable.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-27T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1610,9 +1866,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1701",
-            "summary": "PHP 4 before 4.4.5, and PHP 5 before 5.2.1, when register_globals is enabled, allows context-dependent attackers to execute arbitrary code via deserialization of session data, which overwrites arbitrary global variables, as demonstrated by calling session_decode on a string beginning with \"_SESSION|s:39:\". \n Publish Date : 2007-03-26 Last Update Date : 2012-11-05",
+            "threat": 6.8,
+            "summary": "PHP 4 before 4.4.5, and PHP 5 before 5.2.1, when register_globals is enabled, allows context-dependent attackers to execute arbitrary code via deserialization of session data, which overwrites arbitrary global variables, as demonstrated by calling session_decode on a string beginning with \"_SESSION|s:39:\".",
+            "lastModifiedDate": "2019-10-09T22:52:00+0000",
+            "publishedDate": "2007-03-27T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.5",
@@ -1621,9 +1879,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-1709",
-            "summary": "Buffer overflow in the confirm_phpdoc_compiled function in the phpDOC extension (PECL phpDOC) in PHP 5.2.1 allows context-dependent attackers to execute arbitrary code via a long argument string. \n Publish Date : 2007-03-26 Last Update Date : 2008-09-05",
+            "threat": 4.3,
+            "summary": "Buffer overflow in the confirm_phpdoc_compiled function in the phpDOC extension (PECL phpDOC) in PHP 5.2.1 allows context-dependent attackers to execute arbitrary code via a long argument string.",
+            "lastModifiedDate": "2018-10-16T16:40:00+0000",
+            "publishedDate": "2007-03-27T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1631,9 +1891,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-1710",
-            "summary": "The readfile function in PHP 4.4.4, 5.1.6, and 5.2.1 allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files by referring to local files with a certain URL syntax instead of a pathname syntax, as demonstrated by a filename preceded a \"php:\/\/..\/..\/\" sequence. \n Publish Date : 2007-03-26 Last Update Date : 2013-08-03",
+            "threat": 4.3,
+            "summary": "The readfile function in PHP 4.4.4, 5.1.6, and 5.2.1 allows context-dependent attackers to bypass safe_mode restrictions and read arbitrary files by referring to local files with a certain URL syntax instead of a pathname syntax, as demonstrated by a filename preceded a \"php:\/\/..\/..\/\" sequence.",
+            "lastModifiedDate": "2017-10-11T01:31:00+0000",
+            "publishedDate": "2007-03-27T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.5",
@@ -1643,9 +1905,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1711",
-            "summary": "Double free vulnerability in the unserializer in PHP 4.4.5 and 4.4.6 allows context-dependent attackers to execute arbitrary code by overwriting variables pointing to (1) the GLOBALS array or (2) the session data in _SESSION.  NOTE: this issue was introduced when attempting to patch CVE-2007-1701 (MOPB-31-2007). \n Publish Date : 2007-03-26 Last Update Date : 2012-11-05",
+            "threat": 6.8,
+            "summary": "Double free vulnerability in the unserializer in PHP 4.4.5 and 4.4.6 allows context-dependent attackers to execute arbitrary code by overwriting variables pointing to (1) the GLOBALS array or (2) the session data in _SESSION.  NOTE: this issue was introduced when attempting to patch CVE-2007-1701 (MOPB-31-2007).",
+            "lastModifiedDate": "2018-10-16T16:40:00+0000",
+            "publishedDate": "2007-03-27T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7"
@@ -1653,9 +1917,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2007-1717",
-            "summary": "The mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 truncates e-mail messages at the first ASCIIZ ('\\0') byte, which might allow context-dependent attackers to prevent intended information from being delivered in e-mail messages.  NOTE: this issue might be security-relevant in cases when the trailing contents of e-mail messages are important, such as logging information or if the message is expected to be well-formed. \n Publish Date : 2007-03-27 Last Update Date : 2012-11-05",
+            "threat": 5,
+            "summary": "The mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 truncates e-mail messages at the first ASCIIZ ('\\0') byte, which might allow context-dependent attackers to prevent intended information from being delivered in e-mail messages.  NOTE: this issue might be security-relevant in cases when the trailing contents of e-mail messages are important, such as logging information or if the message is expected to be well-formed.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-28T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1670,9 +1936,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2007-1718",
-            "summary": "CRLF injection vulnerability in the mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows remote attackers to inject arbitrary e-mail headers and possibly conduct spam attacks via a control character immediately following folding of the (1) Subject or (2) To parameter, as demonstrated by a parameter containing a \"\\r\\n\\t\\n\" sequence, related to an increment bug in the SKIP_LONG_HEADER_SEP macro. \n Publish Date : 2007-03-27 Last Update Date : 2013-08-13",
+            "threat": 7.8,
+            "summary": "CRLF injection vulnerability in the mail function in PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows remote attackers to inject arbitrary e-mail headers and possibly conduct spam attacks via a control character immediately following folding of the (1) Subject or (2) To parameter, as demonstrated by a parameter containing a \"\\r\\n\\t\\n\" sequence, related to an increment bug in the SKIP_LONG_HEADER_SEP macro.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-28T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1687,9 +1955,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1777",
-            "summary": "Integer overflow in the zip_read_entry function in PHP 4 before 4.4.5 allows remote attackers to execute arbitrary code via a ZIP archive that contains an entry with a length value of 0xffffffff, which is incremented before use in an emalloc call, triggering a heap overflow. \n Publish Date : 2007-03-29 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "Integer overflow in the zip_read_entry function in PHP 4 before 4.4.5 allows remote attackers to execute arbitrary code via a ZIP archive that contains an entry with a length value of 0xffffffff, which is incremented before use in an emalloc call, triggering a heap overflow.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-03-30T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1701,9 +1971,11 @@
             }
         },
         {
-            "threat": "5.1",
             "cveid": "CVE-2007-1824",
-            "summary": "Buffer overflow in the php_stream_filter_create function in PHP 5 before 5.2.1 allows remote attackers to cause a denial of service (application crash) via a php:\/\/filter\/ URL that has a name ending in the '.' character. \n Publish Date : 2007-04-02 Last Update Date : 2012-11-05",
+            "threat": 5.1,
+            "summary": "Buffer overflow in the php_stream_filter_create function in PHP 5 before 5.2.1 allows remote attackers to cause a denial of service (application crash) via a php:\/\/filter\/ URL that has a name ending in the '.' character.",
+            "lastModifiedDate": "2017-07-29T01:31:00+0000",
+            "publishedDate": "2007-04-02T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1713,9 +1985,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1825",
-            "summary": "Buffer overflow in the imap_mail_compose function in PHP 5 before 5.2.1, and PHP 4 before 4.4.5, allows remote attackers to execute arbitrary code via a long boundary string in a type.parameters field. NOTE: as of 20070411, it appears that this issue might be subsumed by CVE-2007-0906.3. \n Publish Date : 2007-04-02 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the imap_mail_compose function in PHP 5 before 5.2.1, and PHP 4 before 4.4.5, allows remote attackers to execute arbitrary code via a long boundary string in a type.parameters field. NOTE: as of 20070411, it appears that this issue might be subsumed by CVE-2007-0906.3.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-02T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1730,9 +2004,11 @@
             }
         },
         {
-            "threat": "4.6",
             "cveid": "CVE-2007-1835",
-            "summary": "PHP 4 before 4.4.5 and PHP 5 before 5.2.1, when using an empty session save path (session.save_path), uses the TMPDIR default after checking the restrictions, which allows local users to bypass open_basedir restrictions. \n Publish Date : 2007-04-02 Last Update Date : 2012-11-05",
+            "threat": 4.6,
+            "summary": "PHP 4 before 4.4.5 and PHP 5 before 5.2.1, when using an empty session save path (session.save_path), uses the TMPDIR default after checking the restrictions, which allows local users to bypass open_basedir restrictions.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-03T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1747,9 +2023,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1864",
-            "summary": "Buffer overflow in the bundled libxmlrpc library in PHP before 4.4.7, and 5.x before 5.2.2, has unknown impact and remote attack vectors. \n Publish Date : 2007-05-08 Last Update Date : 2012-10-30",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the bundled libxmlrpc library in PHP before 4.4.7, and 5.x before 5.2.2, has unknown impact and remote attack vectors.",
+            "lastModifiedDate": "2019-05-22T18:44:00+0000",
+            "publishedDate": "2007-05-09T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.7",
@@ -1758,9 +2036,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2007-1883",
-            "summary": "PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to read arbitrary memory locations via an interruption that triggers a user space error handler that changes a parameter to an arbitrary pointer, as demonstrated via the iptcembed function, which calls certain convert_to_* functions with its input parameters. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 7.8,
+            "summary": "PHP 4.0.0 through 4.4.6 and 5.0.0 through 5.2.1 allows context-dependent attackers to read arbitrary memory locations via an interruption that triggers a user space error handler that changes a parameter to an arbitrary pointer, as demonstrated via the iptcembed function, which calls certain convert_to_* functions with its input parameters.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1775,9 +2055,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1884",
-            "summary": "Multiple integer signedness errors in the printf function family in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 on 64 bit machines allow context-dependent attackers to execute arbitrary code via (1) certain negative argument numbers that arise in the php_formatted_print function because of 64 to 32 bit truncation, and bypass a check for the maximum allowable value; and (2) a width and precision of -1, which make it possible for the php_sprintf_appendstring function to place an internal buffer at an arbitrary memory location. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 6.8,
+            "summary": "Multiple integer signedness errors in the printf function family in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 on 64 bit machines allow context-dependent attackers to execute arbitrary code via (1) certain negative argument numbers that arise in the php_formatted_print function because of 64 to 32 bit truncation, and bypass a check for the maximum allowable value; and (2) a width and precision of -1, which make it possible for the php_sprintf_appendstring function to place an internal buffer at an arbitrary memory location.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1792,9 +2074,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1885",
-            "summary": "Integer overflow in the str_replace function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via a single character search string in conjunction with a long replacement string, which overflows a 32 bit length counter.  NOTE: this is probably the same issue as CVE-2007-0906.6. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "Integer overflow in the str_replace function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via a single character search string in conjunction with a long replacement string, which overflows a 32 bit length counter.  NOTE: this is probably the same issue as CVE-2007-0906.6.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1809,9 +2093,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-1886",
-            "summary": "Integer overflow in the str_replace function in PHP 4.4.5 and PHP 5.2.1 allows context-dependent attackers to have an unknown impact via a single character search string in conjunction with a single character replacement string, which causes an \"off by one overflow.\" \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 6.8,
+            "summary": "Integer overflow in the str_replace function in PHP 4.4.5 and PHP 5.2.1 allows context-dependent attackers to have an unknown impact via a single character search string in conjunction with a single character replacement string, which causes an \"off by one overflow.\"",
+            "lastModifiedDate": "2017-07-29T01:31:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.6",
@@ -1820,9 +2106,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1887",
-            "summary": "Buffer overflow in the sqlite_decode_binary function in the bundled sqlite library in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter, as demonstrated by calling the sqlite_udf_decode_binary function with a 0x01 character. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the sqlite_decode_binary function in the bundled sqlite library in PHP 4 before 4.4.5 and PHP 5 before 5.2.1 allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter, as demonstrated by calling the sqlite_udf_decode_binary function with a 0x01 character.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1837,9 +2125,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1888",
-            "summary": "Buffer overflow in the sqlite_decode_binary function in src\/encode.c in SQLite 2, as used by PHP 4.x through 5.x and other applications, allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter.  NOTE: some PHP installations use a bundled version of sqlite without this vulnerability.  The SQLite developer has argued that this issue could be due to a misuse of the sqlite_decode_binary() API. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the sqlite_decode_binary function in src\/encode.c in SQLite 2, as used by PHP 4.x through 5.x and other applications, allows context-dependent attackers to execute arbitrary code via an empty value of the in parameter.  NOTE: some PHP installations use a bundled version of sqlite without this vulnerability.  The SQLite developer has argued that this issue could be due to a misuse of the sqlite_decode_binary() API.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1855,9 +2145,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1889",
-            "summary": "Integer signedness error in the _zend_mm_alloc_int function in the Zend Memory Manager in PHP 5.2.0 allows remote attackers to execute arbitrary code via a large emalloc request, related to an incorrect signed long cast, as demonstrated via the HTTP SOAP client in PHP, and via a call to msg_receive with the largest positive integer value of maxsize. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "Integer signedness error in the _zend_mm_alloc_int function in the Zend Memory Manager in PHP 5.2.0 allows remote attackers to execute arbitrary code via a large emalloc request, related to an incorrect signed long cast, as demonstrated via the HTTP SOAP client in PHP, and via a call to msg_receive with the largest positive integer value of maxsize.",
+            "lastModifiedDate": "2017-07-29T01:31:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -1865,9 +2157,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-1890",
-            "summary": "Integer overflow in the msg_receive function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1, on FreeBSD and possibly other platforms, allows context-dependent attackers to execute arbitrary code via certain maxsize values, as demonstrated by 0xffffffff. \n Publish Date : 2007-04-05 Last Update Date : 2012-11-05",
+            "threat": 7.5,
+            "summary": "Integer overflow in the msg_receive function in PHP 4 before 4.4.5 and PHP 5 before 5.2.1, on FreeBSD and possibly other platforms, allows context-dependent attackers to execute arbitrary code via certain maxsize values, as demonstrated by 0xffffffff.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-04-06T01:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1882,9 +2176,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-1900",
-            "summary": "CRLF injection vulnerability in the FILTER_VALIDATE_EMAIL filter in ext\/filter in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to inject arbitrary e-mail headers via an e-mail address with a '\\n' character, which causes a regular expression to ignore the subsequent part of the address string. \n Publish Date : 2007-04-10 Last Update Date : 2009-03-04",
+            "threat": 5,
+            "summary": "CRLF injection vulnerability in the FILTER_VALIDATE_EMAIL filter in ext\/filter in PHP 5.2.0 and 5.2.1 allows context-dependent attackers to inject arbitrary e-mail headers via an e-mail address with a '\\n' character, which causes a regular expression to ignore the subsequent part of the address string.",
+            "lastModifiedDate": "2017-10-11T01:32:00+0000",
+            "publishedDate": "2007-04-10T18:19:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.2"
@@ -1892,9 +2188,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-2369",
-            "summary": "Directory traversal vulnerability in picture.php in WebSPELL 4.01.02 and earlier, when PHP before 4.3.0 is used, allows remote attackers to read arbitrary files via a .. (dot dot) in the id parameter. \n Publish Date : 2007-04-30 Last Update Date : 2008-11-15",
+            "threat": 5,
+            "summary": "Directory traversal vulnerability in picture.php in WebSPELL 4.01.02 and earlier, when PHP before 4.3.0 is used, allows remote attackers to read arbitrary files via a .. (dot dot) in the id parameter.",
+            "lastModifiedDate": "2017-10-11T01:32:00+0000",
+            "publishedDate": "2007-04-30T23:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.01.3",
@@ -1903,9 +2201,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2007-2509",
-            "summary": "CRLF injection vulnerability in the ftp_putcmd function in PHP before 4.4.7, and 5.x before 5.2.2 allows remote attackers to inject arbitrary FTP commands via CRLF sequences in the parameters to earlier FTP commands. \n Publish Date : 2007-05-08 Last Update Date : 2012-11-05",
+            "threat": 2.6,
+            "summary": "CRLF injection vulnerability in the ftp_putcmd function in PHP before 4.4.7, and 5.x before 5.2.2 allows remote attackers to inject arbitrary FTP commands via CRLF sequences in the parameters to earlier FTP commands.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-05-09T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1920,9 +2220,11 @@
             }
         },
         {
-            "threat": "5.1",
             "cveid": "CVE-2007-2510",
-            "summary": "Buffer overflow in the make_http_soap_request function in PHP before 5.2.2 has unknown impact and remote attack vectors, possibly related to \"\/\" (slash) characters. \n Publish Date : 2007-05-08 Last Update Date : 2012-10-30",
+            "threat": 5.1,
+            "summary": "Buffer overflow in the make_http_soap_request function in PHP before 5.2.2 has unknown impact and remote attack vectors, possibly related to \"\/\" (slash) characters.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-05-09T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1937,9 +2239,11 @@
             }
         },
         {
-            "threat": "7.2",
             "cveid": "CVE-2007-2511",
-            "summary": "Buffer overflow in the user_filter_factory_create function in PHP before 5.2.2 has unknown impact and local attack vectors. \n Publish Date : 2007-05-08 Last Update Date : 2012-10-30",
+            "threat": 7.2,
+            "summary": "Buffer overflow in the user_filter_factory_create function in PHP before 5.2.2 has unknown impact and local attack vectors.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-05-09T00:19:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1952,9 +2256,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2007-2727",
-            "summary": "The mcrypt_create_iv function in ext\/mcrypt\/mcrypt.c in PHP before 4.4.7, 5.2.1, and possibly 5.0.x and other PHP 5 versions, calls php_rand_r with an uninitialized seed variable and therefore always generates the same initialization vector (IV), which might allow context-dependent attackers to decrypt certain data more easily because of the guessable encryption keys. \n Publish Date : 2007-05-16 Last Update Date : 2012-11-05",
+            "threat": 2.6,
+            "summary": "The mcrypt_create_iv function in ext\/mcrypt\/mcrypt.c in PHP before 4.4.7, 5.2.1, and possibly 5.0.x and other PHP 5 versions, calls php_rand_r with an uninitialized seed variable and therefore always generates the same initialization vector (IV), which might allow context-dependent attackers to decrypt certain data more easily because of the guessable encryption keys.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-05-16T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1969,9 +2275,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-2748",
-            "summary": "The substr_count function in PHP 5.2.1 and earlier allows context-dependent attackers to obtain sensitive information via unspecified vectors, a different affected function than CVE-2007-1375. \n Publish Date : 2007-05-17 Last Update Date : 2012-10-30",
+            "threat": 4.3,
+            "summary": "The substr_count function in PHP 5.2.1 and earlier allows context-dependent attackers to obtain sensitive information via unspecified vectors, a different affected function than CVE-2007-1375.",
+            "lastModifiedDate": "2018-10-19T19:03:00+0000",
+            "publishedDate": "2007-05-17T20:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -1981,9 +2289,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2007-2844",
-            "summary": "PHP 4.x and 5.x before 5.2.1, when running on multi-threaded systems, does not ensure thread safety for libc crypt function calls using protection schemes such as a mutex, which creates race conditions that allow remote attackers to overwrite internal program memory and gain system access. \n Publish Date : 2007-05-24 Last Update Date : 2012-11-05",
+            "threat": 9.3,
+            "summary": "PHP 4.x and 5.x before 5.2.1, when running on multi-threaded systems, does not ensure thread safety for libc crypt function calls using protection schemes such as a mutex, which creates race conditions that allow remote attackers to overwrite internal program memory and gain system access.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-05-24T18:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -1998,9 +2308,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-2872",
-            "summary": "Multiple integer overflows in the chunk_split function in PHP 5 before 5.2.3 and PHP 4 before 4.4.8 allow remote attackers to cause a denial of service (crash) or execute arbitrary code via the (1) chunks, (2) srclen, and (3) chunklen arguments. \n Publish Date : 2007-06-04 Last Update Date : 2012-10-30",
+            "threat": 6.8,
+            "summary": "Multiple integer overflows in the chunk_split function in PHP 5 before 5.2.3 and PHP 4 before 4.4.8 allow remote attackers to cause a denial of service (crash) or execute arbitrary code via the (1) chunks, (2) srclen, and (3) chunklen arguments.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-06-04T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2011,9 +2323,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-3007",
-            "summary": "PHP 5 before 5.2.3 does not enforce the open_basedir or safe_mode restriction in certain cases, which allows context-dependent attackers to determine the existence of arbitrary files by checking if the readfile function returns a string.  NOTE: this issue might also involve the realpath function. \n Publish Date : 2007-06-04 Last Update Date : 2012-10-30",
+            "threat": 5,
+            "summary": "PHP 5 before 5.2.3 does not enforce the open_basedir or safe_mode restriction in certain cases, which allows context-dependent attackers to determine the existence of arbitrary files by checking if the readfile function returns a string.  NOTE: this issue might also involve the realpath function.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2007-06-04T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2023,9 +2337,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-3294",
-            "summary": "Multiple buffer overflows in libtidy, as used in the Tidy extension for PHP 5.2.3 and possibly other products, allow context-dependent attackers to execute arbitrary code via (1) a long second argument to the tidy_parse_string function or (2) an unspecified vector to the tidy_repair_string function.  NOTE: this might only be an issue in environments where vsnprintf is implemented as a wrapper for vsprintf. \n Publish Date : 2007-06-20 Last Update Date : 2012-10-30",
+            "threat": 7.5,
+            "summary": "Multiple buffer overflows in libtidy, as used in the Tidy extension for PHP 5.2.3 and possibly other products, allow context-dependent attackers to execute arbitrary code via (1) a long second argument to the tidy_parse_string function or (2) an unspecified vector to the tidy_repair_string function.  NOTE: this might only be an issue in environments where vsnprintf is implemented as a wrapper for vsprintf.",
+            "lastModifiedDate": "2017-10-11T01:32:00+0000",
+            "publishedDate": "2007-06-20T21:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2033,9 +2349,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-3378",
-            "summary": "The (1) session_save_path, (2) ini_set, and (3) error_log functions in PHP 4.4.7 and earlier, and PHP 5 5.2.3 and earlier, when invoked from a .htaccess file, allow remote attackers to bypass safe_mode and open_basedir restrictions and possibly execute arbitrary commands, as demonstrated using (a) php_value, (b) php_flag, and (c) directives in .htaccess. \n Publish Date : 2007-06-29 Last Update Date : 2010-11-22",
+            "threat": 6.8,
+            "summary": "The (1) session_save_path, (2) ini_set, and (3) error_log functions in PHP 4.4.7 and earlier, and PHP 5 5.2.3 and earlier, when invoked from a .htaccess file, allow remote attackers to bypass safe_mode and open_basedir restrictions and possibly execute arbitrary commands, as demonstrated using (a) php_value, (b) php_flag, and (c) directives in .htaccess.",
+            "lastModifiedDate": "2019-10-09T22:53:00+0000",
+            "publishedDate": "2007-06-29T18:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2044,9 +2362,11 @@
             }
         },
         {
-            "threat": "5.8",
             "cveid": "CVE-2007-3790",
-            "summary": "The com_print_typeinfo function in the bz2 extension in PHP 5.2.3 allows context-dependent attackers to cause a denial of service via a long argument. \n Publish Date : 2007-07-15 Last Update Date : 2012-10-30",
+            "threat": 5.8,
+            "summary": "The com_print_typeinfo function in the bz2 extension in PHP 5.2.3 allows context-dependent attackers to cause a denial of service via a long argument.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-07-15T23:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2054,9 +2374,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-3799",
-            "summary": "The session_start function in ext\/session in PHP 4.x up to 4.4.7 and 5.x up to 5.2.3 allows remote attackers to insert arbitrary attributes into the session cookie via special characters in a cookie that is obtained from (1) PATH_INFO, (2) the session_id function, and (3) the session_start function, which are not encoded or filtered when the new session cookie is generated, a related issue to CVE-2006-0207. \n Publish Date : 2007-07-16 Last Update Date : 2012-10-30",
+            "threat": 4.3,
+            "summary": "The session_start function in ext\/session in PHP 4.x up to 4.4.7 and 5.x up to 5.2.3 allows remote attackers to insert arbitrary attributes into the session cookie via special characters in a cookie that is obtained from (1) PATH_INFO, (2) the session_id function, and (3) the session_start function, which are not encoded or filtered when the new session cookie is generated, a related issue to CVE-2006-0207.",
+            "lastModifiedDate": "2018-10-03T21:47:00+0000",
+            "publishedDate": "2007-07-16T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2071,9 +2393,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-3806",
-            "summary": "The glob function in PHP 5.2.3 allows context-dependent attackers to cause a denial of service and possibly execute arbitrary code via an invalid value of the flags parameter, probably related to memory corruption or an invalid read on win32 platforms, and possibly related to lack of initialization for a glob structure. \n Publish Date : 2007-07-16 Last Update Date : 2012-11-05",
+            "threat": 6.8,
+            "summary": "The glob function in PHP 5.2.3 allows context-dependent attackers to cause a denial of service and possibly execute arbitrary code via an invalid value of the flags parameter, probably related to memory corruption or an invalid read on win32 platforms, and possibly related to lack of initialization for a glob structure.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-07-17T00:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2081,9 +2405,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-3996",
-            "summary": "Multiple integer overflows in libgd in PHP before 5.2.4 allow remote attackers to cause a denial of service (application crash) and possibly execute arbitrary code via a large (1) srcW or (2) srcH value to the (a) gdImageCopyResized function, or a large (3) sy (height) or (4) sx (width) value to the (b) gdImageCreate or the (c) gdImageCreateTrueColor function. \n Publish Date : 2007-09-04 Last Update Date : 2010-08-21",
+            "threat": 6.8,
+            "summary": "Multiple integer overflows in libgd in PHP before 5.2.4 allow remote attackers to cause a denial of service (application crash) and possibly execute arbitrary code via a large (1) srcW or (2) srcH value to the (a) gdImageCopyResized function, or a large (3) sy (height) or (4) sx (width) value to the (b) gdImageCreate or the (c) gdImageCreateTrueColor function.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-09-04T18:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2091,9 +2417,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-3997",
-            "summary": "The (1) MySQL and (2) MySQLi extensions in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to bypass safe_mode and open_basedir restrictions via MySQL LOCAL INFILE operations, as demonstrated by a query with LOAD DATA LOCAL INFILE. \n Publish Date : 2007-09-04 Last Update Date : 2009-09-16",
+            "threat": 7.5,
+            "summary": "The (1) MySQL and (2) MySQLi extensions in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to bypass safe_mode and open_basedir restrictions via MySQL LOCAL INFILE operations, as demonstrated by a query with LOAD DATA LOCAL INFILE.",
+            "lastModifiedDate": "2018-10-26T13:59:00+0000",
+            "publishedDate": "2007-09-04T18:17:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2102,9 +2430,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-3998",
-            "summary": "The wordwrap function in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, does not properly use the breakcharlen variable, which allows remote attackers to cause a denial of service (divide-by-zero error and application crash, or infinite loop) via certain arguments, as demonstrated by a 'chr(0), 0, \"\"' argument set. \n Publish Date : 2007-09-04 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "The wordwrap function in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, does not properly use the breakcharlen variable, which allows remote attackers to cause a denial of service (divide-by-zero error and application crash, or infinite loop) via certain arguments, as demonstrated by a 'chr(0), 0, \"\"' argument set.",
+            "lastModifiedDate": "2018-10-26T13:59:00+0000",
+            "publishedDate": "2007-09-04T18:17:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2113,9 +2443,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-4010",
-            "summary": "The win32std extension in PHP 5.2.3 does not follow safe_mode and disable_functions restrictions, which allows remote attackers to execute arbitrary commands via the win_shell_execute function. \n Publish Date : 2007-07-25 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "The win32std extension in PHP 5.2.3 does not follow safe_mode and disable_functions restrictions, which allows remote attackers to execute arbitrary commands via the win_shell_execute function.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-07-26T00:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2123,9 +2455,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4033",
-            "summary": "Buffer overflow in the intT1_EnvGetCompletePath function in lib\/t1lib\/t1env.c in t1lib 5.1.1 allows context-dependent attackers to execute arbitrary code via a long FileName parameter.  NOTE: this issue was originally reported to be in the imagepsloadfont function in php_gd2.dll in the gd (PHP_GD2) extension in PHP 5.2.3. \n Publish Date : 2007-07-27 Last Update Date : 2010-08-21",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the intT1_EnvGetCompletePath function in lib\/t1lib\/t1env.c in t1lib 5.1.1 allows context-dependent attackers to execute arbitrary code via a long FileName parameter.  NOTE: this issue was originally reported to be in the imagepsloadfont function in php_gd2.dll in the gd (PHP_GD2) extension in PHP 5.2.3.",
+            "lastModifiedDate": "2018-10-15T21:32:00+0000",
+            "publishedDate": "2007-07-27T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.1.2",
@@ -2134,9 +2468,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4255",
-            "summary": "Buffer overflow in the mSQL extension in PHP 5.2.3 allows context-dependent attackers to execute arbitrary code via a long first argument to the msql_connect function. \n Publish Date : 2007-08-08 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the mSQL extension in PHP 5.2.3 allows context-dependent attackers to execute arbitrary code via a long first argument to the msql_connect function.",
+            "lastModifiedDate": "2018-10-15T21:34:00+0000",
+            "publishedDate": "2007-08-08T23:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2144,9 +2480,11 @@
             }
         },
         {
-            "threat": "4.6",
             "cveid": "CVE-2007-4441",
-            "summary": "Buffer overflow in php_win32std.dll in the win32std extension for PHP 5.2.0 and earlier allows context-dependent attackers to execute arbitrary code via a long string in the filename argument to the win_browse_file function. \n Publish Date : 2007-08-20 Last Update Date : 2008-09-05",
+            "threat": 4.6,
+            "summary": "Buffer overflow in php_win32std.dll in the win32std extension for PHP 5.2.0 and earlier allows context-dependent attackers to execute arbitrary code via a long string in the filename argument to the win_browse_file function.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-08-21T00:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -2154,9 +2492,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-4507",
-            "summary": "Multiple buffer overflows in the php_ntuser component for PHP 5.2.3 allow context-dependent attackers to cause a denial of service or execute arbitrary code via long arguments to the (1) ntuser_getuserlist, (2) ntuser_getuserinfo, (3) ntuser_getusergroups, or (4) ntuser_getdomaincontroller functions. \n Publish Date : 2007-08-23 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "Multiple buffer overflows in the php_ntuser component for PHP 5.2.3 allow context-dependent attackers to cause a denial of service or execute arbitrary code via long arguments to the (1) ntuser_getuserlist, (2) ntuser_getuserinfo, (3) ntuser_getusergroups, or (4) ntuser_getdomaincontroller functions.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-08-23T19:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2164,9 +2504,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-4528",
-            "summary": "The Foreign Function Interface (ffi) extension in PHP 5.0.5 does not follow safe_mode restrictions, which allows context-dependent attackers to execute arbitrary code by loading an arbitrary DLL and calling a function, as demonstrated by kernel32.dll and the WinExec function.  NOTE: this issue does not cross privilege boundaries in most contexts, so perhaps it should not be included in CVE. \n Publish Date : 2007-08-24 Last Update Date : 2008-09-05",
+            "threat": 4.3,
+            "summary": "The Foreign Function Interface (ffi) extension in PHP 5.0.5 does not follow safe_mode restrictions, which allows context-dependent attackers to execute arbitrary code by loading an arbitrary DLL and calling a function, as demonstrated by kernel32.dll and the WinExec function.  NOTE: this issue does not cross privilege boundaries in most contexts, so perhaps it should not be included in CVE.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-08-25T00:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6"
@@ -2174,9 +2516,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4586",
-            "summary": "Multiple buffer overflows in php_iisfunc.dll in the iisfunc extension for PHP 5.2.0 and earlier allow context-dependent attackers to execute arbitrary code, probably during Unicode conversion, as demonstrated by a long string in the first argument to the iis_getservicestate function, related to the ServiceId argument to the (1) fnStartService, (2) fnGetServiceState, (3) fnStopService, and possibly other functions. \n Publish Date : 2007-08-28 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Multiple buffer overflows in php_iisfunc.dll in the iisfunc extension for PHP 5.2.0 and earlier allow context-dependent attackers to execute arbitrary code, probably during Unicode conversion, as demonstrated by a long string in the first argument to the iis_getservicestate function, related to the ServiceId argument to the (1) fnStartService, (2) fnGetServiceState, (3) fnStopService, and possibly other functions.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-08-29T01:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.1"
@@ -2184,9 +2528,11 @@
             }
         },
         {
-            "threat": "4.4",
             "cveid": "CVE-2007-4652",
-            "summary": "The session extension in PHP before 5.2.4 might allow local users to bypass open_basedir restrictions via a session file that is a symlink. \n Publish Date : 2007-09-04 Last Update Date : 2011-08-23",
+            "threat": 4.4,
+            "summary": "The session extension in PHP before 5.2.4 might allow local users to bypass open_basedir restrictions via a session file that is a symlink.",
+            "lastModifiedDate": "2017-07-29T01:33:00+0000",
+            "publishedDate": "2007-09-04T19:17:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2201,9 +2547,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4657",
-            "summary": "Multiple integer overflows in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to obtain sensitive information (memory contents) or cause a denial of service (thread crash) via a large len value to the (1) strspn or (2) strcspn function, which triggers an out-of-bounds read.  NOTE: this affects different product versions than CVE-2007-3996. \n Publish Date : 2007-09-04 Last Update Date : 2009-09-16",
+            "threat": 7.5,
+            "summary": "Multiple integer overflows in PHP 4 before 4.4.8, and PHP 5 before 5.2.4, allow remote attackers to obtain sensitive information (memory contents) or cause a denial of service (thread crash) via a large len value to the (1) strspn or (2) strcspn function, which triggers an out-of-bounds read.  NOTE: this affects different product versions than CVE-2007-3996.",
+            "lastModifiedDate": "2018-10-26T14:05:00+0000",
+            "publishedDate": "2007-09-04T22:17:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2212,9 +2560,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4658",
-            "summary": "The money_format function in PHP 5 before 5.2.4, and PHP 4 before 4.4.8, permits multiple (1) %i and (2) %n tokens, which has unknown impact and attack vectors, possibly related to a format string vulnerability. \n Publish Date : 2007-09-04 Last Update Date : 2011-06-20",
+            "threat": 7.5,
+            "summary": "The money_format function in PHP 5 before 5.2.4, and PHP 4 before 4.4.8, permits multiple (1) %i and (2) %n tokens, which has unknown impact and attack vectors, possibly related to a format string vulnerability.",
+            "lastModifiedDate": "2018-10-03T21:48:00+0000",
+            "publishedDate": "2007-09-04T22:17:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2229,9 +2579,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4659",
-            "summary": "The zend_alter_ini_entry function in PHP before 5.2.4 does not properly handle an interruption to the flow of execution triggered by a memory_limit violation, which has unknown impact and attack vectors. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "The zend_alter_ini_entry function in PHP before 5.2.4 does not properly handle an interruption to the flow of execution triggered by a memory_limit violation, which has unknown impact and attack vectors.",
+            "lastModifiedDate": "2017-07-29T01:33:00+0000",
+            "publishedDate": "2007-09-04T22:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2239,9 +2591,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4660",
-            "summary": "Unspecified vulnerability in the chunk_split function in PHP before 5.2.4 has unknown impact and attack vectors, related to an incorrect size calculation. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-10",
+            "threat": 7.5,
+            "summary": "Unspecified vulnerability in the chunk_split function in PHP before 5.2.4 has unknown impact and attack vectors, related to an incorrect size calculation.",
+            "lastModifiedDate": "2018-10-03T21:48:00+0000",
+            "publishedDate": "2007-09-04T22:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2249,9 +2603,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4661",
-            "summary": "The chunk_split function in string.c in PHP 5.2.3 does not properly calculate the needed buffer size due to precision loss when performing integer arithmetic with floating point numbers, which has unknown attack vectors and impact, possibly resulting in a heap-based buffer overflow.  NOTE: this is due to an incomplete fix for CVE-2007-2872. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "The chunk_split function in string.c in PHP 5.2.3 does not properly calculate the needed buffer size due to precision loss when performing integer arithmetic with floating point numbers, which has unknown attack vectors and impact, possibly resulting in a heap-based buffer overflow.  NOTE: this is due to an incomplete fix for CVE-2007-2872.",
+            "lastModifiedDate": "2018-10-03T21:48:00+0000",
+            "publishedDate": "2007-09-04T22:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2259,9 +2615,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4662",
-            "summary": "Buffer overflow in the php_openssl_make_REQ function in PHP before 5.2.4 has unknown impact and attack vectors. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the php_openssl_make_REQ function in PHP before 5.2.4 has unknown impact and attack vectors.",
+            "lastModifiedDate": "2018-10-03T21:48:00+0000",
+            "publishedDate": "2007-09-04T22:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2269,9 +2627,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4663",
-            "summary": "Directory traversal vulnerability in PHP before 5.2.4 allows attackers to bypass open_basedir restrictions via unspecified vectors involving the glob function. \n Publish Date : 2007-09-04 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "Directory traversal vulnerability in PHP before 5.2.4 allows attackers to bypass open_basedir restrictions via unspecified vectors involving the glob function.",
+            "lastModifiedDate": "2017-07-29T01:33:00+0000",
+            "publishedDate": "2007-09-04T22:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2279,9 +2639,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-4670",
-            "summary": "Unspecified vulnerability in PHP before 5.2.4 has unknown impact and attack vectors, related to an \"Improved fix for MOPB-03-2007,\" probably a variant of CVE-2007-1285. \n Publish Date : 2007-09-04 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "Unspecified vulnerability in PHP before 5.2.4 has unknown impact and attack vectors, related to an \"Improved fix for MOPB-03-2007,\" probably a variant of CVE-2007-1285.",
+            "lastModifiedDate": "2018-10-03T21:48:00+0000",
+            "publishedDate": "2007-09-05T00:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2289,9 +2651,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-4782",
-            "summary": "PHP before 5.2.3 allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the pattern parameter to the glob function; or (2) a long string in the string parameter to the fnmatch function, accompanied by a pattern parameter value with undefined characteristics, as demonstrated by a \"*[1]e\" value.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \n Publish Date : 2007-09-10 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "PHP before 5.2.3 allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the pattern parameter to the glob function; or (2) a long string in the string parameter to the fnmatch function, accompanied by a pattern parameter value with undefined characteristics, as demonstrated by a \"*[1]e\" value.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2007-09-10T21:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2299,9 +2663,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-4783",
-            "summary": "The iconv_substr function in PHP 5.2.4 and earlier allows context-dependent attackers to cause (1) a denial of service (application crash) via a long string in the charset parameter, probably also requiring a long string in the str parameter; or (2) a denial of service (temporary application hang) via a long string in the str parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \n Publish Date : 2007-09-10 Last Update Date : 2009-02-05",
+            "threat": 5,
+            "summary": "The iconv_substr function in PHP 5.2.4 and earlier allows context-dependent attackers to cause (1) a denial of service (application crash) via a long string in the charset parameter, probably also requiring a long string in the str parameter; or (2) a denial of service (temporary application hang) via a long string in the str parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2007-09-10T21:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2309,9 +2675,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-4784",
-            "summary": "The setlocale function in PHP before 5.2.4 allows context-dependent attackers to cause a denial of service (application crash) via a long string in the locale parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution. \n Publish Date : 2007-09-10 Last Update Date : 2009-02-05",
+            "threat": 5,
+            "summary": "The setlocale function in PHP before 5.2.4 allows context-dependent attackers to cause a denial of service (application crash) via a long string in the locale parameter.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2007-09-10T21:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2319,9 +2687,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-4825",
-            "summary": "Directory traversal vulnerability in PHP 5.2.4 and earlier allows attackers to bypass open_basedir restrictions and possibly execute arbitrary code via a .. (dot dot) in the dl function. \n Publish Date : 2007-09-11 Last Update Date : 2009-02-05",
+            "threat": 7.5,
+            "summary": "Directory traversal vulnerability in PHP 5.2.4 and earlier allows attackers to bypass open_basedir restrictions and possibly execute arbitrary code via a .. (dot dot) in the dl function.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2007-09-12T01:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.4"
@@ -2329,9 +2699,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-4840",
-            "summary": "PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the out_charset parameter to the iconv function; or a long string in the charset parameter to the (2) iconv_mime_decode_headers, (3) iconv_mime_decode, or (4) iconv_strlen function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution. \n Publish Date : 2007-09-12 Last Update Date : 2009-02-05",
+            "threat": 5,
+            "summary": "PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via (1) a long string in the out_charset parameter to the iconv function; or a long string in the charset parameter to the (2) iconv_mime_decode_headers, (3) iconv_mime_decode, or (4) iconv_strlen function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless these issues can be demonstrated for code execution.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2007-09-12T20:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2339,9 +2711,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-4850",
-            "summary": "curl\/interface.c in the cURL library (aka libcurl) in PHP 5.2.4 and 5.2.5 allows context-dependent attackers to bypass safe_mode and open_basedir restrictions and read arbitrary files via a file:\/\/ request containing a \\x00 sequence, a different vulnerability than CVE-2006-2563. \n Publish Date : 2008-01-24 Last Update Date : 2009-04-08",
+            "threat": 5,
+            "summary": "curl\/interface.c in the cURL library (aka libcurl) in PHP 5.2.4 and 5.2.5 allows context-dependent attackers to bypass safe_mode and open_basedir restrictions and read arbitrary files via a file:\/\/ request containing a \\x00 sequence, a different vulnerability than CVE-2006-2563.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2008-01-25T01:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -2349,9 +2723,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-4887",
-            "summary": "The dl function in PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in the library parameter.  NOTE: there are limited usage scenarios under which this would be a vulnerability. \n Publish Date : 2007-09-13 Last Update Date : 2009-03-04",
+            "threat": 4.3,
+            "summary": "The dl function in PHP 5.2.4 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in the library parameter.  NOTE: there are limited usage scenarios under which this would be a vulnerability.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2007-09-14T00:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2359,9 +2735,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2007-4889",
-            "summary": "The MySQL extension in PHP 5.2.4 and earlier allows remote attackers to bypass safe_mode and open_basedir restrictions via the MySQL (1) LOAD_FILE, (2) INTO DUMPFILE, and (3) INTO OUTFILE functions, a different issue than CVE-2007-3997. \n Publish Date : 2007-09-13 Last Update Date : 2008-09-05",
+            "threat": 6.8,
+            "summary": "The MySQL extension in PHP 5.2.4 and earlier allows remote attackers to bypass safe_mode and open_basedir restrictions via the MySQL (1) LOAD_FILE, (2) INTO DUMPFILE, and (3) INTO OUTFILE functions, a different issue than CVE-2007-3997.",
+            "lastModifiedDate": "2018-10-15T21:38:00+0000",
+            "publishedDate": "2007-09-14T01:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2369,9 +2747,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2007-5128",
-            "summary": "SimpNews 2.41.03 on Windows, when PHP before 5.0.0 is used, allows remote attackers to obtain sensitive information via an certain link_date parameter to events.php, which reveals the path in an error message due to an unsupported argument type for the mktime function on Windows. \n Publish Date : 2007-09-27 Last Update Date : 2008-09-05",
+            "threat": 5,
+            "summary": "SimpNews 2.41.03 on Windows, when PHP before 5.0.0 is used, allows remote attackers to obtain sensitive information via an certain link_date parameter to events.php, which reveals the path in an error message due to an unsupported argument type for the mktime function on Windows.",
+            "lastModifiedDate": "2018-10-15T21:40:00+0000",
+            "publishedDate": "2007-09-27T19:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.1"
@@ -2379,9 +2759,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2007-5424",
-            "summary": "The disable_functions feature in PHP 4 and 5 allows attackers to bypass intended restrictions by using an alias, as demonstrated by using ini_alter when ini_set is disabled. \n Publish Date : 2007-10-12 Last Update Date : 2008-09-05",
+            "threat": 7.5,
+            "summary": "The disable_functions feature in PHP 4 and 5 allows attackers to bypass intended restrictions by using an alias, as demonstrated by using ini_alter when ini_set is disabled.",
+            "lastModifiedDate": "2018-10-15T21:44:00+0000",
+            "publishedDate": "2007-10-12T23:17:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -2390,9 +2772,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-5447",
-            "summary": "ioncube_loader_win_5.2.dll in the ionCube Loader 6.5 extension for PHP 5.2.4 does not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by reading arbitrary files via the ioncube_read_file function. \n Publish Date : 2007-10-14 Last Update Date : 2008-11-15",
+            "threat": 4.3,
+            "summary": "ioncube_loader_win_5.2.dll in the ionCube Loader 6.5 extension for PHP 5.2.4 does not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by reading arbitrary files via the ioncube_read_file function.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-10-14T18:17:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2400,9 +2784,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2007-5653",
-            "summary": "The Component Object Model (COM) functions in PHP 5.x on Windows do not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by executing objects with the kill bit set in the corresponding ActiveX control Compatibility Flags, executing programs via a function in compatUI.dll, invoking wscript.shell via wscript.exe, invoking Scripting.FileSystemObject via wshom.ocx, and adding users via a function in shgina.dll, related to the com_load_typelib function. \n Publish Date : 2007-10-23 Last Update Date : 2008-09-05",
+            "threat": 9.3,
+            "summary": "The Component Object Model (COM) functions in PHP 5.x on Windows do not follow safe_mode and disable_functions restrictions, which allows context-dependent attackers to bypass intended limitations, as demonstrated by executing objects with the kill bit set in the corresponding ActiveX control Compatibility Flags, executing programs via a function in compatUI.dll, invoking wscript.shell via wscript.exe, invoking Scripting.FileSystemObject via wshom.ocx, and adding users via a function in shgina.dll, related to the com_load_typelib function.",
+            "lastModifiedDate": "2017-09-29T01:29:00+0000",
+            "publishedDate": "2007-10-23T21:47:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2410,9 +2796,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2007-5898",
-            "summary": "The (1) htmlentities and (2) htmlspecialchars functions in PHP before 5.2.5 accept partial multibyte sequences, which has unknown impact and attack vectors, a different issue than CVE-2006-5465. \n Publish Date : 2007-11-20 Last Update Date : 2010-08-21",
+            "threat": 6.4,
+            "summary": "The (1) htmlentities and (2) htmlspecialchars functions in PHP before 5.2.5 accept partial multibyte sequences, which has unknown impact and attack vectors, a different issue than CVE-2006-5465.",
+            "lastModifiedDate": "2018-10-15T21:46:00+0000",
+            "publishedDate": "2007-11-20T18:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2420,9 +2808,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2007-5899",
-            "summary": "The output_add_rewrite_var function in PHP before 5.2.5 rewrites local forms in which the ACTION attribute references a non-local URL, which allows remote attackers to obtain potentially sensitive information by reading the requests for this URL, as demonstrated by a rewritten form containing a local session ID. \n Publish Date : 2007-11-20 Last Update Date : 2010-08-21",
+            "threat": 4.3,
+            "summary": "The output_add_rewrite_var function in PHP before 5.2.5 rewrites local forms in which the ACTION attribute references a non-local URL, which allows remote attackers to obtain potentially sensitive information by reading the requests for this URL, as demonstrated by a rewritten form containing a local session ID.",
+            "lastModifiedDate": "2018-10-15T21:46:00+0000",
+            "publishedDate": "2007-11-20T19:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2430,9 +2820,11 @@
             }
         },
         {
-            "threat": "6.9",
             "cveid": "CVE-2007-5900",
-            "summary": "PHP before 5.2.5 allows local users to bypass protection mechanisms configured through php_admin_value or php_admin_flag in httpd.conf by using ini_set to modify arbitrary configuration variables, a different issue than CVE-2006-4625. \n Publish Date : 2007-11-20 Last Update Date : 2009-02-05",
+            "threat": 6.9,
+            "summary": "PHP before 5.2.5 allows local users to bypass protection mechanisms configured through php_admin_value or php_admin_flag in httpd.conf by using ini_set to modify arbitrary configuration variables, a different issue than CVE-2006-4625.",
+            "lastModifiedDate": "2018-10-15T21:47:00+0000",
+            "publishedDate": "2007-11-20T18:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2440,9 +2832,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2007-6039",
-            "summary": "PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in (1) the domain parameter to the dgettext function, the message parameter to the (2) dcgettext or (3) gettext function, the msgid1 parameter to the (4) dngettext or (5) ngettext function, or (6) the classname parameter to the stream_wrapper_register function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution. \n Publish Date : 2007-11-20 Last Update Date : 2008-09-05",
+            "threat": 2.1,
+            "summary": "PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service (application crash) via a long string in (1) the domain parameter to the dgettext function, the message parameter to the (2) dcgettext or (3) gettext function, the msgid1 parameter to the (4) dngettext or (5) ngettext function, or (6) the classname parameter to the stream_wrapper_register function.  NOTE: this might not be a vulnerability in most web server environments that support multiple threads, unless this issue can be demonstrated for code execution.",
+            "lastModifiedDate": "2018-10-15T21:49:00+0000",
+            "publishedDate": "2007-11-20T19:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.5"
@@ -2450,9 +2844,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-0145",
-            "summary": "Unspecified vulnerability in glob in PHP before 4.4.8, when open_basedir is enabled, has unknown impact and attack vectors.  NOTE: this issue reportedly exists because of a regression related to CVE-2007-4663. \n Publish Date : 2008-01-08 Last Update Date : 2009-09-16",
+            "threat": 7.5,
+            "summary": "Unspecified vulnerability in glob in PHP before 4.4.8, when open_basedir is enabled, has unknown impact and attack vectors.  NOTE: this issue reportedly exists because of a regression related to CVE-2007-4663.",
+            "lastModifiedDate": "2017-08-08T01:29:00+0000",
+            "publishedDate": "2008-01-08T19:46:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8"
@@ -2460,9 +2856,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2008-0599",
-            "summary": "The init_request_info function in sapi\/cgi\/cgi_main.c in PHP before 5.2.6 does not properly consider operator precedence when calculating the length of PATH_TRANSLATED, which might allow remote attackers to execute arbitrary code via a crafted URI. \n Publish Date : 2008-05-05 Last Update Date : 2012-10-30",
+            "threat": 10,
+            "summary": "The init_request_info function in sapi\/cgi\/cgi_main.c in PHP before 5.2.6 does not properly consider operator precedence when calculating the length of PATH_TRANSLATED, which might allow remote attackers to execute arbitrary code via a crafted URI.",
+            "lastModifiedDate": "2018-10-15T22:01:00+0000",
+            "publishedDate": "2008-05-05T17:20:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2472,9 +2870,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2008-1384",
-            "summary": "Integer overflow in PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service and possibly have unspecified other impact via a printf format parameter with a large width specifier, related to the php_sprintf_appendstring function in formatted_print.c and probably other functions for formatted strings (aka *printf functions). \n Publish Date : 2008-03-27 Last Update Date : 2012-10-30",
+            "threat": 5,
+            "summary": "Integer overflow in PHP 5.2.5 and earlier allows context-dependent attackers to cause a denial of service and possibly have unspecified other impact via a printf format parameter with a large width specifier, related to the php_sprintf_appendstring function in formatted_print.c and probably other functions for formatted strings (aka *printf functions).",
+            "lastModifiedDate": "2018-10-11T20:33:00+0000",
+            "publishedDate": "2008-03-27T17:44:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -2482,9 +2882,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2008-2050",
-            "summary": "Stack-based buffer overflow in the FastCGI SAPI (fastcgi.c) in PHP before 5.2.6 has unknown impact and attack vectors. \n Publish Date : 2008-05-05 Last Update Date : 2012-10-30",
+            "threat": 10,
+            "summary": "Stack-based buffer overflow in the FastCGI SAPI (fastcgi.c) in PHP before 5.2.6 has unknown impact and attack vectors.",
+            "lastModifiedDate": "2018-10-11T20:38:00+0000",
+            "publishedDate": "2008-05-05T17:20:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2494,9 +2896,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2008-2051",
-            "summary": "The escapeshellcmd API function in PHP before 5.2.6 has unknown impact and context-dependent attack vectors related to \"incomplete multibyte chars.\" \n Publish Date : 2008-05-05 Last Update Date : 2012-10-30",
+            "threat": 10,
+            "summary": "The escapeshellcmd API function in PHP before 5.2.6 has unknown impact and context-dependent attack vectors related to \"incomplete multibyte chars.\"",
+            "lastModifiedDate": "2018-10-11T20:38:00+0000",
+            "publishedDate": "2008-05-05T17:20:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2506,9 +2910,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-2107",
-            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 32-bit systems, performs a multiplication using values that can produce a zero seed in rare circumstances, which allows context-dependent attackers to predict subsequent values of the rand and mt_rand functions and possibly bypass protection mechanisms that rely on an unknown initial seed. \n Publish Date : 2008-05-07 Last Update Date : 2012-10-30",
+            "threat": 7.5,
+            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 32-bit systems, performs a multiplication using values that can produce a zero seed in rare circumstances, which allows context-dependent attackers to predict subsequent values of the rand and mt_rand functions and possibly bypass protection mechanisms that rely on an unknown initial seed.",
+            "lastModifiedDate": "2018-10-11T20:39:00+0000",
+            "publishedDate": "2008-05-07T21:20:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2519,9 +2925,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-2108",
-            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 64-bit systems, performs a multiplication that generates a portion of zero bits during conversion due to insufficient precision, which produces 24 bits of entropy and simplifies brute force attacks against protection mechanisms that use the rand and mt_rand functions. \n Publish Date : 2008-05-07 Last Update Date : 2012-10-30",
+            "threat": 7.5,
+            "summary": "The GENERATE_SEED macro in PHP 4.x before 4.4.8 and 5.x before 5.2.5, when running on 64-bit systems, performs a multiplication that generates a portion of zero bits during conversion due to insufficient precision, which produces 24 bits of entropy and simplifies brute force attacks against protection mechanisms that use the rand and mt_rand functions.",
+            "lastModifiedDate": "2018-10-11T20:39:00+0000",
+            "publishedDate": "2008-05-07T21:20:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.8",
@@ -2532,9 +2940,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-2371",
+            "threat": 7.5,
             "summary": "Heap-based buffer overflow in pcre_compile.c in the Perl-Compatible Regular Expression (PCRE) library 7.7 allows context-dependent attackers to cause a denial of service (crash) or possibly execute arbitrary code via a regular expression that begins with an option and contains multiple branches.",
+            "lastModifiedDate": "2018-10-11T20:41:00+0000",
+            "publishedDate": "2008-07-07T23:41:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.7"
@@ -2542,9 +2952,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2008-2665",
-            "summary": "Directory traversal vulnerability in the posix_access function in PHP 5.2.6 and earlier allows remote attackers to bypass safe_mode restrictions via a .. (dot dot) in an http URL, which results in the URL being canonicalized to a local filename after the safe_mode check has successfully run. \n Publish Date : 2008-06-19 Last Update Date : 2012-10-30",
+            "threat": 5,
+            "summary": "Directory traversal vulnerability in the posix_access function in PHP 5.2.6 and earlier allows remote attackers to bypass safe_mode restrictions via a .. (dot dot) in an http URL, which results in the URL being canonicalized to a local filename after the safe_mode check has successfully run.",
+            "lastModifiedDate": "2018-10-11T20:42:00+0000",
+            "publishedDate": "2008-06-20T01:41:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.7"
@@ -2552,9 +2964,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2008-2666",
-            "summary": "Multiple directory traversal vulnerabilities in PHP 5.2.6 and earlier allow context-dependent attackers to bypass safe_mode restrictions by creating a subdirectory named http: and then placing ..\/ (dot dot slash) sequences in an http URL argument to the (1) chdir or (2) ftok function. \n Publish Date : 2008-06-19 Last Update Date : 2012-10-30",
+            "threat": 5,
+            "summary": "Multiple directory traversal vulnerabilities in PHP 5.2.6 and earlier allow context-dependent attackers to bypass safe_mode restrictions by creating a subdirectory named http: and then placing ..\/ (dot dot slash) sequences in an http URL argument to the (1) chdir or (2) ftok function.",
+            "lastModifiedDate": "2018-10-11T20:42:00+0000",
+            "publishedDate": "2008-06-20T01:41:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2564,9 +2978,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2008-2829",
-            "summary": "php_imap.c in PHP 5.2.5, 5.2.6, 4.x, and other versions, uses obsolete API calls that allow context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long IMAP request, which triggers an \"rfc822.c legacy routine buffer overflow\" error message, related to the rfc822_write_address function. \n Publish Date : 2008-06-23 Last Update Date : 2012-10-30",
+            "threat": 5,
+            "summary": "php_imap.c in PHP 5.2.5, 5.2.6, 4.x, and other versions, uses obsolete API calls that allow context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long IMAP request, which triggers an \"rfc822.c legacy routine buffer overflow\" error message, related to the rfc822_write_address function.",
+            "lastModifiedDate": "2019-10-09T22:55:00+0000",
+            "publishedDate": "2008-06-23T20:41:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.1",
@@ -2575,9 +2991,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-3658",
-            "summary": "Buffer overflow in the imageloadfont function in ext\/gd\/gd.c in PHP 4.4.x before 4.4.9 and PHP 5.2 before 5.2.6-r6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted font file. \n Publish Date : 2008-08-14 Last Update Date : 2013-08-01",
+            "threat": 7.5,
+            "summary": "Buffer overflow in the imageloadfont function in ext\/gd\/gd.c in PHP 4.4.x before 4.4.9 and PHP 5.2 before 5.2.6-r6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted font file.",
+            "lastModifiedDate": "2018-10-11T20:49:00+0000",
+            "publishedDate": "2008-08-15T00:41:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -2586,9 +3004,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2008-3659",
-            "summary": "Buffer overflow in the memnstr function in PHP 4.4.x before 4.4.9 and PHP 5.6 through 5.2.6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via the delimiter argument to the explode function.  NOTE: the scope of this issue is limited since most applications would not use an attacker-controlled delimiter, but local attacks against safe_mode are feasible. \n Publish Date : 2008-08-14 Last Update Date : 2012-10-30",
+            "threat": 6.4,
+            "summary": "Buffer overflow in the memnstr function in PHP 4.4.x before 4.4.9 and PHP 5.6 through 5.2.6 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via the delimiter argument to the explode function.  NOTE: the scope of this issue is limited since most applications would not use an attacker-controlled delimiter, but local attacks against safe_mode are feasible.",
+            "lastModifiedDate": "2018-10-11T20:49:00+0000",
+            "publishedDate": "2008-08-15T00:41:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -2597,9 +3017,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2008-3660",
-            "summary": "PHP 4.4.x before 4.4.9, and 5.x through 5.2.6, when used as a FastCGI module, allows remote attackers to cause a denial of service (crash) via a request with multiple dots preceding the extension, as demonstrated using foo..php. \n Publish Date : 2008-08-14 Last Update Date : 2012-10-30",
+            "threat": 5,
+            "summary": "PHP 4.4.x before 4.4.9, and 5.x through 5.2.6, when used as a FastCGI module, allows remote attackers to cause a denial of service (crash) via a request with multiple dots preceding the extension, as demonstrated using foo..php.",
+            "lastModifiedDate": "2018-10-11T20:49:00+0000",
+            "publishedDate": "2008-08-15T00:41:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.9",
@@ -2608,9 +3030,11 @@
             }
         },
         {
-            "threat": "5.1",
             "cveid": "CVE-2008-4107",
-            "summary": "The (1) rand and (2) mt_rand functions in PHP 5.2.6 do not produce cryptographically strong random numbers, which allows attackers to leverage exposures in products that rely on these functions for security-relevant functionality, as demonstrated by the password-reset functionality in Joomla! 1.5.x and WordPress before 2.6.2, a different vulnerability than CVE-2008-2107, CVE-2008-2108, and CVE-2008-4102. \n Publish Date : 2008-09-18 Last Update Date : 2012-10-29",
+            "threat": 5.1,
+            "summary": "The (1) rand and (2) mt_rand functions in PHP 5.2.6 do not produce cryptographically strong random numbers, which allows attackers to leverage exposures in products that rely on these functions for security-relevant functionality, as demonstrated by the password-reset functionality in Joomla! 1.5.x and WordPress before 2.6.2, a different vulnerability than CVE-2008-2107, CVE-2008-2108, and CVE-2008-4102.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2008-09-18T17:59:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2625,9 +3049,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2008-5498",
-            "summary": "Array index error in the imageRotate function in PHP 5.2.8 and earlier allows context-dependent attackers to read the contents of arbitrary memory locations via a crafted value of the third argument (aka the bgd_color or clrBack argument) for an indexed image. \n Publish Date : 2008-12-26 Last Update Date : 2010-08-21",
+            "threat": 5,
+            "summary": "Array index error in the imageRotate function in PHP 5.2.8 and earlier allows context-dependent attackers to read the contents of arbitrary memory locations via a crafted value of the third argument (aka the bgd_color or clrBack argument) for an indexed image.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2008-12-26T20:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2637,9 +3063,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2008-5557",
-            "summary": "Heap-based buffer overflow in ext\/mbstring\/libmbfl\/filters\/mbfilter_htmlent.c in the mbstring extension in PHP 4.3.0 through 5.2.6 allows context-dependent attackers to execute arbitrary code via a crafted string containing an HTML entity, which is not properly handled during Unicode conversion, related to the (1) mb_convert_encoding, (2) mb_check_encoding, (3) mb_convert_variables, and (4) mb_parse_str functions. \n Publish Date : 2008-12-23 Last Update Date : 2010-08-21",
+            "threat": 10,
+            "summary": "Heap-based buffer overflow in ext\/mbstring\/libmbfl\/filters\/mbfilter_htmlent.c in the mbstring extension in PHP 4.3.0 through 5.2.6 allows context-dependent attackers to execute arbitrary code via a crafted string containing an HTML entity, which is not properly handled during Unicode conversion, related to the (1) mb_convert_encoding, (2) mb_check_encoding, (3) mb_convert_variables, and (4) mb_parse_str functions.",
+            "lastModifiedDate": "2018-10-11T20:56:00+0000",
+            "publishedDate": "2008-12-23T18:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.3.12",
@@ -2651,9 +3079,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-5624",
-            "summary": "PHP 5 before 5.2.7 does not properly initialize the page_uid and page_gid global variables for use by the SAPI php_getuid function, which allows context-dependent attackers to bypass safe_mode restrictions via variable settings that are intended to be restricted to root, as demonstrated by a setting of \/etc for the error_log variable. \n Publish Date : 2008-12-17 Last Update Date : 2009-10-31",
+            "threat": 7.5,
+            "summary": "PHP 5 before 5.2.7 does not properly initialize the page_uid and page_gid global variables for use by the SAPI php_getuid function, which allows context-dependent attackers to bypass safe_mode restrictions via variable settings that are intended to be restricted to root, as demonstrated by a setting of \/etc for the error_log variable.",
+            "lastModifiedDate": "2018-10-11T20:56:00+0000",
+            "publishedDate": "2008-12-17T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2663,9 +3093,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-5625",
-            "summary": "PHP 5 before 5.2.7 does not enforce the error_log safe_mode restrictions when safe_mode is enabled through a php_admin_flag setting in httpd.conf, which allows context-dependent attackers to write to arbitrary files by placing a \"php_value error_log\" entry in a .htaccess file. \n Publish Date : 2008-12-17 Last Update Date : 2009-10-31",
+            "threat": 7.5,
+            "summary": "PHP 5 before 5.2.7 does not enforce the error_log safe_mode restrictions when safe_mode is enabled through a php_admin_flag setting in httpd.conf, which allows context-dependent attackers to write to arbitrary files by placing a \"php_value error_log\" entry in a .htaccess file.",
+            "lastModifiedDate": "2018-10-11T20:56:00+0000",
+            "publishedDate": "2008-12-17T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2675,9 +3107,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-5658",
-            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in PHP 5.2.6 and earlier allows context-dependent attackers to write arbitrary files via a ZIP file with a file whose name contains .. (dot dot) sequences. \n Publish Date : 2008-12-17 Last Update Date : 2009-10-31",
+            "threat": 7.5,
+            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in PHP 5.2.6 and earlier allows context-dependent attackers to write arbitrary files via a ZIP file with a file whose name contains .. (dot dot) sequences.",
+            "lastModifiedDate": "2018-10-11T20:56:00+0000",
+            "publishedDate": "2008-12-17T20:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2687,9 +3121,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2008-5814",
-            "summary": "Cross-site scripting (XSS) vulnerability in PHP, possibly 5.2.7 and earlier, when display_errors is enabled, allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.  NOTE: because of the lack of details, it is unclear whether this is related to CVE-2006-0208. \n Publish Date : 2009-01-02 Last Update Date : 2010-08-21",
+            "threat": 2.6,
+            "summary": "Cross-site scripting (XSS) vulnerability in PHP, possibly 5.2.7 and earlier, when display_errors is enabled, allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.  NOTE: because of the lack of details, it is unclear whether this is related to CVE-2006-0208.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-01-02T18:11:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2704,9 +3140,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2008-5844",
-            "summary": "PHP 5.2.7 contains an incorrect change to the FILTER_UNSAFE_RAW functionality, and unintentionally disables magic_quotes_gpc regardless of the actual magic_quotes_gpc setting, which might make it easier for context-dependent attackers to conduct SQL injection attacks and unspecified other attacks. \n Publish Date : 2009-01-05 Last Update Date : 2009-05-14",
+            "threat": 7.5,
+            "summary": "PHP 5.2.7 contains an incorrect change to the FILTER_UNSAFE_RAW functionality, and unintentionally disables magic_quotes_gpc regardless of the actual magic_quotes_gpc setting, which might make it easier for context-dependent attackers to conduct SQL injection attacks and unspecified other attacks.",
+            "lastModifiedDate": "2009-05-14T05:32:00+0000",
+            "publishedDate": "2009-01-05T20:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.8"
@@ -2714,9 +3152,11 @@
             }
         },
         {
-            "threat": "7.2",
             "cveid": "CVE-2008-7002",
-            "summary": "PHP 5.2.5 does not enforce (a) open_basedir and (b) safe_mode_exec_dir restrictions for certain functions, which might allow local users to bypass intended access restrictions and call programs outside of the intended directory via the (1) exec, (2) system, (3) shell_exec, (4) passthru, or (5) popen functions, possibly involving pathnames such as \"C:\" drive notation. \n Publish Date : 2009-08-19 Last Update Date : 2009-08-19",
+            "threat": 7.2,
+            "summary": "PHP 5.2.5 does not enforce (a) open_basedir and (b) safe_mode_exec_dir restrictions for certain functions, which might allow local users to bypass intended access restrictions and call programs outside of the intended directory via the (1) exec, (2) system, (3) shell_exec, (4) passthru, or (5) popen functions, possibly involving pathnames such as \"C:\" drive notation.",
+            "lastModifiedDate": "2009-08-19T05:24:00+0000",
+            "publishedDate": "2009-08-19T05:24:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.6"
@@ -2724,9 +3164,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2008-7068",
-            "summary": "The dba_replace function in PHP 5.2.6 and 4.x allows context-dependent attackers to cause a denial of service (file truncation) via a key with the NULL byte.  NOTE: this might only be a vulnerability in limited circumstances in which the attacker can modify or add database entries but does not have permissions to truncate the file. \n Publish Date : 2009-08-25 Last Update Date : 2009-08-25",
+            "threat": 6.4,
+            "summary": "The dba_replace function in PHP 5.2.6 and 4.x allows context-dependent attackers to cause a denial of service (file truncation) via a key with the NULL byte.  NOTE: this might only be a vulnerability in limited circumstances in which the attacker can modify or add database entries but does not have permissions to truncate the file.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-08-25T10:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2739,9 +3181,11 @@
             }
         },
         {
-            "threat": "2.1",
             "cveid": "CVE-2009-0754",
-            "summary": "PHP 4.4.4, 5.1.6, and other versions, when running on Apache, allows local users to modify behavior of other sites hosted on the same web server by modifying the mbstring.func_overload setting within .htaccess, which causes this setting to be applied to other virtual hosts on the same server. \n Publish Date : 2009-03-03 Last Update Date : 2010-08-21",
+            "threat": 2.1,
+            "summary": "PHP 4.4.4, 5.1.6, and other versions, when running on Apache, allows local users to modify behavior of other sites hosted on the same web server by modifying the mbstring.func_overload setting within .htaccess, which causes this setting to be applied to other virtual hosts on the same server.",
+            "lastModifiedDate": "2018-10-03T21:58:00+0000",
+            "publishedDate": "2009-03-03T16:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.4.5",
@@ -2750,9 +3194,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2009-1271",
-            "summary": "The JSON_parser function (ext\/json\/JSON_parser.c) in PHP 5.2.x before 5.2.9 allows remote attackers to cause a denial of service (segmentation fault) via a malformed string to the json_decode API function. \n Publish Date : 2009-04-08 Last Update Date : 2009-09-16",
+            "threat": 5,
+            "summary": "The JSON_parser function (ext\/json\/JSON_parser.c) in PHP 5.2.x before 5.2.9 allows remote attackers to cause a denial of service (segmentation fault) via a malformed string to the json_decode API function.",
+            "lastModifiedDate": "2018-10-03T21:59:00+0000",
+            "publishedDate": "2009-04-08T18:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.9"
@@ -2760,9 +3206,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2009-1272",
-            "summary": "The php_zip_make_relative_path function in php_zip.c in PHP 5.2.x before 5.2.9 allows context-dependent attackers to cause a denial of service (crash) via a ZIP file that contains filenames with relative paths, which is not properly handled during extraction. \n Publish Date : 2009-04-08 Last Update Date : 2009-09-16",
+            "threat": 5,
+            "summary": "The php_zip_make_relative_path function in php_zip.c in PHP 5.2.x before 5.2.9 allows context-dependent attackers to cause a denial of service (crash) via a ZIP file that contains filenames with relative paths, which is not properly handled during extraction.",
+            "lastModifiedDate": "2009-09-16T05:30:00+0000",
+            "publishedDate": "2009-04-08T18:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.9"
@@ -2770,9 +3218,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2009-2626",
-            "summary": "The zend_restore_ini_entry_cb function in zend_ini.c in PHP 5.3.0, 5.2.10, and earlier versions allows context-specific attackers to obtain sensitive information (memory contents) and cause a PHP crash by using the ini_set function to declare a variable, then using the ini_restore function to restore the variable. \n Publish Date : 2009-12-01 Last Update Date : 2009-12-19",
+            "threat": 6.4,
+            "summary": "The zend_restore_ini_entry_cb function in zend_ini.c in PHP 5.3.0, 5.2.10, and earlier versions allows context-specific attackers to obtain sensitive information (memory contents) and cause a PHP crash by using the ini_set function to declare a variable, then using the ini_restore function to restore the variable.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-12-01T16:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2788,9 +3238,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2009-2687",
-            "summary": "The exif_read_data function in the Exif module in PHP before 5.2.10 allows remote attackers to cause a denial of service (crash) via a malformed JPEG image with invalid offset fields, a different issue than CVE-2005-3353. \n Publish Date : 2009-08-05 Last Update Date : 2011-07-18",
+            "threat": 4.3,
+            "summary": "The exif_read_data function in the Exif module in PHP before 5.2.10 allows remote attackers to cause a denial of service (crash) via a malformed JPEG image with invalid offset fields, a different issue than CVE-2005-3353.",
+            "lastModifiedDate": "2018-10-03T22:01:00+0000",
+            "publishedDate": "2009-08-05T19:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.11"
@@ -2798,9 +3250,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2009-3291",
-            "summary": "The php_openssl_apply_verification_policy function in PHP before 5.2.11 does not properly perform certificate validation, which has unknown impact and attack vectors, probably related to an ability to spoof certificates. \n Publish Date : 2009-09-22 Last Update Date : 2011-09-06",
+            "threat": 7.5,
+            "summary": "The php_openssl_apply_verification_policy function in PHP before 5.2.11 does not properly perform certificate validation, which has unknown impact and attack vectors, probably related to an ability to spoof certificates.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-09-22T10:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2815,9 +3269,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2009-3292",
-            "summary": "Unspecified vulnerability in PHP before 5.2.11, and 5.3.x before 5.3.1, has unknown impact and attack vectors related to \"missing sanity checks around exif processing.\" \n Publish Date : 2009-09-22 Last Update Date : 2011-09-06",
+            "threat": 7.5,
+            "summary": "Unspecified vulnerability in PHP before 5.2.11, and 5.3.x before 5.3.1, has unknown impact and attack vectors related to \"missing sanity checks around exif processing.\"",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-09-22T10:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2832,9 +3288,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2009-3293",
-            "summary": "Unspecified vulnerability in the imagecolortransparent function in PHP before 5.2.11 has unknown impact and attack vectors related to an incorrect \"sanity check for the color index.\" \n Publish Date : 2009-09-22 Last Update Date : 2011-09-06",
+            "threat": 7.5,
+            "summary": "Unspecified vulnerability in the imagecolortransparent function in PHP before 5.2.11 has unknown impact and attack vectors related to an incorrect \"sanity check for the color index.\"",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-09-22T10:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2849,9 +3307,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2009-3294",
-            "summary": "The popen API function in TSRM\/tsrm_win32.c in PHP before 5.2.11 and 5.3.x before 5.3.1, when running on certain Windows operating systems, allows context-dependent attackers to cause a denial of service (crash) via a crafted (1) \"e\" or (2) \"er\" string in the second argument (aka mode), possibly related to the _fdopen function in the Microsoft C runtime library. NOTE: this might not cross privilege boundaries except in rare cases in which the mode argument is accessible to an attacker outside of an application that uses the popen function. \n Publish Date : 2009-09-22 Last Update Date : 2009-11-25",
+            "threat": 5,
+            "summary": "The popen API function in TSRM\/tsrm_win32.c in PHP before 5.2.11 and 5.3.x before 5.3.1, when running on certain Windows operating systems, allows context-dependent attackers to cause a denial of service (crash) via a crafted (1) \"e\" or (2) \"er\" string in the second argument (aka mode), possibly related to the _fdopen function in the Microsoft C runtime library. NOTE: this might not cross privilege boundaries except in rare cases in which the mode argument is accessible to an attacker outside of an application that uses the popen function.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-09-22T10:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2866,9 +3326,11 @@
             }
         },
         {
-            "threat": "9.3",
             "cveid": "CVE-2009-3546",
-            "summary": "The _gdGetColors function in gd_gd.c in PHP 5.2.11 and 5.3.x before 5.3.1, and the GD Graphics Library 2.x, does not properly verify a certain colorsTotal structure member, which might allow remote attackers to conduct buffer overflow or buffer over-read attacks via a crafted GD file, a different vulnerability than CVE-2009-3293. NOTE: some of these details are obtained from third party information. \n Publish Date : 2009-10-19 Last Update Date : 2011-08-25",
+            "threat": 9.3,
+            "summary": "The _gdGetColors function in gd_gd.c in PHP 5.2.11 and 5.3.x before 5.3.1, and the GD Graphics Library 2.x, does not properly verify a certain colorsTotal structure member, which might allow remote attackers to conduct buffer overflow or buffer over-read attacks via a crafted GD file, a different vulnerability than CVE-2009-3293. NOTE: some of these details are obtained from third party information.",
+            "lastModifiedDate": "2017-09-19T01:29:00+0000",
+            "publishedDate": "2009-10-19T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.12",
@@ -2877,9 +3339,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2009-3557",
-            "summary": "The tempnam function in ext\/standard\/file.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass safe_mode restrictions, and create files in group-writable or world-writable directories, via the dir and prefix arguments. \n Publish Date : 2009-11-23 Last Update Date : 2011-07-18",
+            "threat": 5,
+            "summary": "The tempnam function in ext\/standard\/file.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass safe_mode restrictions, and create files in group-writable or world-writable directories, via the dir and prefix arguments.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-11-23T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2895,9 +3359,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2009-3558",
-            "summary": "The posix_mkfifo function in ext\/posix\/posix.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass open_basedir restrictions, and create FIFO files, via the pathname and mode arguments, as demonstrated by creating a .htaccess file. \n Publish Date : 2009-11-23 Last Update Date : 2010-04-01",
+            "threat": 6.8,
+            "summary": "The posix_mkfifo function in ext\/posix\/posix.c in PHP before 5.2.12 and 5.3.x before 5.3.1 allows context-dependent attackers to bypass open_basedir restrictions, and create FIFO files, via the pathname and mode arguments, as demonstrated by creating a .htaccess file.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-11-23T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2913,9 +3379,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2009-3559",
-            "summary": "** DISPUTED **  main\/streams\/plain_wrapper.c in PHP 5.3.x before 5.3.1 does not recognize the safe_mode_include_dir directive, which allows context-dependent attackers to have an unknown impact by triggering the failure of PHP scripts that perform include or require operations, as demonstrated by a script that attempts to perform a require_once on a file in a standard library directory.  NOTE: a reliable third party reports that this is not a vulnerability, because it results in a more restrictive security policy. \n Publish Date : 2009-11-23 Last Update Date : 2010-04-01",
+            "threat": 7.5,
+            "summary": "** DISPUTED **  main\/streams\/plain_wrapper.c in PHP 5.3.x before 5.3.1 does not recognize the safe_mode_include_dir directive, which allows context-dependent attackers to have an unknown impact by triggering the failure of PHP scripts that perform include or require operations, as demonstrated by a script that attempts to perform a require_once on a file in a standard library directory.  NOTE: a reliable third party reports that this is not a vulnerability, because it results in a more restrictive security policy.",
+            "lastModifiedDate": "2010-04-01T05:37:00+0000",
+            "publishedDate": "2009-11-23T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.1"
@@ -2923,9 +3391,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2009-4017",
-            "summary": "PHP before 5.2.12 and 5.3.x before 5.3.1 does not restrict the number of temporary files created when handling a multipart\/form-data POST request, which allows remote attackers to cause a denial of service (resource exhaustion), and makes it easier for remote attackers to exploit local file inclusion vulnerabilities, via multiple requests, related to lack of support for the max_file_uploads directive. \n Publish Date : 2009-11-23 Last Update Date : 2011-07-18",
+            "threat": 5,
+            "summary": "PHP before 5.2.12 and 5.3.x before 5.3.1 does not restrict the number of temporary files created when handling a multipart\/form-data POST request, which allows remote attackers to cause a denial of service (resource exhaustion), and makes it easier for remote attackers to exploit local file inclusion vulnerabilities, via multiple requests, related to lack of support for the max_file_uploads directive.",
+            "lastModifiedDate": "2018-10-10T19:48:00+0000",
+            "publishedDate": "2009-11-24T00:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.12",
@@ -2934,9 +3404,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2009-4018",
-            "summary": "The proc_open function in ext\/standard\/proc_open.c in PHP before 5.2.11 and 5.3.x before 5.3.1 does not enforce the (1) safe_mode_allowed_env_vars and (2) safe_mode_protected_env_vars directives, which allows context-dependent attackers to execute programs with an arbitrary environment via the env parameter, as demonstrated by a crafted value of the LD_LIBRARY_PATH environment variable. \n Publish Date : 2009-11-29 Last Update Date : 2011-07-18",
+            "threat": 7.5,
+            "summary": "The proc_open function in ext\/standard\/proc_open.c in PHP before 5.2.11 and 5.3.x before 5.3.1 does not enforce the (1) safe_mode_allowed_env_vars and (2) safe_mode_protected_env_vars directives, which allows context-dependent attackers to execute programs with an arbitrary environment via the env parameter, as demonstrated by a crafted value of the LD_LIBRARY_PATH environment variable.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-11-29T13:07:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2952,9 +3424,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2009-4142",
-            "summary": "The htmlspecialchars function in PHP before 5.2.12 does not properly handle (1) overlong UTF-8 sequences, (2) invalid Shift_JIS sequences, and (3) invalid EUC-JP sequences, which allows remote attackers to conduct cross-site scripting (XSS) attacks by placing a crafted byte sequence before a special character. \n Publish Date : 2009-12-21 Last Update Date : 2011-07-18",
+            "threat": 4.3,
+            "summary": "The htmlspecialchars function in PHP before 5.2.12 does not properly handle (1) overlong UTF-8 sequences, (2) invalid Shift_JIS sequences, and (3) invalid EUC-JP sequences, which allows remote attackers to conduct cross-site scripting (XSS) attacks by placing a crafted byte sequence before a special character.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-12-21T16:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2969,9 +3443,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2009-4143",
-            "summary": "PHP before 5.2.12 does not properly handle session data, which has unspecified impact and attack vectors related to (1) interrupt corruption of the SESSION superglobal array and (2) the session.save_path directive. \n Publish Date : 2009-12-21 Last Update Date : 2011-07-18",
+            "threat": 10,
+            "summary": "PHP before 5.2.12 does not properly handle session data, which has unspecified impact and attack vectors related to (1) interrupt corruption of the SESSION superglobal array and (2) the session.save_path directive.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2009-12-21T16:30:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -2986,9 +3462,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2009-4418",
-            "summary": "The unserialize function in PHP 5.3.0 and earlier allows context-dependent attackers to cause a denial of service (resource consumption) via a deeply nested serialized variable, as demonstrated by a string beginning with a:1: followed by many {a:1: sequences. \n Publish Date : 2009-12-24 Last Update Date : 2009-12-28",
+            "threat": 5,
+            "summary": "The unserialize function in PHP 5.3.0 and earlier allows context-dependent attackers to cause a denial of service (resource consumption) via a deeply nested serialized variable, as demonstrated by a string beginning with a:1: followed by many {a:1: sequences.",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2009-12-24T17:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -2999,9 +3477,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2009-5016",
-            "summary": "Integer overflow in the xml_utf8_decode function in ext\/xml\/xml.c in PHP before 5.2.11 makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string that uses overlong UTF-8 encoding, a different vulnerability than CVE-2010-3870. \n Publish Date : 2010-11-12 Last Update Date : 2011-02-23",
+            "threat": 6.8,
+            "summary": "Integer overflow in the xml_utf8_decode function in ext\/xml\/xml.c in PHP before 5.2.11 makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string that uses overlong UTF-8 encoding, a different vulnerability than CVE-2010-3870.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2010-11-12T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3016,9 +3496,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-0397",
-            "summary": "The xmlrpc extension in PHP 5.3.1 does not properly handle a missing methodName element in the first argument to the xmlrpc_decode_request function, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) and possibly have unspecified other impact via a crafted argument. \n Publish Date : 2010-03-16 Last Update Date : 2010-12-10",
+            "threat": 5,
+            "summary": "The xmlrpc extension in PHP 5.3.1 does not properly handle a missing methodName element in the first argument to the xmlrpc_decode_request function, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) and possibly have unspecified other impact via a crafted argument.",
+            "lastModifiedDate": "2010-12-10T06:37:00+0000",
+            "publishedDate": "2010-03-16T19:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.2"
@@ -3026,9 +3508,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2010-1128",
-            "summary": "The Linear Congruential Generator (LCG) in PHP before 5.2.13 does not provide the expected entropy, which makes it easier for context-dependent attackers to guess values that were intended to be unpredictable, as demonstrated by session cookies generated by using the uniqid function. \n Publish Date : 2010-03-26 Last Update Date : 2010-12-10",
+            "threat": 6.4,
+            "summary": "The Linear Congruential Generator (LCG) in PHP before 5.2.13 does not provide the expected entropy, which makes it easier for context-dependent attackers to guess values that were intended to be unpredictable, as demonstrated by session cookies generated by using the uniqid function.",
+            "lastModifiedDate": "2010-12-10T06:39:00+0000",
+            "publishedDate": "2010-03-26T20:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.13"
@@ -3036,9 +3520,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2010-1129",
-            "summary": "The safe_mode implementation in PHP before 5.2.13 does not properly handle directory pathnames that lack a trailing \/ (slash) character, which allows context-dependent attackers to bypass intended access restrictions via vectors related to use of the tempnam function. \n Publish Date : 2010-03-26 Last Update Date : 2010-08-31",
+            "threat": 7.5,
+            "summary": "The safe_mode implementation in PHP before 5.2.13 does not properly handle directory pathnames that lack a trailing \/ (slash) character, which allows context-dependent attackers to bypass intended access restrictions via vectors related to use of the tempnam function.",
+            "lastModifiedDate": "2010-08-31T05:42:00+0000",
+            "publishedDate": "2010-03-26T20:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.13"
@@ -3046,9 +3532,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-1130",
-            "summary": "session.c in the session extension in PHP before 5.2.13, and 5.3.1, does not properly interpret ; (semicolon) characters in the argument to the session_save_path function, which allows context-dependent attackers to bypass open_basedir and safe_mode restrictions via an argument that contains multiple ; characters in conjunction with a .. (dot dot). \n Publish Date : 2010-03-26 Last Update Date : 2010-06-08",
+            "threat": 5,
+            "summary": "session.c in the session extension in PHP before 5.2.13, and 5.3.1, does not properly interpret ; (semicolon) characters in the argument to the session_save_path function, which allows context-dependent attackers to bypass open_basedir and safe_mode restrictions via an argument that contains multiple ; characters in conjunction with a .. (dot dot).",
+            "lastModifiedDate": "2018-10-30T16:25:00+0000",
+            "publishedDate": "2010-03-26T20:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3059,9 +3547,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-1860",
-            "summary": "The html_entity_decode function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal call, related to the call time pass by reference feature. \n Publish Date : 2010-05-07 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The html_entity_decode function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal call, related to the call time pass by reference feature.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-05-07T23:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3070,9 +3560,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2010-1861",
-            "summary": "The sysvshm extension for PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to write to arbitrary memory addresses by using an object's __sleep function to interrupt an internal call to the shm_put_var function, which triggers access of a freed resource. \n Publish Date : 2010-05-07 Last Update Date : 2010-05-10",
+            "threat": 6.4,
+            "summary": "The sysvshm extension for PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to write to arbitrary memory addresses by using an object's __sleep function to interrupt an internal call to the shm_put_var function, which triggers access of a freed resource.",
+            "lastModifiedDate": "2010-05-10T04:00:00+0000",
+            "publishedDate": "2010-05-07T23:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3081,9 +3573,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-1862",
-            "summary": "The chunk_split function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-07 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The chunk_split function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-05-07T23:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3092,9 +3586,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-1864",
-            "summary": "The addcslashes function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-07 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The addcslashes function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-05-07T23:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3103,9 +3599,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2010-1866",
-            "summary": "The dechunk filter in PHP 5.3 through 5.3.2, when decoding an HTTP chunked encoding stream, allows context-dependent attackers to cause a denial of service (crash) and possibly trigger memory corruption via a negative chunk size, which bypasses a signed comparison, related to an integer overflow in the chunk size decoder. \n Publish Date : 2010-05-07 Last Update Date : 2010-09-30",
+            "threat": 7.5,
+            "summary": "The dechunk filter in PHP 5.3 through 5.3.2, when decoding an HTTP chunked encoding stream, allows context-dependent attackers to cause a denial of service (crash) and possibly trigger memory corruption via a negative chunk size, which bypasses a signed comparison, related to an integer overflow in the chunk size decoder.",
+            "lastModifiedDate": "2010-09-30T06:00:00+0000",
+            "publishedDate": "2010-05-07T23:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3113,9 +3611,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2010-1868",
-            "summary": "The (1) sqlite_single_query and (2) sqlite_array_query functions in ext\/sqlite\/sqlite.c in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to execute arbitrary code by calling these functions with an empty SQL query, which triggers access of uninitialized memory. \n Publish Date : 2010-05-07 Last Update Date : 2010-05-11",
+            "threat": 7.5,
+            "summary": "The (1) sqlite_single_query and (2) sqlite_array_query functions in ext\/sqlite\/sqlite.c in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to execute arbitrary code by calling these functions with an empty SQL query, which triggers access of uninitialized memory.",
+            "lastModifiedDate": "2010-05-11T04:00:00+0000",
+            "publishedDate": "2010-05-07T23:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3124,9 +3624,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-1914",
-            "summary": "The Zend Engine in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information by interrupting the handler for the (1) ZEND_BW_XOR opcode (shift_left_function), (2) ZEND_SL opcode (bitwise_xor_function), or (3) ZEND_SR opcode (shift_right_function), related to the convert_to_long_base function. \n Publish Date : 2010-05-12 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The Zend Engine in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information by interrupting the handler for the (1) ZEND_BW_XOR opcode (shift_left_function), (2) ZEND_SL opcode (bitwise_xor_function), or (3) ZEND_SR opcode (shift_right_function), related to the convert_to_long_base function.",
+            "lastModifiedDate": "2017-08-17T01:32:00+0000",
+            "publishedDate": "2010-05-12T11:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -3135,9 +3637,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-1915",
-            "summary": "The preg_quote function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature, modification of ZVALs whose values are not updated in the associated local variables, and access of previously-freed memory. \n Publish Date : 2010-05-12 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The preg_quote function in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature, modification of ZVALs whose values are not updated in the associated local variables, and access of previously-freed memory.",
+            "lastModifiedDate": "2017-08-17T01:32:00+0000",
+            "publishedDate": "2010-05-12T11:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -3146,9 +3650,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-1917",
-            "summary": "Stack consumption vulnerability in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (PHP crash) via a crafted first argument to the fnmatch function, as demonstrated using a long string. \n Publish Date : 2010-05-12 Last Update Date : 2011-05-03",
+            "threat": 5,
+            "summary": "Stack consumption vulnerability in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (PHP crash) via a crafted first argument to the fnmatch function, as demonstrated using a long string.",
+            "lastModifiedDate": "2017-08-17T01:32:00+0000",
+            "publishedDate": "2010-05-12T11:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3157,9 +3663,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-2093",
-            "summary": "Use-after-free vulnerability in the request shutdown functionality in PHP 5.2 before 5.2.13 and 5.3 before 5.3.2 allows context-dependent attackers to cause a denial of service (crash) via a stream context structure that is freed before destruction occurs. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "Use-after-free vulnerability in the request shutdown functionality in PHP 5.2 before 5.2.13 and 5.3 before 5.3.2 allows context-dependent attackers to cause a denial of service (crash) via a stream context structure that is freed before destruction occurs.",
+            "lastModifiedDate": "2010-12-07T06:48:00+0000",
+            "publishedDate": "2010-05-27T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.13",
@@ -3168,9 +3676,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2010-2094",
-            "summary": "Multiple format string vulnerabilities in the phar extension in PHP 5.3 before 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the (1) phar_stream_flush, (2) phar_wrapper_unlink, (3) phar_parse_url, or (4) phar_wrapper_open_url functions in ext\/phar\/stream.c; and the (5) phar_wrapper_open_dir function in ext\/phar\/dirstream.c, which triggers errors in the php_stream_wrapper_log_error function. \n Publish Date : 2010-05-27 Last Update Date : 2011-01-26",
+            "threat": 6.8,
+            "summary": "Multiple format string vulnerabilities in the phar extension in PHP 5.3 before 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the (1) phar_stream_flush, (2) phar_wrapper_unlink, (3) phar_parse_url, or (4) phar_wrapper_open_url functions in ext\/phar\/stream.c; and the (5) phar_wrapper_open_dir function in ext\/phar\/dirstream.c, which triggers errors in the php_stream_wrapper_log_error function.",
+            "lastModifiedDate": "2011-01-26T06:48:00+0000",
+            "publishedDate": "2010-05-27T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.2"
@@ -3178,9 +3688,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-2097",
-            "summary": "The (1) iconv_mime_decode, (2) iconv_substr, and (3) iconv_mime_encode functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The (1) iconv_mime_decode, (2) iconv_substr, and (3) iconv_mime_encode functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-05-27T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3189,9 +3701,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-2100",
-            "summary": "The (1) htmlentities, (2) htmlspecialchars, (3) str_getcsv, (4) http_build_query, (5) strpbrk, and (6) strtr functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The (1) htmlentities, (2) htmlspecialchars, (3) str_getcsv, (4) http_build_query, (5) strpbrk, and (6) strtr functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-05-27T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3200,9 +3714,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-2101",
-            "summary": "The (1) strip_tags, (2) setcookie, (3) strtok, (4) wordwrap, (5) str_word_count, and (6) str_pad functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-05-27 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The (1) strip_tags, (2) setcookie, (3) strtok, (4) wordwrap, (5) str_word_count, and (6) str_pad functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-05-27T22:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3211,9 +3727,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-2190",
-            "summary": "The (1) trim, (2) ltrim, (3) rtrim, and (4) substr_replace functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature. \n Publish Date : 2010-06-07 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The (1) trim, (2) ltrim, (3) rtrim, and (4) substr_replace functions in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) by causing a userspace interruption of an internal function, related to the call time pass by reference feature.",
+            "lastModifiedDate": "2017-08-17T01:32:00+0000",
+            "publishedDate": "2010-06-08T00:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3222,9 +3740,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2010-2191",
-            "summary": "The (1) parse_str, (2) preg_match, (3) unpack, and (4) pack functions; the (5) ZEND_FETCH_RW, (6) ZEND_CONCAT, and (7) ZEND_ASSIGN_CONCAT opcodes; and the (8) ArrayObject::uasort method in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.  NOTE: vectors 2 through 4 are related to the call time pass by reference feature. \n Publish Date : 2010-06-07 Last Update Date : 2010-12-07",
+            "threat": 6.4,
+            "summary": "The (1) parse_str, (2) preg_match, (3) unpack, and (4) pack functions; the (5) ZEND_FETCH_RW, (6) ZEND_CONCAT, and (7) ZEND_ASSIGN_CONCAT opcodes; and the (8) ArrayObject::uasort method in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 allow context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.  NOTE: vectors 2 through 4 are related to the call time pass by reference feature.",
+            "lastModifiedDate": "2017-08-17T01:32:00+0000",
+            "publishedDate": "2010-06-08T00:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3233,9 +3753,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2010-2225",
-            "summary": "Use-after-free vulnerability in the SplObjectStorage unserializer in PHP 5.2.x and 5.3.x through 5.3.2 allows remote attackers to execute arbitrary code or obtain sensitive information via serialized data, related to the PHP unserialize function. \n Publish Date : 2010-06-24 Last Update Date : 2010-12-07",
+            "threat": 7.5,
+            "summary": "Use-after-free vulnerability in the SplObjectStorage unserializer in PHP 5.2.x and 5.3.x through 5.3.2 allows remote attackers to execute arbitrary code or obtain sensitive information via serialized data, related to the PHP unserialize function.",
+            "lastModifiedDate": "2017-08-17T01:32:00+0000",
+            "publishedDate": "2010-06-24T12:30:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3244,9 +3766,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-2484",
-            "summary": "The strrchr function in PHP 5.2 before 5.2.14 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The strrchr function in PHP 5.2 before 5.2.14 allows context-dependent attackers to obtain sensitive information (memory contents) or trigger memory corruption by causing a userspace interruption of an internal function or handler.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-08-20T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14"
@@ -3254,9 +3778,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2010-2531",
-            "summary": "The var_export function in PHP 5.2 before 5.2.14 and 5.3 before 5.3.3 flushes the output buffer to the user when certain fatal errors occur, even if display_errors is off, which allows remote attackers to obtain sensitive information by causing the application to exceed limits for memory, execution time, or recursion. \n Publish Date : 2010-08-20 Last Update Date : 2011-08-26",
+            "threat": 4.3,
+            "summary": "The var_export function in PHP 5.2 before 5.2.14 and 5.3 before 5.3.3 flushes the output buffer to the user when certain fatal errors occur, even if display_errors is off, which allows remote attackers to obtain sensitive information by causing the application to exceed limits for memory, execution time, or recursion.",
+            "lastModifiedDate": "2016-08-23T02:01:00+0000",
+            "publishedDate": "2010-08-20T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3265,9 +3791,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2010-2950",
-            "summary": "Format string vulnerability in stream.c in the phar extension in PHP 5.3.x through 5.3.3 allows context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the phar_stream_flush function, leading to errors in the php_stream_wrapper_log_error function.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2010-2094. \n Publish Date : 2010-09-28 Last Update Date : 2011-05-03",
+            "threat": 6.8,
+            "summary": "Format string vulnerability in stream.c in the phar extension in PHP 5.3.x through 5.3.3 allows context-dependent attackers to obtain sensitive information (memory contents) and possibly execute arbitrary code via a crafted phar:\/\/ URI that is not properly handled by the phar_stream_flush function, leading to errors in the php_stream_wrapper_log_error function.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2010-2094.",
+            "lastModifiedDate": "2011-05-04T02:49:00+0000",
+            "publishedDate": "2010-09-28T18:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -3275,9 +3803,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-3062",
-            "summary": "mysqlnd_wireprotocol.c in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows remote attackers to (1) read sensitive memory via a modified length value, which is not properly handled by the php_mysqlnd_ok_read function; or (2) trigger a heap-based buffer overflow via a modified length value, which is not properly handled by the php_mysqlnd_rset_header_read function. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "mysqlnd_wireprotocol.c in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows remote attackers to (1) read sensitive memory via a modified length value, which is not properly handled by the php_mysqlnd_ok_read function; or (2) trigger a heap-based buffer overflow via a modified length value, which is not properly handled by the php_mysqlnd_rset_header_read function.",
+            "lastModifiedDate": "2010-12-07T06:50:00+0000",
+            "publishedDate": "2010-08-20T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3285,9 +3815,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-3063",
-            "summary": "The php_mysqlnd_read_error_from_line function in the Mysqlnd extension in PHP 5.3 through 5.3.2 does not properly calculate a buffer length, which allows context-dependent attackers to trigger a heap-based buffer overflow via crafted inputs that cause a negative length value to be used. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "threat": 5,
+            "summary": "The php_mysqlnd_read_error_from_line function in the Mysqlnd extension in PHP 5.3 through 5.3.2 does not properly calculate a buffer length, which allows context-dependent attackers to trigger a heap-based buffer overflow via crafted inputs that cause a negative length value to be used.",
+            "lastModifiedDate": "2010-12-07T06:50:00+0000",
+            "publishedDate": "2010-08-20T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3295,9 +3827,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2010-3064",
-            "summary": "Stack-based buffer overflow in the php_mysqlnd_auth_write function in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long (1) username or (2) database name argument to the (a) mysql_connect or (b) mysqli_connect function. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-07",
+            "threat": 6.8,
+            "summary": "Stack-based buffer overflow in the php_mysqlnd_auth_write function in the Mysqlnd extension in PHP 5.3 through 5.3.2 allows context-dependent attackers to cause a denial of service (crash) and possibly execute arbitrary code via a long (1) username or (2) database name argument to the (a) mysql_connect or (b) mysqli_connect function.",
+            "lastModifiedDate": "2010-12-07T06:50:00+0000",
+            "publishedDate": "2010-08-20T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.3"
@@ -3305,9 +3839,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-3065",
-            "summary": "The default session serializer in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 does not properly handle the PS_UNDEF_MARKER marker, which allows context-dependent attackers to modify arbitrary session variables via a crafted session variable name. \n Publish Date : 2010-08-20 Last Update Date : 2010-12-10",
+            "threat": 5,
+            "summary": "The default session serializer in PHP 5.2 through 5.2.13 and 5.3 through 5.3.2 does not properly handle the PS_UNDEF_MARKER marker, which allows context-dependent attackers to modify arbitrary session variables via a crafted session variable name.",
+            "lastModifiedDate": "2010-12-10T06:44:00+0000",
+            "publishedDate": "2010-08-20T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.14",
@@ -3316,9 +3852,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-3436",
-            "summary": "fopen_wrappers.c in PHP 5.3.x through 5.3.3 might allow remote attackers to bypass open_basedir restrictions via vectors related to the length of a filename. \n Publish Date : 2010-11-08 Last Update Date : 2011-10-20",
+            "threat": 5,
+            "summary": "fopen_wrappers.c in PHP 5.3.x through 5.3.3 might allow remote attackers to bypass open_basedir restrictions via vectors related to the length of a filename.",
+            "lastModifiedDate": "2011-10-21T02:48:00+0000",
+            "publishedDate": "2010-11-09T01:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -3326,9 +3864,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2010-3709",
-            "summary": "The ZipArchive::getArchiveComment function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3 allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted ZIP archive. \n Publish Date : 2010-11-08 Last Update Date : 2011-05-03",
+            "threat": 4.3,
+            "summary": "The ZipArchive::getArchiveComment function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3 allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted ZIP archive.",
+            "lastModifiedDate": "2016-08-23T02:02:00+0000",
+            "publishedDate": "2010-11-09T01:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3337,9 +3877,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2010-3710",
-            "summary": "Stack consumption vulnerability in the filter_var function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3, when FILTER_VALIDATE_EMAIL mode is used, allows remote attackers to cause a denial of service (memory consumption and application crash) via a long e-mail address string. \n Publish Date : 2010-10-25 Last Update Date : 2011-03-23",
+            "threat": 4.3,
+            "summary": "Stack consumption vulnerability in the filter_var function in PHP 5.2.x through 5.2.14 and 5.3.x through 5.3.3, when FILTER_VALIDATE_EMAIL mode is used, allows remote attackers to cause a denial of service (memory consumption and application crash) via a long e-mail address string.",
+            "lastModifiedDate": "2016-08-23T02:02:00+0000",
+            "publishedDate": "2010-10-25T20:01:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3348,9 +3890,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2010-3870",
-            "summary": "The utf8_decode function in PHP before 5.3.4 does not properly handle non-shortest form UTF-8 encoding and ill-formed subsequences in UTF-8 data, which makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string. \n Publish Date : 2010-11-12 Last Update Date : 2011-03-23",
+            "threat": 6.8,
+            "summary": "The utf8_decode function in PHP before 5.3.4 does not properly handle non-shortest form UTF-8 encoding and ill-formed subsequences in UTF-8 data, which makes it easier for remote attackers to bypass cross-site scripting (XSS) and SQL injection protection mechanisms via a crafted string.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2010-11-12T21:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3366,9 +3910,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-4150",
-            "summary": "Double free vulnerability in the imap_do_open function in the IMAP extension (ext\/imap\/php_imap.c) in PHP 5.2 before 5.2.15 and 5.3 before 5.3.4 allows attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via unspecified vectors. \n Publish Date : 2010-12-07 Last Update Date : 2011-07-18",
+            "threat": 5,
+            "summary": "Double free vulnerability in the imap_do_open function in the IMAP extension (ext\/imap\/php_imap.c) in PHP 5.2 before 5.2.15 and 5.3 before 5.3.4 allows attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via unspecified vectors.",
+            "lastModifiedDate": "2017-09-19T01:31:00+0000",
+            "publishedDate": "2010-12-07T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3377,9 +3923,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-4409",
-            "summary": "Integer overflow in the NumberFormatter::getSymbol (aka numfmt_get_symbol) function in PHP 5.3.3 and earlier allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument. \n Publish Date : 2010-12-06 Last Update Date : 2012-06-22",
+            "threat": 5,
+            "summary": "Integer overflow in the NumberFormatter::getSymbol (aka numfmt_get_symbol) function in PHP 5.3.3 and earlier allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2010-12-06T20:13:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3392,9 +3940,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-4645",
-            "summary": "strtod.c, as used in the zend_strtod function in PHP 5.2 before 5.2.17 and 5.3 before 5.3.5, and other products, allows context-dependent attackers to cause a denial of service (infinite loop) via a certain floating-point value in scientific notation, which is not properly handled in x87 FPU registers, as demonstrated using 2.2250738585072011e-308. \n Publish Date : 2011-01-10 Last Update Date : 2012-08-13",
+            "threat": 5,
+            "summary": "strtod.c, as used in the zend_strtod function in PHP 5.2 before 5.2.17 and 5.3 before 5.3.5, and other products, allows context-dependent attackers to cause a denial of service (infinite loop) via a certain floating-point value in scientific notation, which is not properly handled in x87 FPU registers, as demonstrated using 2.2250738585072011e-308.",
+            "lastModifiedDate": "2017-08-17T01:33:00+0000",
+            "publishedDate": "2011-01-11T03:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.17",
@@ -3403,9 +3953,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2010-4697",
-            "summary": "Use-after-free vulnerability in the Zend engine in PHP before 5.2.15 and 5.3.x before 5.3.4 might allow context-dependent attackers to cause a denial of service (heap memory corruption) or have unspecified other impact via vectors related to use of __set, __get, __isset, and __unset methods on objects accessed by a reference. \n Publish Date : 2011-01-18 Last Update Date : 2011-07-18",
+            "threat": 6.8,
+            "summary": "Use-after-free vulnerability in the Zend engine in PHP before 5.2.15 and 5.3.x before 5.3.4 might allow context-dependent attackers to cause a denial of service (heap memory corruption) or have unspecified other impact via vectors related to use of __set, __get, __isset, and __unset methods on objects accessed by a reference.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-01-18T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3421,9 +3973,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-4698",
-            "summary": "Stack-based buffer overflow in the GD extension in PHP before 5.2.15 and 5.3.x before 5.3.4 allows context-dependent attackers to cause a denial of service (application crash) via a large number of anti-aliasing steps in an argument to the imagepstext function. \n Publish Date : 2011-01-18 Last Update Date : 2011-08-01",
+            "threat": 5,
+            "summary": "Stack-based buffer overflow in the GD extension in PHP before 5.2.15 and 5.3.x before 5.3.4 allows context-dependent attackers to cause a denial of service (application crash) via a large number of anti-aliasing steps in an argument to the imagepstext function.",
+            "lastModifiedDate": "2017-09-19T01:31:00+0000",
+            "publishedDate": "2011-01-18T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.15",
@@ -3432,9 +3986,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2010-4699",
-            "summary": "The iconv_mime_decode_headers function in the Iconv extension in PHP before 5.3.4 does not properly handle encodings that are unrecognized by the iconv and mbstring (aka Multibyte String) implementations, which allows remote attackers to trigger an incomplete output array, and possibly bypass spam detection or have unspecified other impact, via a crafted Subject header in an e-mail message, as demonstrated by the ks_c_5601-1987 character set. \n Publish Date : 2011-01-18 Last Update Date : 2011-07-18",
+            "threat": 5,
+            "summary": "The iconv_mime_decode_headers function in the Iconv extension in PHP before 5.3.4 does not properly handle encodings that are unrecognized by the iconv and mbstring (aka Multibyte String) implementations, which allows remote attackers to trigger an incomplete output array, and possibly bypass spam detection or have unspecified other impact, via a crafted Subject header in an e-mail message, as demonstrated by the ks_c_5601-1987 character set.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-01-18T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3450,9 +4006,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2010-4700",
-            "summary": "The set_magic_quotes_runtime function in PHP 5.3.2 and 5.3.3, when the MySQLi extension is used, does not properly interact with use of the mysqli_fetch_assoc function, which might make it easier for context-dependent attackers to conduct SQL injection attacks via crafted input that had been properly handled in earlier PHP versions. \n Publish Date : 2011-01-18 Last Update Date : 2011-07-18",
+            "threat": 6.8,
+            "summary": "The set_magic_quotes_runtime function in PHP 5.3.2 and 5.3.3, when the MySQLi extension is used, does not properly interact with use of the mysqli_fetch_assoc function, which might make it easier for context-dependent attackers to conduct SQL injection attacks via crafted input that had been properly handled in earlier PHP versions.",
+            "lastModifiedDate": "2017-09-19T01:31:00+0000",
+            "publishedDate": "2011-01-18T20:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -3460,9 +4018,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-0420",
-            "summary": "The grapheme_extract function in the Internationalization extension (Intl) for ICU for PHP 5.3.5 allows context-dependent attackers to cause a denial of service (crash) via an invalid size argument, which triggers a NULL pointer dereference. \n Publish Date : 2011-02-18 Last Update Date : 2013-09-07",
+            "threat": 5,
+            "summary": "The grapheme_extract function in the Internationalization extension (Intl) for ICU for PHP 5.3.5 allows context-dependent attackers to cause a denial of service (crash) via an invalid size argument, which triggers a NULL pointer dereference.",
+            "lastModifiedDate": "2018-10-10T20:09:00+0000",
+            "publishedDate": "2011-02-19T01:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.6"
@@ -3470,9 +4030,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-0421",
-            "summary": "The _zip_name_locate function in zip_name_locate.c in the Zip extension in PHP before 5.3.6 does not properly handle a ZIPARCHIVE::FL_UNCHANGED argument, which might allow context-dependent attackers to cause a denial of service (NULL pointer dereference) via an empty ZIP archive that is processed with a (1) locateName or (2) statName operation. \n Publish Date : 2011-03-19 Last Update Date : 2014-02-20",
+            "threat": 4.3,
+            "summary": "The _zip_name_locate function in zip_name_locate.c in the Zip extension in PHP before 5.3.6 does not properly handle a ZIPARCHIVE::FL_UNCHANGED argument, which might allow context-dependent attackers to cause a denial of service (NULL pointer dereference) via an empty ZIP archive that is processed with a (1) locateName or (2) statName operation.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3488,9 +4050,11 @@
             }
         },
         {
-            "threat": "6.3",
             "cveid": "CVE-2011-0441",
-            "summary": "The Debian GNU\/Linux \/etc\/cron.d\/php5 cron job for PHP 5.3.5 allows local users to delete arbitrary files via a symlink attack on a directory under \/var\/lib\/php5\/. \n Publish Date : 2011-03-29 Last Update Date : 2011-04-20",
+            "threat": 6.3,
+            "summary": "The Debian GNU\/Linux \/etc\/cron.d\/php5 cron job for PHP 5.3.5 allows local users to delete arbitrary files via a symlink attack on a directory under \/var\/lib\/php5\/.",
+            "lastModifiedDate": "2017-08-17T01:33:00+0000",
+            "publishedDate": "2011-03-29T18:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.6"
@@ -3498,9 +4062,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-0708",
-            "summary": "exif.c in the Exif extension in PHP before 5.3.6 on 64-bit platforms performs an incorrect cast, which allows remote attackers to cause a denial of service (application crash) via an image with a crafted Image File Directory (IFD) that triggers a buffer over-read. \n Publish Date : 2011-03-19 Last Update Date : 2012-11-05",
+            "threat": 4.3,
+            "summary": "exif.c in the Exif extension in PHP before 5.3.6 on 64-bit platforms performs an incorrect cast, which allows remote attackers to cause a denial of service (application crash) via an image with a crafted Image File Directory (IFD) that triggers a buffer over-read.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3516,9 +4082,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-0752",
-            "summary": "The extract function in PHP before 5.2.15 does not prevent use of the EXTR_OVERWRITE parameter to overwrite (1) the GLOBALS superglobal array and (2) the this variable, which allows context-dependent attackers to bypass intended access restrictions by modifying data structures that were not intended to depend on external input, a related issue to CVE-2005-2691 and CVE-2006-3758. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "threat": 5,
+            "summary": "The extract function in PHP before 5.2.15 does not prevent use of the EXTR_OVERWRITE parameter to overwrite (1) the GLOBALS superglobal array and (2) the this variable, which allows context-dependent attackers to bypass intended access restrictions by modifying data structures that were not intended to depend on external input, a related issue to CVE-2005-2691 and CVE-2006-3758.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-02-02T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3533,9 +4101,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-0753",
-            "summary": "Race condition in the PCNTL extension in PHP before 5.3.4, when a user-defined signal handler exists, might allow context-dependent attackers to cause a denial of service (memory corruption) via a large number of concurrent signals. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "threat": 4.3,
+            "summary": "Race condition in the PCNTL extension in PHP before 5.3.4, when a user-defined signal handler exists, might allow context-dependent attackers to cause a denial of service (memory corruption) via a large number of concurrent signals.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-02-02T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3548,9 +4118,11 @@
             }
         },
         {
-            "threat": "4.4",
             "cveid": "CVE-2011-0754",
-            "summary": "The SplFileInfo::getType function in the Standard PHP Library (SPL) extension in PHP before 5.3.4 on Windows does not properly detect symbolic links, which might make it easier for local users to conduct symlink attacks by leveraging cross-platform differences in the stat structure, related to lack of a FILE_ATTRIBUTE_REPARSE_POINT check. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "threat": 4.4,
+            "summary": "The SplFileInfo::getType function in the Standard PHP Library (SPL) extension in PHP before 5.3.4 on Windows does not properly detect symbolic links, which might make it easier for local users to conduct symlink attacks by leveraging cross-platform differences in the stat structure, related to lack of a FILE_ATTRIBUTE_REPARSE_POINT check.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-02-02T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3563,9 +4135,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-0755",
-            "summary": "Integer overflow in the mt_rand function in PHP before 5.3.4 might make it easier for context-dependent attackers to predict the return values by leveraging a script's use of a large max parameter, as demonstrated by a value that exceeds mt_getrandmax. \n Publish Date : 2011-02-02 Last Update Date : 2011-07-18",
+            "threat": 5,
+            "summary": "Integer overflow in the mt_rand function in PHP before 5.3.4 might make it easier for context-dependent attackers to predict the return values by leveraging a script's use of a large max parameter, as demonstrated by a value that exceeds mt_getrandmax.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-02-02T22:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3581,9 +4155,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2011-1092",
-            "summary": "Integer overflow in ext\/shmop\/shmop.c in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (crash) and possibly read sensitive memory via a large third argument to the shmop_read function. \n Publish Date : 2011-03-15 Last Update Date : 2011-10-20",
+            "threat": 7.5,
+            "summary": "Integer overflow in ext\/shmop\/shmop.c in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (crash) and possibly read sensitive memory via a large third argument to the shmop_read function.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-15T17:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3599,9 +4175,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2011-1148",
-            "summary": "Use-after-free vulnerability in the substr_replace function in PHP 5.3.6 and earlier allows context-dependent attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact by using the same variable for multiple arguments. \n Publish Date : 2011-03-18 Last Update Date : 2012-02-03",
+            "threat": 7.5,
+            "summary": "Use-after-free vulnerability in the substr_replace function in PHP 5.3.6 and earlier allows context-dependent attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact by using the same variable for multiple arguments.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-18T15:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3614,9 +4192,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2011-1153",
-            "summary": "Multiple format string vulnerabilities in phar_object.c in the phar extension in PHP 5.3.5 and earlier allow context-dependent attackers to obtain sensitive information from process memory, cause a denial of service (memory corruption), or possibly execute arbitrary code via format string specifiers in an argument to a class method, leading to an incorrect zend_throw_exception_ex call. \n Publish Date : 2011-03-16 Last Update Date : 2011-10-20",
+            "threat": 7.5,
+            "summary": "Multiple format string vulnerabilities in phar_object.c in the phar extension in PHP 5.3.5 and earlier allow context-dependent attackers to obtain sensitive information from process memory, cause a denial of service (memory corruption), or possibly execute arbitrary code via format string specifiers in an argument to a class method, leading to an incorrect zend_throw_exception_ex call.",
+            "lastModifiedDate": "2017-08-17T01:33:00+0000",
+            "publishedDate": "2011-03-16T22:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3632,9 +4212,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-1398",
-            "summary": "The sapi_header_op function in main\/SAPI.c in PHP before 5.3.11 and 5.4.x before 5.4.0RC2 does not check for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome. \n Publish Date : 2012-08-30 Last Update Date : 2013-10-10",
+            "threat": 4.3,
+            "summary": "The sapi_header_op function in main\/SAPI.c in PHP before 5.3.11 and 5.4.x before 5.4.0RC2 does not check for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.",
+            "lastModifiedDate": "2013-10-11T03:34:00+0000",
+            "publishedDate": "2012-08-30T22:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.11"
@@ -3642,9 +4224,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-1464",
-            "summary": "Buffer overflow in the strval function in PHP before 5.3.6, when the precision configuration option has a large value, might allow context-dependent attackers to cause a denial of service (application crash) via a small numerical value in the argument. \n Publish Date : 2011-03-19 Last Update Date : 2011-04-08",
+            "threat": 4.3,
+            "summary": "Buffer overflow in the strval function in PHP before 5.3.6, when the precision configuration option has a large value, might allow context-dependent attackers to cause a denial of service (application crash) via a small numerical value in the argument.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3660,9 +4244,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-1466",
-            "summary": "Integer overflow in the SdnToJulian function in the Calendar extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a large integer in the first argument to the cal_from_jd function. \n Publish Date : 2011-03-19 Last Update Date : 2012-11-05",
+            "threat": 5,
+            "summary": "Integer overflow in the SdnToJulian function in the Calendar extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a large integer in the first argument to the cal_from_jd function.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3678,9 +4264,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-1467",
-            "summary": "Unspecified vulnerability in the NumberFormatter::setSymbol (aka numfmt_set_symbol) function in the Intl extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument, a related issue to CVE-2010-4409. \n Publish Date : 2011-03-19 Last Update Date : 2011-10-20",
+            "threat": 5,
+            "summary": "Unspecified vulnerability in the NumberFormatter::setSymbol (aka numfmt_set_symbol) function in the Intl extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via an invalid argument, a related issue to CVE-2010-4409.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3696,9 +4284,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-1468",
-            "summary": "Multiple memory leaks in the OpenSSL extension in PHP before 5.3.6 might allow remote attackers to cause a denial of service (memory consumption) via (1) plaintext data to the openssl_encrypt function or (2) ciphertext data to the openssl_decrypt function. \n Publish Date : 2011-03-19 Last Update Date : 2012-01-18",
+            "threat": 4.3,
+            "summary": "Multiple memory leaks in the OpenSSL extension in PHP before 5.3.6 might allow remote attackers to cause a denial of service (memory consumption) via (1) plaintext data to the openssl_encrypt function or (2) ciphertext data to the openssl_decrypt function.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3714,9 +4304,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-1469",
-            "summary": "Unspecified vulnerability in the Streams component in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) by accessing an ftp:\/\/ URL during use of an HTTP proxy with the FTP wrapper. \n Publish Date : 2011-03-19 Last Update Date : 2012-01-18",
+            "threat": 4.3,
+            "summary": "Unspecified vulnerability in the Streams component in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) by accessing an ftp:\/\/ URL during use of an HTTP proxy with the FTP wrapper.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3732,9 +4324,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-1470",
-            "summary": "The Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a ziparchive stream that is not properly handled by the stream_get_contents function. \n Publish Date : 2011-03-19 Last Update Date : 2011-10-20",
+            "threat": 4.3,
+            "summary": "The Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (application crash) via a ziparchive stream that is not properly handled by the stream_get_contents function.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3750,9 +4344,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-1471",
-            "summary": "Integer signedness error in zip_stream.c in the Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (CPU consumption) via a malformed archive file that triggers errors in zip_fread function calls. \n Publish Date : 2011-03-19 Last Update Date : 2013-08-31",
+            "threat": 4.3,
+            "summary": "Integer signedness error in zip_stream.c in the Zip extension in PHP before 5.3.6 allows context-dependent attackers to cause a denial of service (CPU consumption) via a malformed archive file that triggers errors in zip_fread function calls.",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-03-20T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3765,9 +4361,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-1657",
-            "summary": "The (1) ZipArchive::addGlob and (2) ZipArchive::addPattern functions in ext\/zip\/php_zip.c in PHP 5.3.6 allow context-dependent attackers to cause a denial of service (application crash) via certain flags arguments, as demonstrated by (a) GLOB_ALTDIRFUNC and (b) GLOB_APPEND. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "threat": 5,
+            "summary": "The (1) ZipArchive::addGlob and (2) ZipArchive::addPattern functions in ext\/zip\/php_zip.c in PHP 5.3.6 allow context-dependent attackers to cause a denial of service (application crash) via certain flags arguments, as demonstrated by (a) GLOB_ALTDIRFUNC and (b) GLOB_APPEND.",
+            "lastModifiedDate": "2018-10-09T19:31:00+0000",
+            "publishedDate": "2011-08-25T14:22:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.7"
@@ -3775,9 +4373,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2011-1938",
-            "summary": "Stack-based buffer overflow in the socket_connect function in ext\/sockets\/sockets.c in PHP 5.3.3 through 5.3.6 might allow context-dependent attackers to execute arbitrary code via a long pathname for a UNIX socket. \n Publish Date : 2011-05-31 Last Update Date : 2012-02-08",
+            "threat": 7.5,
+            "summary": "Stack-based buffer overflow in the socket_connect function in ext\/sockets\/sockets.c in PHP 5.3.3 through 5.3.6 might allow context-dependent attackers to execute arbitrary code via a long pathname for a UNIX socket.",
+            "lastModifiedDate": "2017-08-17T01:34:00+0000",
+            "publishedDate": "2011-05-31T20:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.7"
@@ -3785,9 +4385,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2011-2202",
-            "summary": "The rfc1867_post_handler function in main\/rfc1867.c in PHP before 5.3.7 does not properly restrict filenames in multipart\/form-data POST requests, which allows remote attackers to conduct absolute path traversal attacks, and possibly create or overwrite arbitrary files, via a crafted upload request, related to a \"file path injection vulnerability.\" \n Publish Date : 2011-06-16 Last Update Date : 2012-11-05",
+            "threat": 6.4,
+            "summary": "The rfc1867_post_handler function in main\/rfc1867.c in PHP before 5.3.7 does not properly restrict filenames in multipart\/form-data POST requests, which allows remote attackers to conduct absolute path traversal attacks, and possibly create or overwrite arbitrary files, via a crafted upload request, related to a \"file path injection vulnerability.\"",
+            "lastModifiedDate": "2018-10-30T16:26:00+0000",
+            "publishedDate": "2011-06-16T23:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3800,9 +4402,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-2483",
-            "summary": "crypt_blowfish before 1.1, as used in PHP before 5.3.7 on certain platforms, PostgreSQL before 8.4.9, and other products, does not properly handle 8-bit characters, which makes it easier for context-dependent attackers to determine a cleartext password by leveraging knowledge of a password hash. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-08",
+            "threat": 5,
+            "summary": "crypt_blowfish before 1.1, as used in PHP before 5.3.7 on certain platforms, PostgreSQL before 8.4.9, and other products, does not properly handle 8-bit characters, which makes it easier for context-dependent attackers to determine a cleartext password by leveraging knowledge of a password hash.",
+            "lastModifiedDate": "2017-08-29T01:29:00+0000",
+            "publishedDate": "2011-08-25T14:22:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3813,14 +4417,17 @@
                     "5.0.6",
                     "5.1.7",
                     "5.2.15",
-                    "5.3.7"
+                    "5.3.7",
+                    "5.4.0"
                 ]
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-3182",
-            "summary": "PHP before 5.3.7 does not properly check the return values of the malloc, calloc, and realloc library functions, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger a buffer overflow by leveraging the ability to provide an arbitrary value for a function argument, related to (1) ext\/curl\/interface.c, (2) ext\/date\/lib\/parse_date.c, (3) ext\/date\/lib\/parse_iso_intervals.c, (4) ext\/date\/lib\/parse_tz.c, (5) ext\/date\/lib\/timelib.c, (6) ext\/pdo_odbc\/pdo_odbc.c, (7) ext\/reflection\/php_reflection.c, (8) ext\/soap\/php_sdl.c, (9) ext\/xmlrpc\/libxmlrpc\/base64.c, (10) TSRM\/tsrm_win32.c, and (11) the strtotime function. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "threat": 5,
+            "summary": "PHP before 5.3.7 does not properly check the return values of the malloc, calloc, and realloc library functions, which allows context-dependent attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger a buffer overflow by leveraging the ability to provide an arbitrary value for a function argument, related to (1) ext\/curl\/interface.c, (2) ext\/date\/lib\/parse_date.c, (3) ext\/date\/lib\/parse_iso_intervals.c, (4) ext\/date\/lib\/parse_tz.c, (5) ext\/date\/lib\/timelib.c, (6) ext\/pdo_odbc\/pdo_odbc.c, (7) ext\/reflection\/php_reflection.c, (8) ext\/soap\/php_sdl.c, (9) ext\/xmlrpc\/libxmlrpc\/base64.c, (10) TSRM\/tsrm_win32.c, and (11) the strtotime function.",
+            "lastModifiedDate": "2017-08-29T01:30:00+0000",
+            "publishedDate": "2011-08-25T14:22:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3836,9 +4443,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2011-3189",
-            "summary": "The crypt function in PHP 5.3.7, when the MD5 hash type is used, returns the value of the salt argument instead of the hashed string, which might allow remote attackers to bypass authentication via an arbitrary password, a different vulnerability than CVE-2011-2483. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "threat": 4.3,
+            "summary": "The crypt function in PHP 5.3.7, when the MD5 hash type is used, returns the value of the salt argument instead of the hashed string, which might allow remote attackers to bypass authentication via an arbitrary password, a different vulnerability than CVE-2011-2483.",
+            "lastModifiedDate": "2017-08-29T01:30:00+0000",
+            "publishedDate": "2011-08-25T14:22:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.8"
@@ -3846,9 +4455,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-3267",
-            "summary": "PHP before 5.3.7 does not properly implement the error_log function, which allows context-dependent attackers to cause a denial of service (application crash) via unspecified vectors. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "threat": 5,
+            "summary": "PHP before 5.3.7 does not properly implement the error_log function, which allows context-dependent attackers to cause a denial of service (application crash) via unspecified vectors.",
+            "lastModifiedDate": "2017-08-29T01:30:00+0000",
+            "publishedDate": "2011-08-25T18:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3864,9 +4475,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2011-3268",
-            "summary": "Buffer overflow in the crypt function in PHP before 5.3.7 allows context-dependent attackers to have an unspecified impact via a long salt argument, a different vulnerability than CVE-2011-2483. \n Publish Date : 2011-08-25 Last Update Date : 2012-02-03",
+            "threat": 10,
+            "summary": "Buffer overflow in the crypt function in PHP before 5.3.7 allows context-dependent attackers to have an unspecified impact via a long salt argument, a different vulnerability than CVE-2011-2483.",
+            "lastModifiedDate": "2017-08-29T01:30:00+0000",
+            "publishedDate": "2011-08-25T18:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -3882,9 +4495,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2011-3379",
-            "summary": "The is_a function in PHP 5.3.7 and 5.3.8 triggers a call to the __autoload function, which makes it easier for remote attackers to execute arbitrary code by providing a crafted URL and leveraging potentially unsafe behavior in certain PEAR packages and custom autoloaders. \n Publish Date : 2011-11-03 Last Update Date : 2012-07-03",
+            "threat": 7.5,
+            "summary": "The is_a function in PHP 5.3.7 and 5.3.8 triggers a call to the __autoload function, which makes it easier for remote attackers to execute arbitrary code by providing a crafted URL and leveraging potentially unsafe behavior in certain PEAR packages and custom autoloaders.",
+            "lastModifiedDate": "2012-07-03T04:02:00+0000",
+            "publishedDate": "2011-11-03T15:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3892,9 +4507,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-4153",
-            "summary": "PHP 5.3.8 does not always check the return value of the zend_strndup function, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that performs strndup operations on untrusted string data, as demonstrated by the define function in zend_builtin_functions.c, and unspecified functions in ext\/soap\/php_sdl.c, ext\/standard\/syslog.c, ext\/standard\/browscap.c, ext\/oci8\/oci8.c, ext\/com_dotnet\/com_typeinfo.c, and main\/php_open_temporary_file.c. \n Publish Date : 2012-01-18 Last Update Date : 2012-07-21",
+            "threat": 5,
+            "summary": "PHP 5.3.8 does not always check the return value of the zend_strndup function, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that performs strndup operations on untrusted string data, as demonstrated by the define function in zend_builtin_functions.c, and unspecified functions in ext\/soap\/php_sdl.c, ext\/standard\/syslog.c, ext\/standard\/browscap.c, ext\/oci8\/oci8.c, ext\/com_dotnet\/com_typeinfo.c, and main\/php_open_temporary_file.c.",
+            "lastModifiedDate": "2018-01-18T02:29:00+0000",
+            "publishedDate": "2012-01-18T20:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3902,9 +4519,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2011-4566",
-            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in the exif extension in PHP 5.4.0beta2 on 32-bit platforms allows remote attackers to read the contents of arbitrary memory locations or cause a denial of service via a crafted offset_val value in an EXIF header in a JPEG file, a different vulnerability than CVE-2011-0708. \n Publish Date : 2011-11-28 Last Update Date : 2012-11-06",
+            "threat": 6.4,
+            "summary": "Integer overflow in the exif_process_IFD_TAG function in exif.c in the exif extension in PHP 5.4.0beta2 on 32-bit platforms allows remote attackers to read the contents of arbitrary memory locations or cause a denial of service via a crafted offset_val value in an EXIF header in a JPEG file, a different vulnerability than CVE-2011-0708.",
+            "lastModifiedDate": "2017-08-29T01:30:00+0000",
+            "publishedDate": "2011-11-29T00:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.1"
@@ -3912,9 +4531,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2011-4718",
-            "summary": "Session fixation vulnerability in the Sessions subsystem in PHP before 5.5.2 allows remote attackers to hijack web sessions by specifying a session ID. \n Publish Date : 2013-08-13 Last Update Date : 2013-08-13",
+            "threat": 6.8,
+            "summary": "Session fixation vulnerability in the Sessions subsystem in PHP before 5.5.2 allows remote attackers to hijack web sessions by specifying a session ID.",
+            "lastModifiedDate": "2013-08-13T18:32:00+0000",
+            "publishedDate": "2013-08-13T15:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3927,9 +4548,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2011-4885",
-            "summary": "PHP before 5.3.9 computes hash values for form parameters without restricting the ability to trigger hash collisions predictably, which allows remote attackers to cause a denial of service (CPU consumption) by sending many crafted parameters. \n Publish Date : 2011-12-29 Last Update Date : 2013-10-10",
+            "threat": 5,
+            "summary": "PHP before 5.3.9 computes hash values for form parameters without restricting the ability to trigger hash collisions predictably, which allows remote attackers to cause a denial of service (CPU consumption) by sending many crafted parameters.",
+            "lastModifiedDate": "2018-01-09T02:29:00+0000",
+            "publishedDate": "2011-12-30T01:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3940,9 +4563,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2012-0057",
-            "summary": "PHP before 5.3.9 has improper libxslt security settings, which allows remote attackers to create arbitrary files via a crafted XSLT stylesheet that uses the libxslt output extension. \n Publish Date : 2012-02-01 Last Update Date : 2012-07-03",
+            "threat": 6.4,
+            "summary": "PHP before 5.3.9 has improper libxslt security settings, which allows remote attackers to create arbitrary files via a crafted XSLT stylesheet that uses the libxslt output extension.",
+            "lastModifiedDate": "2018-01-18T02:29:00+0000",
+            "publishedDate": "2012-02-02T00:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3953,9 +4578,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-0781",
-            "summary": "The tidy_diagnose function in PHP 5.3.8 might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that attempts to perform Tidy::diagnose operations on invalid objects, a different vulnerability than CVE-2011-4153. \n Publish Date : 2012-01-18 Last Update Date : 2012-06-27",
+            "threat": 5,
+            "summary": "The tidy_diagnose function in PHP 5.3.8 might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted input to an application that attempts to perform Tidy::diagnose operations on invalid objects, a different vulnerability than CVE-2011-4153.",
+            "lastModifiedDate": "2018-01-09T02:29:00+0000",
+            "publishedDate": "2012-01-18T20:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.9"
@@ -3963,9 +4590,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-0788",
-            "summary": "The PDORow implementation in PHP before 5.3.9 does not properly interact with the session feature, which allows remote attackers to cause a denial of service (application crash) via a crafted application that uses a PDO driver for a fetch and then calls the session_start function, as demonstrated by a crash of the Apache HTTP Server. \n Publish Date : 2012-02-14 Last Update Date : 2012-06-27",
+            "threat": 5,
+            "summary": "The PDORow implementation in PHP before 5.3.9 does not properly interact with the session feature, which allows remote attackers to cause a denial of service (application crash) via a crafted application that uses a PDO driver for a fetch and then calls the session_start function, as demonstrated by a crash of the Apache HTTP Server.",
+            "lastModifiedDate": "2018-01-09T02:29:00+0000",
+            "publishedDate": "2012-02-14T15:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3976,9 +4605,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-0789",
-            "summary": "Memory leak in the timezone functionality in PHP before 5.3.9 allows remote attackers to cause a denial of service (memory consumption) by triggering many strtotime function calls, which are not properly handled by the php_date_parse_tzfile cache. \n Publish Date : 2012-02-14 Last Update Date : 2012-06-27",
+            "threat": 5,
+            "summary": "Memory leak in the timezone functionality in PHP before 5.3.9 allows remote attackers to cause a denial of service (memory consumption) by triggering many strtotime function calls, which are not properly handled by the php_date_parse_tzfile cache.",
+            "lastModifiedDate": "2018-01-09T02:29:00+0000",
+            "publishedDate": "2012-02-14T15:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -3989,9 +4620,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2012-0830",
-            "summary": "The php_register_variable_ex function in php_variables.c in PHP 5.3.9 allows remote attackers to execute arbitrary code via a request containing a large number of variables, related to improper handling of array variables.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-4885. \n Publish Date : 2012-02-06 Last Update Date : 2012-07-21",
+            "threat": 7.5,
+            "summary": "The php_register_variable_ex function in php_variables.c in PHP 5.3.9 allows remote attackers to execute arbitrary code via a request containing a large number of variables, related to improper handling of array variables.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-4885.",
+            "lastModifiedDate": "2018-01-09T02:29:00+0000",
+            "publishedDate": "2012-02-06T20:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.10"
@@ -3999,9 +4632,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2012-0831",
-            "summary": "PHP before 5.3.10 does not properly perform a temporary change to the magic_quotes_gpc directive during the importing of environment variables, which makes it easier for remote attackers to conduct SQL injection attacks via a crafted request, related to main\/php_variables.c, sapi\/cgi\/cgi_main.c, and sapi\/fpm\/fpm\/fpm_main.c. \n Publish Date : 2012-02-10 Last Update Date : 2013-10-10",
+            "threat": 6.8,
+            "summary": "PHP before 5.3.10 does not properly perform a temporary change to the magic_quotes_gpc directive during the importing of environment variables, which makes it easier for remote attackers to conduct SQL injection attacks via a crafted request, related to main\/php_variables.c, sapi\/cgi\/cgi_main.c, and sapi\/fpm\/fpm\/fpm_main.c.",
+            "lastModifiedDate": "2018-01-18T02:29:00+0000",
+            "publishedDate": "2012-02-10T20:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4017,9 +4652,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-1171",
-            "summary": "The libxml RSHUTDOWN function in PHP 5.x allows remote attackers to bypass the open_basedir protection mechanism and read arbitrary files via vectors involving a stream_close method call during use of a custom stream wrapper. \n Publish Date : 2014-02-15 Last Update Date : 2014-02-18",
+            "threat": 5,
+            "summary": "The libxml RSHUTDOWN function in PHP 5.x allows remote attackers to bypass the open_basedir protection mechanism and read arbitrary files via vectors involving a stream_close method call during use of a custom stream wrapper.",
+            "lastModifiedDate": "2014-02-18T18:57:00+0000",
+            "publishedDate": "2014-02-15T14:57:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4032,9 +4669,11 @@
             }
         },
         {
-            "threat": "5.8",
             "cveid": "CVE-2012-1172",
-            "summary": "The file-upload implementation in rfc1867.c in PHP before 5.4.0 does not properly handle invalid [ (open square bracket) characters in name values, which makes it easier for remote attackers to cause a denial of service (malformed $_FILES indexes) or conduct directory traversal attacks during multi-file uploads by leveraging a script that lacks its own filename restrictions. \n Publish Date : 2012-05-23 Last Update Date : 2012-09-21",
+            "threat": 5.8,
+            "summary": "The file-upload implementation in rfc1867.c in PHP before 5.4.0 does not properly handle invalid [ (open square bracket) characters in name values, which makes it easier for remote attackers to cause a denial of service (malformed $_FILES indexes) or conduct directory traversal attacks during multi-file uploads by leveraging a script that lacks its own filename restrictions.",
+            "lastModifiedDate": "2018-01-18T02:29:00+0000",
+            "publishedDate": "2012-05-24T00:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4045,9 +4684,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2012-1823",
-            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-19",
+            "threat": 7.5,
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.",
+            "lastModifiedDate": "2018-01-18T02:29:00+0000",
+            "publishedDate": "2012-05-11T10:15:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4059,9 +4700,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2012-2143",
-            "summary": "The crypt_des (aka DES-based crypt) function in FreeBSD before 9.0-RELEASE-p2, as used in PHP, PostgreSQL, and other products, does not process the complete cleartext password if this password contains a 0x80 character, which makes it easier for context-dependent attackers to obtain access via an authentication attempt with an initial substring of the intended password, as demonstrated by a Unicode password. \n Publish Date : 2012-07-05 Last Update Date : 2013-06-10",
+            "threat": 4.3,
+            "summary": "The crypt_des (aka DES-based crypt) function in FreeBSD before 9.0-RELEASE-p2, as used in PHP, PostgreSQL, and other products, does not process the complete cleartext password if this password contains a 0x80 character, which makes it easier for context-dependent attackers to obtain access via an authentication attempt with an initial substring of the intended password, as demonstrated by a Unicode password.",
+            "lastModifiedDate": "2016-12-08T03:02:00+0000",
+            "publishedDate": "2012-07-05T14:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4072,14 +4715,17 @@
                     "5.0.6",
                     "5.1.7",
                     "5.2.18",
-                    "5.3.14"
+                    "5.3.14",
+                    "5.4.4"
                 ]
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2012-2311",
-            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that contain a %3D sequence but no = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "threat": 7.5,
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that contain a %3D sequence but no = (equals sign) character, which allows remote attackers to execute arbitrary code by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'd' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823.",
+            "lastModifiedDate": "2018-01-18T02:29:00+0000",
+            "publishedDate": "2012-05-11T10:15:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4096,9 +4742,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-2329",
-            "summary": "Buffer overflow in the apache_request_headers function in sapi\/cgi\/cgi_main.c in PHP 5.4.x before 5.4.3 allows remote attackers to cause a denial of service (application crash) via a long string in the header of an HTTP request. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "threat": 5,
+            "summary": "Buffer overflow in the apache_request_headers function in sapi\/cgi\/cgi_main.c in PHP 5.4.x before 5.4.3 allows remote attackers to cause a denial of service (application crash) via a long string in the header of an HTTP request.",
+            "lastModifiedDate": "2017-08-29T01:31:00+0000",
+            "publishedDate": "2012-05-11T10:15:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.3"
@@ -4106,9 +4754,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2012-2335",
-            "summary": "php-wrapper.fcgi does not properly handle command-line arguments, which allows remote attackers to bypass a protection mechanism in PHP 5.3.12 and 5.4.2 and execute arbitrary code by leveraging improper interaction between the PHP sapi\/cgi\/cgi_main.c component and a query string beginning with a +- sequence. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "threat": 7.5,
+            "summary": "php-wrapper.fcgi does not properly handle command-line arguments, which allows remote attackers to bypass a protection mechanism in PHP 5.3.12 and 5.4.2 and execute arbitrary code by leveraging improper interaction between the PHP sapi\/cgi\/cgi_main.c component and a query string beginning with a +- sequence.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2012-05-11T10:15:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.13",
@@ -4117,9 +4767,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-2336",
-            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to cause a denial of service (resource consumption) by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'T' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823. \n Publish Date : 2012-05-11 Last Update Date : 2013-07-23",
+            "threat": 5,
+            "summary": "sapi\/cgi\/cgi_main.c in PHP before 5.3.13 and 5.4.x before 5.4.3, when configured as a CGI script (aka php-cgi), does not properly handle query strings that lack an = (equals sign) character, which allows remote attackers to cause a denial of service (resource consumption) by placing command-line options in the query string, related to lack of skipping a certain php_getopt for the 'T' case.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1823.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2012-05-11T10:15:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4136,9 +4788,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2012-2376",
-            "summary": "Buffer overflow in the com_print_typeinfo function in PHP 5.4.3 and earlier on Windows allows remote attackers to execute arbitrary code via crafted arguments that trigger incorrect handling of COM object VARIANT types, as exploited in the wild in May 2012. \n Publish Date : 2012-05-21 Last Update Date : 2012-08-16",
+            "threat": 10,
+            "summary": "Buffer overflow in the com_print_typeinfo function in PHP 5.4.3 and earlier on Windows allows remote attackers to execute arbitrary code via crafted arguments that trigger incorrect handling of COM object VARIANT types, as exploited in the wild in May 2012.",
+            "lastModifiedDate": "2017-08-29T01:31:00+0000",
+            "publishedDate": "2012-05-21T15:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4155,9 +4809,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2012-2386",
-            "summary": "Integer overflow in the phar_parse_tarfile function in tar.c in the phar extension in PHP before 5.3.14 and 5.4.x before 5.4.4 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted tar file that triggers a heap-based buffer overflow. \n Publish Date : 2012-07-07 Last Update Date : 2012-09-21",
+            "threat": 7.5,
+            "summary": "Integer overflow in the phar_parse_tarfile function in tar.c in the phar extension in PHP before 5.3.14 and 5.4.x before 5.4.4 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted tar file that triggers a heap-based buffer overflow.",
+            "lastModifiedDate": "2012-09-22T03:32:00+0000",
+            "publishedDate": "2012-07-07T10:21:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4174,9 +4830,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2012-2688",
-            "summary": "Unspecified vulnerability in the _php_stream_scandir function in the stream implementation in PHP before 5.3.15 and 5.4.x before 5.4.5 has unknown impact and remote attack vectors, related to an \"overflow.\" \n Publish Date : 2012-07-20 Last Update Date : 2013-10-10",
+            "threat": 10,
+            "summary": "Unspecified vulnerability in the _php_stream_scandir function in the stream implementation in PHP before 5.3.15 and 5.4.x before 5.4.5 has unknown impact and remote attack vectors, related to an \"overflow.\"",
+            "lastModifiedDate": "2017-12-22T02:29:00+0000",
+            "publishedDate": "2012-07-20T10:40:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4193,9 +4851,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-3365",
-            "summary": "The SQLite functionality in PHP before 5.3.15 allows remote attackers to bypass the open_basedir protection mechanism via unspecified vectors. \n Publish Date : 2012-07-20 Last Update Date : 2013-06-25",
+            "threat": 5,
+            "summary": "The SQLite functionality in PHP before 5.3.15 allows remote attackers to bypass the open_basedir protection mechanism via unspecified vectors.",
+            "lastModifiedDate": "2017-12-01T02:29:00+0000",
+            "publishedDate": "2012-07-20T10:40:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4211,9 +4871,11 @@
             }
         },
         {
-            "threat": "2.6",
             "cveid": "CVE-2012-3450",
-            "summary": "pdo_sql_parser.re in the PDO extension in PHP before 5.3.14 and 5.4.x before 5.4.4 does not properly determine the end of the query string during parsing of prepared statements, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted parameter value. \n Publish Date : 2012-08-06 Last Update Date : 2013-04-18",
+            "threat": 2.6,
+            "summary": "pdo_sql_parser.re in the PDO extension in PHP before 5.3.14 and 5.4.x before 5.4.4 does not properly determine the end of the query string during parsing of prepared statements, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted parameter value.",
+            "lastModifiedDate": "2013-04-19T03:23:00+0000",
+            "publishedDate": "2012-08-06T16:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.14",
@@ -4222,9 +4884,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2012-4388",
-            "summary": "The sapi_header_op function in main\/SAPI.c in PHP 5.4.0RC2 through 5.4.0 does not properly determine a pointer during checks for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-1398. \n Publish Date : 2012-09-07 Last Update Date : 2013-09-11",
+            "threat": 4.3,
+            "summary": "The sapi_header_op function in main\/SAPI.c in PHP 5.4.0RC2 through 5.4.0 does not properly determine a pointer during checks for %0D sequences (aka carriage return characters), which allows remote attackers to bypass an HTTP response-splitting protection mechanism via a crafted URL, related to improper interaction between the PHP header function and certain browsers, as demonstrated by Internet Explorer and Google Chrome.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2011-1398.",
+            "lastModifiedDate": "2013-09-12T03:28:00+0000",
+            "publishedDate": "2012-09-07T22:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.1"
@@ -4232,9 +4896,11 @@
             }
         },
         {
-            "threat": "6.0",
             "cveid": "CVE-2012-5381",
-            "summary": "** DISPUTED ** Untrusted search path vulnerability in the installation functionality in PHP 5.3.17, when installed in the top-level C:\\ directory, might allow local users to gain privileges via a Trojan horse DLL in the C:\\PHP directory, which may be added to the PATH system environment variable by an administrator, as demonstrated by a Trojan horse wlbsctrl.dll file used by the \"IKE and AuthIP IPsec Keying Modules\" system service in Windows Vista SP1, Windows Server 2008 SP2, Windows 7 SP1, and Windows 8 Release Preview.  NOTE: CVE disputes this issue because the unsafe PATH is established only by a separate administrative action that is not a default part of the PHP installation. \n Publish Date : 2012-10-11 Last Update Date : 2013-03-01",
+            "threat": 6,
+            "summary": "** DISPUTED ** Untrusted search path vulnerability in the installation functionality in PHP 5.3.17, when installed in the top-level C:\\ directory, might allow local users to gain privileges via a Trojan horse DLL in the C:\\PHP directory, which may be added to the PATH system environment variable by an administrator, as demonstrated by a Trojan horse wlbsctrl.dll file used by the \"IKE and AuthIP IPsec Keying Modules\" system service in Windows Vista SP1, Windows Server 2008 SP2, Windows 7 SP1, and Windows 8 Release Preview.  NOTE: CVE disputes this issue because the unsafe PATH is established only by a separate administrative action that is not a default part of the PHP installation.",
+            "lastModifiedDate": "2013-03-02T04:47:00+0000",
+            "publishedDate": "2012-10-11T10:51:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.18"
@@ -4242,9 +4908,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2012-6113",
-            "summary": "The openssl_encrypt function in ext\/openssl\/openssl.c in PHP 5.3.9 through 5.3.13 does not initialize a certain variable, which allows remote attackers to obtain sensitive information from process memory by providing zero bytes of input data. \n Publish Date : 2013-01-19 Last Update Date : 2013-02-02",
+            "threat": 5,
+            "summary": "The openssl_encrypt function in ext\/openssl\/openssl.c in PHP 5.3.9 through 5.3.13 does not initialize a certain variable, which allows remote attackers to obtain sensitive information from process memory by providing zero bytes of input data.",
+            "lastModifiedDate": "2013-02-02T05:10:00+0000",
+            "publishedDate": "2013-01-19T21:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.14"
@@ -4252,9 +4920,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2013-1635",
-            "summary": "ext\/soap\/soap.c in PHP before 5.3.22 and 5.4.x before 5.4.13 does not validate the relationship between the soap.wsdl_cache_dir directive and the open_basedir directive, which allows remote attackers to bypass intended access restrictions by triggering the creation of cached SOAP WSDL files in an arbitrary directory. \n Publish Date : 2013-03-06 Last Update Date : 2014-01-27",
+            "threat": 7.5,
+            "summary": "ext\/soap\/soap.c in PHP before 5.3.22 and 5.4.x before 5.4.13 does not validate the relationship between the soap.wsdl_cache_dir directive and the open_basedir directive, which allows remote attackers to bypass intended access restrictions by triggering the creation of cached SOAP WSDL files in an arbitrary directory.",
+            "lastModifiedDate": "2014-01-28T04:51:00+0000",
+            "publishedDate": "2013-03-06T13:10:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4266,14 +4936,17 @@
                     "5.1.7",
                     "5.2.18",
                     "5.3.22",
+                    "5.3.23",
                     "5.4.13"
                 ]
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2013-1643",
-            "summary": "The SOAP parser in PHP before 5.3.23 and 5.4.x before 5.4.13 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2013-1824. \n Publish Date : 2013-03-06 Last Update Date : 2014-01-27",
+            "threat": 5,
+            "summary": "The SOAP parser in PHP before 5.3.23 and 5.4.x before 5.4.13 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2013-1824.",
+            "lastModifiedDate": "2014-01-28T04:51:00+0000",
+            "publishedDate": "2013-03-06T13:10:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4290,9 +4963,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2013-1824",
-            "summary": "The SOAP parser in PHP before 5.3.22 and 5.4.x before 5.4.12 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions. \n Publish Date : 2013-09-16 Last Update Date : 2013-09-18",
+            "threat": 4.3,
+            "summary": "The SOAP parser in PHP before 5.3.22 and 5.4.x before 5.4.12 allows remote attackers to read arbitrary files via a SOAP WSDL file containing an XML external entity declaration in conjunction with an entity reference, related to an XML External Entity (XXE) issue in the soap_xmlParseFile and soap_xmlParseMemory functions.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2013-09-16T13:02:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.22",
@@ -4301,9 +4976,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2013-2110",
-            "summary": "Heap-based buffer overflow in the php_quot_print_encode function in ext\/standard\/quot_print.c in PHP before 5.3.26 and 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted argument to the quoted_printable_encode function. \n Publish Date : 2013-06-21 Last Update Date : 2013-09-17",
+            "threat": 5,
+            "summary": "Heap-based buffer overflow in the php_quot_print_encode function in ext\/standard\/quot_print.c in PHP before 5.3.26 and 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted argument to the quoted_printable_encode function.",
+            "lastModifiedDate": "2016-12-31T02:59:00+0000",
+            "publishedDate": "2013-06-21T20:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4320,9 +4997,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2013-3735",
-            "summary": "** DISPUTED ** The Zend Engine in PHP before 5.4.16 RC1, and 5.5.0 before RC2, does not properly determine whether a parser error occurred, which allows context-dependent attackers to cause a denial of service (memory consumption and application crash) via a crafted function definition, as demonstrated by an attack within a shared web-hosting environment.  NOTE: the vendor's http:\/\/php.net\/security-note.php page says \"for critical security situations you should be using OS-level security by running multiple web servers each as their own user id.\" \n Publish Date : 2013-05-31 Last Update Date : 2013-06-03",
+            "threat": 5,
+            "summary": "** DISPUTED ** The Zend Engine in PHP before 5.4.16 RC1, and 5.5.0 before RC2, does not properly determine whether a parser error occurred, which allows context-dependent attackers to cause a denial of service (memory consumption and application crash) via a crafted function definition, as demonstrated by an attack within a shared web-hosting environment.  NOTE: the vendor's http:\/\/php.net\/security-note.php page says \"for critical security situations you should be using OS-level security by running multiple web servers each as their own user id.\"",
+            "lastModifiedDate": "2013-06-03T04:00:00+0000",
+            "publishedDate": "2013-05-31T21:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.16",
@@ -4331,9 +5010,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2013-4113",
-            "summary": "ext\/xml\/xml.c in PHP before 5.3.27 does not properly consider parsing depth, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted document that is processed by the xml_parse_into_struct function. \n Publish Date : 2013-07-13 Last Update Date : 2014-03-05",
+            "threat": 6.8,
+            "summary": "ext\/xml\/xml.c in PHP before 5.3.27 does not properly consider parsing depth, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted document that is processed by the xml_parse_into_struct function.",
+            "lastModifiedDate": "2014-03-06T04:47:00+0000",
+            "publishedDate": "2013-07-13T13:10:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.27"
@@ -4341,9 +5022,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2013-4248",
-            "summary": "The openssl_x509_parse function in openssl.c in the OpenSSL module in PHP before 5.4.18 and 5.5.x before 5.5.2 does not properly handle a '\\0' character in a domain name in the Subject Alternative Name field of an X.509 certificate, which allows man-in-the-middle attackers to spoof arbitrary SSL servers via a crafted certificate issued by a legitimate Certification Authority, a related issue to CVE-2009-2408. \n Publish Date : 2013-08-17 Last Update Date : 2015-11-20",
+            "threat": 4.3,
+            "summary": "The openssl_x509_parse function in openssl.c in the OpenSSL module in PHP before 5.4.18 and 5.5.x before 5.5.2 does not properly handle a '\\0' character in a domain name in the Subject Alternative Name field of an X.509 certificate, which allows man-in-the-middle attackers to spoof arbitrary SSL servers via a crafted certificate issued by a legitimate Certification Authority, a related issue to CVE-2009-2408.",
+            "lastModifiedDate": "2016-11-28T19:09:00+0000",
+            "publishedDate": "2013-08-18T02:52:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4351,14 +5034,18 @@
                     "5.2.18",
                     "5.3.28",
                     "5.4.18",
-                    "5.5.2"
+                    "5.4.19",
+                    "5.5.2",
+                    "5.5.3"
                 ]
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2013-4635",
-            "summary": "Integer overflow in the SdnToJewish function in jewish.c in the Calendar component in PHP before 5.3.26 and 5.4.x before 5.4.16 allows context-dependent attackers to cause a denial of service (application hang) via a large argument to the jdtojewish function. \n Publish Date : 2013-06-21 Last Update Date : 2013-09-11",
+            "threat": 5,
+            "summary": "Integer overflow in the SdnToJewish function in jewish.c in the Calendar component in PHP before 5.3.26 and 5.4.x before 5.4.16 allows context-dependent attackers to cause a denial of service (application hang) via a large argument to the jdtojewish function.",
+            "lastModifiedDate": "2013-09-12T03:36:00+0000",
+            "publishedDate": "2013-06-21T21:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4375,9 +5062,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2013-4636",
-            "summary": "The mget function in libmagic\/softmagic.c in the Fileinfo component in PHP 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (invalid pointer dereference and application crash) via an MP3 file that triggers incorrect MIME type detection during access to an finfo object. \n Publish Date : 2013-06-21 Last Update Date : 2013-06-24",
+            "threat": 4.3,
+            "summary": "The mget function in libmagic\/softmagic.c in the Fileinfo component in PHP 5.4.x before 5.4.16 allows remote attackers to cause a denial of service (invalid pointer dereference and application crash) via an MP3 file that triggers incorrect MIME type detection during access to an finfo object.",
+            "lastModifiedDate": "2013-06-24T22:37:00+0000",
+            "publishedDate": "2013-06-21T21:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.16"
@@ -4385,9 +5074,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2013-6420",
-            "summary": "The asn1_time_to_time_t function in ext\/openssl\/openssl.c in PHP before 5.3.28, 5.4.x before 5.4.23, and 5.5.x before 5.5.7 does not properly parse (1) notBefore and (2) notAfter timestamps in X.509 certificates, which allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted certificate that is not properly handled by the openssl_x509_parse function. \n Publish Date : 2013-12-16 Last Update Date : 2015-05-18",
+            "threat": 7.5,
+            "summary": "The asn1_time_to_time_t function in ext\/openssl\/openssl.c in PHP before 5.3.28, 5.4.x before 5.4.23, and 5.5.x before 5.5.7 does not properly parse (1) notBefore and (2) notAfter timestamps in X.509 certificates, which allows remote attackers to execute arbitrary code or cause a denial of service (memory corruption) via a crafted certificate that is not properly handled by the openssl_x509_parse function.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2013-12-17T04:46:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.28",
@@ -4397,9 +5088,11 @@
             }
         },
         {
-            "threat": "4.6",
             "cveid": "CVE-2013-6501",
-            "summary": "The default soap.wsdl_cache_dir setting in (1) php.ini-production and (2) php.ini-development in PHP through 5.6.7 specifies the \/tmp directory, which makes it easier for local users to conduct WSDL injection attacks by creating a file under \/tmp with a predictable filename that is used by the get_sdl function in ext\/soap\/php_sdl.c. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-22",
+            "threat": 4.6,
+            "summary": "The default soap.wsdl_cache_dir setting in (1) php.ini-production and (2) php.ini-development in PHP through 5.6.7 specifies the \/tmp directory, which makes it easier for local users to conduct WSDL injection attacks by creating a file under \/tmp with a predictable filename that is used by the get_sdl function in ext\/soap\/php_sdl.c.",
+            "lastModifiedDate": "2016-11-30T02:59:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.8"
@@ -4407,19 +5100,25 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2013-6712",
-            "summary": "The scan function in ext\/date\/lib\/parse_iso_intervals.c in PHP through 5.5.6 does not properly restrict creation of DateInterval objects, which might allow remote attackers to cause a denial of service (heap-based buffer over-read) via a crafted interval specification. \n Publish Date : 2013-11-27 Last Update Date : 2015-05-18",
+            "threat": 5,
+            "summary": "The scan function in ext\/date\/lib\/parse_iso_intervals.c in PHP through 5.5.6 does not properly restrict creation of DateInterval objects, which might allow remote attackers to cause a denial of service (heap-based buffer over-read) via a crafted interval specification.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2013-11-28T04:37:00+0000",
             "fixVersions": {
                 "base": [
-                    "5.5.7"
+                    "5.4.24",
+                    "5.5.7",
+                    "5.5.8"
                 ]
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2013-7226",
-            "summary": "Integer overflow in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via an imagecrop function call with a large x dimension value, leading to a heap-based buffer overflow. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-13",
+            "threat": 6.8,
+            "summary": "Integer overflow in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via an imagecrop function call with a large x dimension value, leading to a heap-based buffer overflow.",
+            "lastModifiedDate": "2017-08-29T01:34:00+0000",
+            "publishedDate": "2014-02-18T11:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4427,9 +5126,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2013-7327",
-            "summary": "The gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check return values, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via invalid imagecrop arguments that lead to use of a NULL pointer as a return value, a different vulnerability than CVE-2013-7226. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-08",
+            "threat": 6.8,
+            "summary": "The gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check return values, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via invalid imagecrop arguments that lead to use of a NULL pointer as a return value, a different vulnerability than CVE-2013-7226.",
+            "lastModifiedDate": "2016-09-21T15:35:00+0000",
+            "publishedDate": "2014-02-18T11:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4437,9 +5138,11 @@
             }
         },
         {
-            "threat": "5.8",
             "cveid": "CVE-2013-7328",
-            "summary": "Multiple integer signedness errors in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allow remote attackers to cause a denial of service (application crash) or obtain sensitive information via an imagecrop function call with a negative value for the (1) x or (2) y dimension, a different vulnerability than CVE-2013-7226. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-08",
+            "threat": 5.8,
+            "summary": "Multiple integer signedness errors in the gdImageCrop function in ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 allow remote attackers to cause a denial of service (application crash) or obtain sensitive information via an imagecrop function call with a negative value for the (1) x or (2) y dimension, a different vulnerability than CVE-2013-7226.",
+            "lastModifiedDate": "2014-03-08T05:12:00+0000",
+            "publishedDate": "2014-02-18T11:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4447,9 +5150,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2013-7345",
+            "threat": 5,
             "summary": "The BEGIN regular expression in the awk script detector in magic\/Magdir\/commands in file before 5.15 uses multiple wildcards with unlimited repetitions, which allows context-dependent attackers to cause a denial of service (CPU consumption) via a crafted ASCII file that triggers a large amount of backtracking, as demonstrated via a file with many newline characters.",
+            "lastModifiedDate": "2014-11-19T02:59:00+0000",
+            "publishedDate": "2014-03-24T16:31:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.27",
@@ -4458,9 +5163,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2013-7456",
+            "threat": 7.6,
             "summary": "gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.1.1, as used in PHP before 5.5.36, 5.6.x before 5.6.22, and 7.x before 7.0.7, allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a crafted image that is mishandled by the imagescale function.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.7"
@@ -4468,9 +5175,11 @@
             }
         },
         {
-            "threat": "7.2",
             "cveid": "CVE-2014-0185",
-            "summary": "sapi\/fpm\/fpm\/fpm_unix.c in the FastCGI Process Manager (FPM) in PHP before 5.4.28 and 5.5.x before 5.5.12 uses 0666 permissions for the UNIX socket, which allows local users to gain privileges via a crafted FastCGI client. \n Publish Date : 2014-05-06 Last Update Date : 2014-09-23",
+            "threat": 7.2,
+            "summary": "sapi\/fpm\/fpm\/fpm_unix.c in the FastCGI Process Manager (FPM) in PHP before 5.4.28 and 5.5.x before 5.5.12 uses 0666 permissions for the UNIX socket, which allows local users to gain privileges via a crafted FastCGI client.",
+            "lastModifiedDate": "2017-01-07T02:59:00+0000",
+            "publishedDate": "2014-05-06T10:44:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.28",
@@ -4479,9 +5188,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2014-0207",
-            "summary": "The cdf_read_short_sector function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (assertion failure and application exit) via a crafted CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
+            "threat": 4.3,
+            "summary": "The cdf_read_short_sector function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (assertion failure and application exit) via a crafted CDF file.",
+            "lastModifiedDate": "2016-11-28T19:10:00+0000",
+            "publishedDate": "2014-07-09T11:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4490,9 +5201,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-0236",
-            "summary": "file before 5.18, as used in the Fileinfo component in PHP before 5.6.0, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a zero root_storage value in a CDF file, related to cdf.c and readcdf.c. \n Publish Date : 2016-05-16 Last Update Date : 2016-05-18",
+            "threat": 7.5,
+            "summary": "file before 5.18, as used in the Fileinfo component in PHP before 5.6.0, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a zero root_storage value in a CDF file, related to cdf.c and readcdf.c.",
+            "lastModifiedDate": "2016-05-18T18:26:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.36"
@@ -4500,9 +5213,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-0237",
-            "summary": "The cdf_unpack_summary_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (performance degradation) by triggering many file_printf calls. \n Publish Date : 2014-06-01 Last Update Date : 2015-04-13",
+            "threat": 5,
+            "summary": "The cdf_unpack_summary_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (performance degradation) by triggering many file_printf calls.",
+            "lastModifiedDate": "2017-01-07T02:59:00+0000",
+            "publishedDate": "2014-06-01T04:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4515,9 +5230,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-0238",
-            "summary": "The cdf_read_property_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (infinite loop or out-of-bounds memory access) via a vector that (1) has zero length or (2) is too long. \n Publish Date : 2014-06-01 Last Update Date : 2015-04-13",
+            "threat": 5,
+            "summary": "The cdf_read_property_info function in cdf.c in the Fileinfo component in PHP before 5.4.29 and 5.5.x before 5.5.13 allows remote attackers to cause a denial of service (infinite loop or out-of-bounds memory access) via a vector that (1) has zero length or (2) is too long.",
+            "lastModifiedDate": "2017-01-07T02:59:00+0000",
+            "publishedDate": "2014-06-01T04:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4525,14 +5242,17 @@
                     "5.2.18",
                     "5.3.29",
                     "5.4.27",
+                    "5.4.29",
                     "5.5.13"
                 ]
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-1943",
+            "threat": 5,
             "summary": "Fine Free file before 5.17 allows context-dependent attackers to cause a denial of service (infinite recursion, CPU consumption, and crash) via a crafted indirect offset value in the magic of a file.",
+            "lastModifiedDate": "2014-11-19T03:00:00+0000",
+            "publishedDate": "2014-02-18T19:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.26",
@@ -4541,9 +5261,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-2020",
-            "summary": "ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check data types, which might allow remote attackers to obtain sensitive information by using a (1) string or (2) array data type in place of a numeric data type, as demonstrated by an imagecrop function call with a string for the x dimension value, a different vulnerability than CVE-2013-7226. \n Publish Date : 2014-02-18 Last Update Date : 2014-03-08",
+            "threat": 5,
+            "summary": "ext\/gd\/gd.c in PHP 5.5.x before 5.5.9 does not check data types, which might allow remote attackers to obtain sensitive information by using a (1) string or (2) array data type in place of a numeric data type, as demonstrated by an imagecrop function call with a string for the x dimension value, a different vulnerability than CVE-2013-7226.",
+            "lastModifiedDate": "2014-03-08T05:13:00+0000",
+            "publishedDate": "2014-02-18T11:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.9"
@@ -4551,9 +5273,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2014-2497",
-            "summary": "The gdImageCreateFromXpm function in gdxpm.c in libgd, as used in PHP 5.4.26 and earlier, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted color table in an XPM file. \n Publish Date : 2014-03-21 Last Update Date : 2015-04-14",
+            "threat": 4.3,
+            "summary": "The gdImageCreateFromXpm function in gdxpm.c in libgd, as used in PHP 5.4.26 and earlier, allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted color table in an XPM file.",
+            "lastModifiedDate": "2017-01-07T02:59:00+0000",
+            "publishedDate": "2014-03-21T14:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -4565,9 +5289,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-3478",
-            "summary": "Buffer overflow in the mconvert function in softmagic.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (application crash) via a crafted Pascal string in a FILE_PSTRING conversion. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
+            "threat": 5,
+            "summary": "Buffer overflow in the mconvert function in softmagic.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, allows remote attackers to cause a denial of service (application crash) via a crafted Pascal string in a FILE_PSTRING conversion.",
+            "lastModifiedDate": "2016-11-28T19:11:00+0000",
+            "publishedDate": "2014-07-09T11:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4576,9 +5302,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2014-3479",
-            "summary": "The cdf_check_stream_offset function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, relies on incorrect sector-size data, which allows remote attackers to cause a denial of service (application crash) via a crafted stream offset in a CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
+            "threat": 4.3,
+            "summary": "The cdf_check_stream_offset function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, relies on incorrect sector-size data, which allows remote attackers to cause a denial of service (application crash) via a crafted stream offset in a CDF file.",
+            "lastModifiedDate": "2016-11-28T19:11:00+0000",
+            "publishedDate": "2014-07-09T11:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4587,9 +5315,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2014-3480",
-            "summary": "The cdf_count_chain function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate sector-count data, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
+            "threat": 4.3,
+            "summary": "The cdf_count_chain function in cdf.c in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate sector-count data, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.",
+            "lastModifiedDate": "2016-11-28T19:11:00+0000",
+            "publishedDate": "2014-07-09T11:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4598,9 +5328,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2014-3487",
-            "summary": "The cdf_read_property_info function in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate a stream offset, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file. \n Publish Date : 2014-07-09 Last Update Date : 2015-04-13",
+            "threat": 4.3,
+            "summary": "The cdf_read_property_info function in file before 5.19, as used in the Fileinfo component in PHP before 5.4.30 and 5.5.x before 5.5.14, does not properly validate a stream offset, which allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.",
+            "lastModifiedDate": "2016-11-28T19:11:00+0000",
+            "publishedDate": "2014-07-09T11:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4609,9 +5341,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-3515",
-            "summary": "The SPL component in PHP before 5.4.30 and 5.5.x before 5.5.14 incorrectly anticipates that certain data structures will have the array data type after unserialization, which allows remote attackers to execute arbitrary code via a crafted string that triggers use of a Hashtable destructor, related to \"type confusion\" issues in (1) ArrayObject and (2) SPLObjectStorage. \n Publish Date : 2014-07-09 Last Update Date : 2014-11-18",
+            "threat": 7.5,
+            "summary": "The SPL component in PHP before 5.4.30 and 5.5.x before 5.5.14 incorrectly anticipates that certain data structures will have the array data type after unserialization, which allows remote attackers to execute arbitrary code via a crafted string that triggers use of a Hashtable destructor, related to \"type confusion\" issues in (1) ArrayObject and (2) SPLObjectStorage.",
+            "lastModifiedDate": "2017-01-07T03:00:00+0000",
+            "publishedDate": "2014-07-09T11:07:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.30",
@@ -4620,9 +5354,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-3538",
+            "threat": 5,
             "summary": "file before 5.19 does not properly restrict the amount of data read during a regex search, which allows remote attackers to cause a denial of service (CPU consumption) via a crafted file that triggers backtracking during processing of an awk rule.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2013-7345.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2014-07-03T14:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.16"
@@ -4630,9 +5366,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2014-3587",
-            "summary": "Integer overflow in the cdf_read_property_info function in cdf.c in file through 5.19, as used in the Fileinfo component in PHP before 5.4.32 and 5.5.x before 5.5.16, allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1571. \n Publish Date : 2014-08-22 Last Update Date : 2015-04-13",
+            "threat": 4.3,
+            "summary": "Integer overflow in the cdf_read_property_info function in cdf.c in file through 5.19, as used in the Fileinfo component in PHP before 5.4.32 and 5.5.x before 5.5.16, allows remote attackers to cause a denial of service (application crash) via a crafted CDF file.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2012-1571.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2014-08-23T01:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -4641,9 +5379,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2014-3597",
-            "summary": "Multiple buffer overflows in the php_parserr function in ext\/standard\/dns.c in PHP before 5.4.32 and 5.5.x before 5.5.16 allow remote DNS servers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted DNS record, related to the dns_get_record function and the dn_expand function.  NOTE: this issue exists because of an incomplete fix for CVE-2014-4049. \n Publish Date : 2014-08-22 Last Update Date : 2015-05-11",
+            "threat": 6.8,
+            "summary": "Multiple buffer overflows in the php_parserr function in ext\/standard\/dns.c in PHP before 5.4.32 and 5.5.x before 5.5.16 allow remote DNS servers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted DNS record, related to the dns_get_record function and the dn_expand function.  NOTE: this issue exists because of an incomplete fix for CVE-2014-4049.",
+            "lastModifiedDate": "2017-01-07T03:00:00+0000",
+            "publishedDate": "2014-08-23T01:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -4652,9 +5392,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-3668",
-            "summary": "Buffer overflow in the date_from_ISO8601 function in the mkgmtime implementation in libxmlrpc\/xmlrpc.c in the XMLRPC extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) via (1) a crafted first argument to the xmlrpc_set_type function or (2) a crafted argument to the xmlrpc_decode function, related to an out-of-bounds read operation. \n Publish Date : 2014-10-29 Last Update Date : 2015-05-13",
+            "threat": 5,
+            "summary": "Buffer overflow in the date_from_ISO8601 function in the mkgmtime implementation in libxmlrpc\/xmlrpc.c in the XMLRPC extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) via (1) a crafted first argument to the xmlrpc_set_type function or (2) a crafted argument to the xmlrpc_decode function, related to an out-of-bounds read operation.",
+            "lastModifiedDate": "2016-10-18T03:44:00+0000",
+            "publishedDate": "2014-10-29T10:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -4664,9 +5406,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-3669",
-            "summary": "Integer overflow in the object_custom function in ext\/standard\/var_unserializer.c in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an argument to the unserialize function that triggers calculation of a large length value. \n Publish Date : 2014-10-29 Last Update Date : 2015-04-17",
+            "threat": 7.5,
+            "summary": "Integer overflow in the object_custom function in ext\/standard\/var_unserializer.c in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an argument to the unserialize function that triggers calculation of a large length value.",
+            "lastModifiedDate": "2017-01-03T02:59:00+0000",
+            "publishedDate": "2014-10-29T10:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -4676,9 +5420,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2014-3670",
-            "summary": "The exif_ifd_make_value function in exif.c in the EXIF extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 operates on floating-point arrays incorrectly, which allows remote attackers to cause a denial of service (heap memory corruption and application crash) or possibly execute arbitrary code via a crafted JPEG image with TIFF thumbnail data that is improperly handled by the exif_thumbnail function. \n Publish Date : 2014-10-29 Last Update Date : 2015-05-13",
+            "threat": 6.8,
+            "summary": "The exif_ifd_make_value function in exif.c in the EXIF extension in PHP before 5.4.34, 5.5.x before 5.5.18, and 5.6.x before 5.6.2 operates on floating-point arrays incorrectly, which allows remote attackers to cause a denial of service (heap memory corruption and application crash) or possibly execute arbitrary code via a crafted JPEG image with TIFF thumbnail data that is improperly handled by the exif_thumbnail function.",
+            "lastModifiedDate": "2016-10-18T03:44:00+0000",
+            "publishedDate": "2014-10-29T10:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.34",
@@ -4688,9 +5434,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-3710",
-            "summary": "The donote function in readelf.c in file through 5.20, as used in the Fileinfo component in PHP 5.4.34, does not ensure that sufficient note headers are present, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted ELF file. \n Publish Date : 2014-11-05 Last Update Date : 2015-04-13",
+            "threat": 5,
+            "summary": "The donote function in readelf.c in file through 5.20, as used in the Fileinfo component in PHP 5.4.34, does not ensure that sufficient note headers are present, which allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted ELF file.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2014-11-05T11:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.35",
@@ -4700,49 +5448,11 @@
             }
         },
         {
-            "threat": "3.3",
             "cveid": "CVE-2014-3981",
-            "summary": "acinclude.m4, as used in the configure script in PHP 5.5.13 and earlier, allows local users to overwrite arbitrary files via a symlink attack on the \/tmp\/phpglibccheck file. \n Publish Date : 2014-06-08 Last Update Date : 2015-04-13",
-            "fixVersions": {
-                "base": [
-                    "5.5.14"
-                ]
-            }
-        },
-        {
-            "threat": "5.1",
-            "cveid": "CVE-2014-4049",
-            "summary": "Heap-based buffer overflow in the php_parserr function in ext\/standard\/dns.c in PHP 5.6.0beta4 and earlier allows remote servers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted DNS TXT record, related to the dns_get_record function. \n Publish Date : 2014-06-18 Last Update Date : 2015-08-28",
-            "fixVersions": {
-                "base": [
-                    "5.6.1"
-                ]
-            }
-        },
-        {
-            "threat": "4.6",
-            "cveid": "CVE-2014-4670",
-            "summary": "Use-after-free vulnerability in ext\/spl\/spl_dllist.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted iterator usage within applications in certain web-hosting environments. \n Publish Date : 2014-07-10 Last Update Date : 2015-04-13",
-            "fixVersions": {
-                "base": [
-                    "5.5.15"
-                ]
-            }
-        },
-        {
-            "threat": "4.6",
-            "cveid": "CVE-2014-4698",
-            "summary": "Use-after-free vulnerability in ext\/spl\/spl_array.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted ArrayIterator usage within applications in certain web-hosting environments. \n Publish Date : 2014-07-10 Last Update Date : 2015-04-13",
-            "fixVersions": {
-                "base": [
-                    "5.5.15"
-                ]
-            }
-        },
-        {
-            "threat": "2.6",
-            "cveid": "CVE-2014-4721",
-            "summary": "The phpinfo implementation in ext\/standard\/info.c in PHP before 5.4.30 and 5.5.x before 5.5.14 does not ensure use of the string data type for the PHP_AUTH_PW, PHP_AUTH_TYPE, PHP_AUTH_USER, and PHP_SELF variables, which might allow context-dependent attackers to obtain sensitive information from process memory by using the integer data type with crafted values, related to a \"type confusion\" vulnerability, as demonstrated by reading a private SSL key in an Apache HTTP Server web-hosting environment with mod_ssl and a PHP 5.3.x mod_php. \n Publish Date : 2014-07-06 Last Update Date : 2014-11-18",
+            "threat": 3.3,
+            "summary": "acinclude.m4, as used in the configure script in PHP 5.5.13 and earlier, allows local users to overwrite arbitrary files via a symlink attack on the \/tmp\/phpglibccheck file.",
+            "lastModifiedDate": "2017-01-07T03:00:00+0000",
+            "publishedDate": "2014-06-08T18:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.29",
@@ -4752,9 +5462,62 @@
             }
         },
         {
-            "threat": "6.4",
+            "cveid": "CVE-2014-4049",
+            "threat": 5.1,
+            "summary": "Heap-based buffer overflow in the php_parserr function in ext\/standard\/dns.c in PHP 5.6.0beta4 and earlier allows remote servers to cause a denial of service (crash) and possibly execute arbitrary code via a crafted DNS TXT record, related to the dns_get_record function.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2014-06-18T19:55:00+0000",
+            "fixVersions": {
+                "base": [
+                    "5.6.1"
+                ]
+            }
+        },
+        {
+            "cveid": "CVE-2014-4670",
+            "threat": 4.6,
+            "summary": "Use-after-free vulnerability in ext\/spl\/spl_dllist.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted iterator usage within applications in certain web-hosting environments.",
+            "lastModifiedDate": "2017-01-07T03:00:00+0000",
+            "publishedDate": "2014-07-10T11:06:00+0000",
+            "fixVersions": {
+                "base": [
+                    "5.5.15"
+                ]
+            }
+        },
+        {
+            "cveid": "CVE-2014-4698",
+            "threat": 4.6,
+            "summary": "Use-after-free vulnerability in ext\/spl\/spl_array.c in the SPL component in PHP through 5.5.14 allows context-dependent attackers to cause a denial of service or possibly have unspecified other impact via crafted ArrayIterator usage within applications in certain web-hosting environments.",
+            "lastModifiedDate": "2017-01-07T03:00:00+0000",
+            "publishedDate": "2014-07-10T11:06:00+0000",
+            "fixVersions": {
+                "base": [
+                    "5.5.15"
+                ]
+            }
+        },
+        {
+            "cveid": "CVE-2014-4721",
+            "threat": 2.6,
+            "summary": "The phpinfo implementation in ext\/standard\/info.c in PHP before 5.4.30 and 5.5.x before 5.5.14 does not ensure use of the string data type for the PHP_AUTH_PW, PHP_AUTH_TYPE, PHP_AUTH_USER, and PHP_SELF variables, which might allow context-dependent attackers to obtain sensitive information from process memory by using the integer data type with crafted values, related to a \"type confusion\" vulnerability, as demonstrated by reading a private SSL key in an Apache HTTP Server web-hosting environment with mod_ssl and a PHP 5.3.x mod_php.",
+            "lastModifiedDate": "2017-01-07T03:00:00+0000",
+            "publishedDate": "2014-07-06T23:55:00+0000",
+            "fixVersions": {
+                "base": [
+                    "5.3.29",
+                    "5.4.30",
+                    "5.5.14",
+                    "5.6.0"
+                ]
+            }
+        },
+        {
             "cveid": "CVE-2014-5120",
-            "summary": "gd_ctx.c in the GD component in PHP 5.4.x before 5.4.32 and 5.5.x before 5.5.16 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to overwrite arbitrary files via crafted input to an application that calls the (1) imagegd, (2) imagegd2, (3) imagegif, (4) imagejpeg, (5) imagepng, (6) imagewbmp, or (7) imagewebp function. \n Publish Date : 2014-08-22 Last Update Date : 2015-04-13",
+            "threat": 6.4,
+            "summary": "gd_ctx.c in the GD component in PHP 5.4.x before 5.4.32 and 5.5.x before 5.5.16 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to overwrite arbitrary files via crafted input to an application that calls the (1) imagegd, (2) imagegd2, (3) imagegif, (4) imagejpeg, (5) imagepng, (6) imagewbmp, or (7) imagewebp function.",
+            "lastModifiedDate": "2016-10-26T02:00:00+0000",
+            "publishedDate": "2014-08-23T01:55:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.32",
@@ -4763,9 +5526,11 @@
             }
         },
         {
-            "threat": "3.6",
             "cveid": "CVE-2014-5459",
-            "summary": "The PEAR_REST class in REST.php in PEAR in PHP through 5.6.0 allows local users to write to arbitrary files via a symlink attack on a (1) rest.cachefile or (2) rest.cacheid file in \/tmp\/pear\/cache\/, related to the retrieveCacheFirst and useLocalCache functions. \n Publish Date : 2014-09-27 Last Update Date : 2014-10-17",
+            "threat": 3.6,
+            "summary": "The PEAR_REST class in REST.php in PEAR in PHP through 5.6.0 allows local users to write to arbitrary files via a symlink attack on a (1) rest.cachefile or (2) rest.cacheid file in \/tmp\/pear\/cache\/, related to the retrieveCacheFirst and useLocalCache functions.",
+            "lastModifiedDate": "2016-10-26T02:00:00+0000",
+            "publishedDate": "2014-09-27T10:55:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4784,9 +5549,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-8142",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019. \n Publish Date : 2014-12-20 Last Update Date : 2015-03-17",
+            "threat": 7.5,
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.36, 5.5.x before 5.5.20, and 5.6.x before 5.6.4 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate keys within the serialized properties of an object, a different vulnerability than CVE-2004-1019.",
+            "lastModifiedDate": "2016-12-31T02:59:00+0000",
+            "publishedDate": "2014-12-20T11:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.36",
@@ -4796,9 +5563,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-8626",
-            "summary": "Stack-based buffer overflow in the date_from_ISO8601 function in ext\/xmlrpc\/libxmlrpc\/xmlrpc.c in PHP before 5.2.7 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code by including a timezone field in a date, leading to improper XML-RPC encoding. \n Publish Date : 2014-11-22 Last Update Date : 2015-04-29",
+            "threat": 7.5,
+            "summary": "Stack-based buffer overflow in the date_from_ISO8601 function in ext\/xmlrpc\/libxmlrpc\/xmlrpc.c in PHP before 5.2.7 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code by including a timezone field in a date, leading to improper XML-RPC encoding.",
+            "lastModifiedDate": "2015-04-30T02:01:00+0000",
+            "publishedDate": "2014-11-23T02:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.2.7"
@@ -4806,9 +5575,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-9425",
-            "summary": "Double free vulnerability in the zend_ts_hash_graceful_destroy function in zend_ts_hash.c in the Zend Engine in PHP through 5.5.20 and 5.6.x through 5.6.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors. \n Publish Date : 2014-12-30 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Double free vulnerability in the zend_ts_hash_graceful_destroy function in zend_ts_hash.c in the Zend Engine in PHP through 5.5.20 and 5.6.x through 5.6.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2014-12-31T02:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.21",
@@ -4817,9 +5588,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-9426",
-            "summary": "** DISPUTED ** The apprentice_load function in libmagic\/apprentice.c in the Fileinfo component in PHP through 5.6.4 attempts to perform a free operation on a stack-based character array, which allows remote attackers to cause a denial of service (memory corruption or application crash) or possibly have unspecified other impact via unknown vectors.  NOTE: this is disputed by the vendor because the standard erealloc behavior makes the free operation unreachable. \n Publish Date : 2014-12-30 Last Update Date : 2015-03-16",
+            "threat": 7.5,
+            "summary": "** DISPUTED ** The apprentice_load function in libmagic\/apprentice.c in the Fileinfo component in PHP through 5.6.4 attempts to perform a free operation on a stack-based character array, which allows remote attackers to cause a denial of service (memory corruption or application crash) or possibly have unspecified other impact via unknown vectors.  NOTE: this is disputed by the vendor because the standard erealloc behavior makes the free operation unreachable.",
+            "lastModifiedDate": "2015-03-17T02:01:00+0000",
+            "publishedDate": "2014-12-31T02:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4829,9 +5602,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-9427",
-            "summary": "sapi\/cgi\/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping. \n Publish Date : 2015-01-02 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "sapi\/cgi\/cgi_main.c in the CGI component in PHP through 5.4.36, 5.5.x through 5.5.20, and 5.6.x through 5.6.4, when mmap is used to read a .php file, does not properly consider the mapping's length during processing of an invalid file that begins with a # character and lacks a newline character, which causes an out-of-bounds read and might (1) allow remote attackers to obtain sensitive information from php-cgi process memory by leveraging the ability to upload a .php file or (2) trigger unexpected code execution if a valid PHP script is present in memory locations adjacent to the mapping.",
+            "lastModifiedDate": "2016-12-31T02:59:00+0000",
+            "publishedDate": "2015-01-03T02:59:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -4850,9 +5625,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-9652",
-            "summary": "The mconvert function in softmagic.c in file before 5.21, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not properly handle a certain string-length field during a copy of a truncated version of a Pascal string, which might allow remote attackers to cause a denial of service (out-of-bounds memory access and application crash) via a crafted file. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 5,
+            "summary": "The mconvert function in softmagic.c in file before 5.21, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not properly handle a certain string-length field during a copy of a truncated version of a Pascal string, which might allow remote attackers to cause a denial of service (out-of-bounds memory access and application crash) via a crafted file.",
+            "lastModifiedDate": "2017-07-01T01:29:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4862,9 +5639,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-9653",
-            "summary": "readelf.c in file before 5.22, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not consider that pread calls sometimes read only a subset of the available data, which allows remote attackers to cause a denial of service (uninitialized memory access) or possibly have unspecified other impact via a crafted ELF file. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-22",
+            "threat": 7.5,
+            "summary": "readelf.c in file before 5.22, as used in the Fileinfo component in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5, does not consider that pread calls sometimes read only a subset of the available data, which allows remote attackers to cause a denial of service (uninitialized memory access) or possibly have unspecified other impact via a crafted ELF file.",
+            "lastModifiedDate": "2018-06-16T01:29:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4874,9 +5653,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2014-9705",
-            "summary": "Heap-based buffer overflow in the enchant_broker_request_dict function in ext\/enchant\/enchant.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allows remote attackers to execute arbitrary code via vectors that trigger creation of multiple dictionaries. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Heap-based buffer overflow in the enchant_broker_request_dict function in ext\/enchant\/enchant.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allows remote attackers to execute arbitrary code via vectors that trigger creation of multiple dictionaries.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.38",
@@ -4886,9 +5667,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2014-9709",
-            "summary": "The GetCode_ function in gd_gif_in.c in GD 2.1.1 and earlier, as used in PHP before 5.5.21 and 5.6.x before 5.6.5, allows remote attackers to cause a denial of service (buffer over-read and application crash) via a crafted GIF image that is improperly handled by the gdImageCreateFromGif function. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 5,
+            "summary": "The GetCode_ function in gd_gif_in.c in GD 2.1.1 and earlier, as used in PHP before 5.5.21 and 5.6.x before 5.6.5, allows remote attackers to cause a denial of service (buffer over-read and application crash) via a crafted GIF image that is improperly handled by the gdImageCreateFromGif function.",
+            "lastModifiedDate": "2019-10-09T23:12:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4898,9 +5681,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2014-9767",
-            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in ext\/zip\/php_zip.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 and ext\/zip\/ext_zip.cpp in HHVM before 3.12.1 allows remote attackers to create arbitrary empty directories via a crafted ZIP archive. \n Publish Date : 2016-05-21 Last Update Date : 2016-11-30",
+            "threat": 4.3,
+            "summary": "Directory traversal vulnerability in the ZipArchive::extractTo function in ext\/zip\/php_zip.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 and ext\/zip\/ext_zip.cpp in HHVM before 3.12.1 allows remote attackers to create arbitrary empty directories via a crafted ZIP archive.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.46",
@@ -4910,9 +5695,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-0231",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate numerical keys within the serialized properties of an object.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-8142. \n Publish Date : 2015-01-27 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages improper handling of duplicate numerical keys within the serialized properties of an object.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-8142.",
+            "lastModifiedDate": "2016-12-31T02:59:00+0000",
+            "publishedDate": "2015-01-27T20:03:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4922,9 +5709,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2015-0232",
-            "summary": "The exif_process_unicode function in ext\/exif\/exif.c in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized pointer free and application crash) via crafted EXIF data in a JPEG image. \n Publish Date : 2015-01-27 Last Update Date : 2015-10-09",
+            "threat": 6.8,
+            "summary": "The exif_process_unicode function in ext\/exif\/exif.c in PHP before 5.4.37, 5.5.x before 5.5.21, and 5.6.x before 5.6.5 allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized pointer free and application crash) via crafted EXIF data in a JPEG image.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2015-01-27T20:04:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.37",
@@ -4934,9 +5723,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-0235",
-            "summary": "GHOST: glibc gethostbyname buffer overflow",
+            "threat": 10,
+            "summary": "Heap-based buffer overflow in the __nss_hostname_digits_dots function in glibc 2.2, and other 2.x versions before 2.18, allows context-dependent attackers to execute arbitrary code via vectors related to the (1) gethostbyname or (2) gethostbyname2 function, aka \"GHOST.\"",
+            "lastModifiedDate": "2019-06-13T21:29:00+0000",
+            "publishedDate": "2015-01-28T19:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.38",
@@ -4946,9 +5737,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-0273",
-            "summary": "Multiple use-after-free vulnerabilities in ext\/date\/php_date.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allow remote attackers to execute arbitrary code via crafted serialized input containing a (1) R or (2) r type specifier in (a) DateTimeZone data handled by the php_date_timezone_initialize_from_hash function or (b) DateTime data handled by the php_date_initialize_from_hash function. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-23",
+            "threat": 7.5,
+            "summary": "Multiple use-after-free vulnerabilities in ext\/date\/php_date.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 allow remote attackers to execute arbitrary code via crafted serialized input containing a (1) R or (2) r type specifier in (a) DateTimeZone data handled by the php_date_timezone_initialize_from_hash function or (b) DateTime data handled by the php_date_initialize_from_hash function.",
+            "lastModifiedDate": "2018-01-05T02:29:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.38",
@@ -4958,9 +5751,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-1351",
-            "summary": "Use-after-free vulnerability in the _zend_shared_memdup function in zend_shared_alloc.c in the OPcache extension in PHP through 5.6.7 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Use-after-free vulnerability in the _zend_shared_memdup function in zend_shared_alloc.c in the OPcache extension in PHP through 5.6.7 allows remote attackers to cause a denial of service or possibly have unspecified other impact via unknown vectors.",
+            "lastModifiedDate": "2019-02-04T18:57:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.24",
@@ -4969,9 +5764,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-1352",
-            "summary": "The build_tablename function in pgsql.c in the PostgreSQL (aka pgsql) extension in PHP through 5.6.7 does not validate token extraction for table names, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted name. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 5,
+            "summary": "The build_tablename function in pgsql.c in the PostgreSQL (aka pgsql) extension in PHP through 5.6.7 does not validate token extraction for table names, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted name.",
+            "lastModifiedDate": "2019-10-09T23:13:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4981,9 +5778,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-2301",
-            "summary": "Use-after-free vulnerability in the phar_rename_archive function in phar_object.c in PHP before 5.5.22 and 5.6.x before 5.6.6 allows remote attackers to cause a denial of service or possibly have unspecified other impact via vectors that trigger an attempted renaming of a Phar archive to the name of an existing file. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Use-after-free vulnerability in the phar_rename_archive function in phar_object.c in PHP before 5.5.22 and 5.6.x before 5.6.6 allows remote attackers to cause a denial of service or possibly have unspecified other impact via vectors that trigger an attempted renaming of a Phar archive to the name of an existing file.",
+            "lastModifiedDate": "2019-10-09T23:13:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -4993,9 +5792,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2015-2305",
-            "summary": "heap overflow vulnerability in regcomp.c",
+            "threat": 6.8,
+            "summary": "Integer overflow in the regcomp implementation in the Henry Spencer BSD regex library (aka rxspencer) alpha3.8.g5 on 32-bit platforms, as used in NetBSD through 6.1.5 and other products, might allow context-dependent attackers to execute arbitrary code via a large regular expression that leads to a heap-based buffer overflow.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5005,9 +5806,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-2331",
-            "summary": "Integer overflow in the _zip_cdir_new function in zip_dirent.c in libzip 0.11.2 and earlier, as used in the ZIP extension in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 and other products, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a ZIP archive that contains many entries, leading to a heap-based buffer overflow. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Integer overflow in the _zip_cdir_new function in zip_dirent.c in libzip 0.11.2 and earlier, as used in the ZIP extension in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 and other products, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a ZIP archive that contains many entries, leading to a heap-based buffer overflow.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5017,9 +5820,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-2348",
-            "summary": "The move_uploaded_file implementation in ext\/standard\/basic_functions.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 truncates a pathname upon encountering a \\x00 character, which allows remote attackers to bypass intended extension restrictions and create files with unexpected names via a crafted second argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 5,
+            "summary": "The move_uploaded_file implementation in ext\/standard\/basic_functions.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 truncates a pathname upon encountering a \\x00 character, which allows remote attackers to bypass intended extension restrictions and create files with unexpected names via a crafted second argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5029,9 +5834,11 @@
             }
         },
         {
-            "threat": "5.8",
             "cveid": "CVE-2015-2783",
-            "summary": "ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (buffer over-read and application crash) via a crafted length value in conjunction with crafted serialized data in a phar archive, related to the phar_parse_metadata and phar_parse_pharfile functions. \n Publish Date : 2015-06-09 Last Update Date : 2015-10-09",
+            "threat": 5.8,
+            "summary": "ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (buffer over-read and application crash) via a crafted length value in conjunction with crafted serialized data in a phar archive, related to the phar_parse_metadata and phar_parse_pharfile functions.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5041,9 +5848,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-2787",
-            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages use of the unset function within an __wakeup function, a related issue to CVE-2015-0231. \n Publish Date : 2015-03-30 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Use-after-free vulnerability in the process_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 allows remote attackers to execute arbitrary code via a crafted unserialize call that leverages use of the unset function within an __wakeup function, a related issue to CVE-2015-0231.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2015-03-30T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5053,9 +5862,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2015-3152",
-            "summary": "Oracle MySQL before 5.7.3, Oracle MySQL Connector\/C (aka libmysqlclient) before 6.1.3, and MariaDB before 5.5.44 use the --ssl option to mean that SSL is optional, which allows man-in-the-middle attackers to spoof servers via a cleartext-downgrade attack, aka a &quot;BACKRONYM&quot; attack.",
+            "threat": 5.9,
+            "summary": "Oracle MySQL before 5.7.3, Oracle MySQL Connector\/C (aka libmysqlclient) before 6.1.3, and MariaDB before 5.5.44 use the --ssl option to mean that SSL is optional, which allows man-in-the-middle attackers to spoof servers via a cleartext-downgrade attack, aka a \"BACKRONYM\" attack.",
+            "lastModifiedDate": "2018-10-09T19:56:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.43",
@@ -5065,9 +5876,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-3307",
-            "summary": "The phar_parse_metadata function in ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (heap metadata corruption) or possibly have unspecified other impact via a crafted tar archive. \n Publish Date : 2015-06-09 Last Update Date : 2015-08-17",
+            "threat": 7.5,
+            "summary": "The phar_parse_metadata function in ext\/phar\/phar.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (heap metadata corruption) or possibly have unspecified other impact via a crafted tar archive.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5077,9 +5890,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-3329",
-            "summary": "Multiple stack-based buffer overflows in the phar_set_inode function in phar_internal.h in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allow remote attackers to execute arbitrary code via a crafted length value in a (1) tar, (2) phar, or (3) ZIP archive. \n Publish Date : 2015-06-09 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "Multiple stack-based buffer overflows in the phar_set_inode function in phar_internal.h in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allow remote attackers to execute arbitrary code via a crafted length value in a (1) tar, (2) phar, or (3) ZIP archive.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5089,9 +5904,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2015-3330",
-            "summary": "The php_handler function in sapi\/apache2handler\/sapi_apache2.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, when the Apache HTTP Server 2.4.x is used, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via pipelined HTTP requests that result in a \"deconfigured interpreter.\" \n Publish Date : 2015-06-09 Last Update Date : 2015-10-09",
+            "threat": 6.8,
+            "summary": "The php_handler function in sapi\/apache2handler\/sapi_apache2.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, when the Apache HTTP Server 2.4.x is used, allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via pipelined HTTP requests that result in a \"deconfigured interpreter.\"",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5101,9 +5918,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2015-3411",
+            "threat": 6.5,
             "summary": "PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to read or write to arbitrary files via crafted input to an application that calls (1) a DOMDocument load method, (2) the xmlwriter_open_uri function, (3) the finfo_file function, or (4) the hash_hmac_file function, as demonstrated by a filename\\0.xml attack that bypasses an intended configuration in which client users may read only .xml files.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.8"
@@ -5111,9 +5930,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-3414",
-            "summary": "SQLite before 3.8.9 does not properly implement the dequoting of collation-sequence names, which allows context-dependent attackers to cause a denial of service (uninitialized memory access and application crash) or possibly have unspecified other impact via a crafted COLLATE clause, as demonstrated by COLLATE\"\"\"\"\"\"\"\" at the end of a SELECT statement. \n Publish Date : 2015-04-24 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "SQLite before 3.8.9 does not properly implement the dequoting of collation-sequence names, which allows context-dependent attackers to cause a denial of service (uninitialized memory access and application crash) or possibly have unspecified other impact via a crafted COLLATE clause, as demonstrated by COLLATE\"\"\"\"\"\"\"\" at the end of a SELECT statement.",
+            "lastModifiedDate": "2018-07-19T01:29:00+0000",
+            "publishedDate": "2015-04-24T17:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.42",
@@ -5123,9 +5944,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-3415",
-            "summary": "The sqlite3VdbeExec function in vdbe.c in SQLite before 3.8.9 does not properly implement comparison operators, which allows context-dependent attackers to cause a denial of service (invalid free operation) or possibly have unspecified other impact via a crafted CHECK clause, as demonstrated by CHECK(0&O>O) in a CREATE TABLE statement. \n Publish Date : 2015-04-24 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "The sqlite3VdbeExec function in vdbe.c in SQLite before 3.8.9 does not properly implement comparison operators, which allows context-dependent attackers to cause a denial of service (invalid free operation) or possibly have unspecified other impact via a crafted CHECK clause, as demonstrated by CHECK(0&O>O) in a CREATE TABLE statement.",
+            "lastModifiedDate": "2018-07-19T01:29:00+0000",
+            "publishedDate": "2015-04-24T17:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.42",
@@ -5135,9 +5958,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-3416",
-            "summary": "The sqlite3VXPrintf function in printf.c in SQLite before 3.8.9 does not properly handle precision and width values during floating-point conversions, which allows context-dependent attackers to cause a denial of service (integer overflow and stack-based buffer overflow) or possibly have unspecified other impact via large integers in a crafted printf function call in a SELECT statement. \n Publish Date : 2015-04-24 Last Update Date : 2015-10-09",
+            "threat": 7.5,
+            "summary": "The sqlite3VXPrintf function in printf.c in SQLite before 3.8.9 does not properly handle precision and width values during floating-point conversions, which allows context-dependent attackers to cause a denial of service (integer overflow and stack-based buffer overflow) or possibly have unspecified other impact via large integers in a crafted printf function call in a SELECT statement.",
+            "lastModifiedDate": "2018-07-19T01:29:00+0000",
+            "publishedDate": "2015-04-24T17:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.42",
@@ -5147,9 +5972,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-4021",
-            "summary": "The phar_parse_tarfile function in ext\/phar\/tar.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 does not verify that the first character of a filename is different from the \\0 character, which allows remote attackers to cause a denial of service (integer underflow and memory corruption) via a crafted entry in a tar archive. \n Publish Date : 2015-06-09 Last Update Date : 2016-12-30",
+            "threat": 5,
+            "summary": "The phar_parse_tarfile function in ext\/phar\/tar.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 does not verify that the first character of a filename is different from the \\0 character, which allows remote attackers to cause a denial of service (integer underflow and memory corruption) via a crafted entry in a tar archive.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5159,9 +5986,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-4022",
-            "summary": "Integer overflow in the ftp_genlist function in ext\/ftp\/ftp.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote FTP servers to execute arbitrary code via a long reply to a LIST command, leading to a heap-based buffer overflow. \n Publish Date : 2015-06-09 Last Update Date : 2016-12-30",
+            "threat": 7.5,
+            "summary": "Integer overflow in the ftp_genlist function in ext\/ftp\/ftp.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote FTP servers to execute arbitrary code via a long reply to a LIST command, leading to a heap-based buffer overflow.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5171,9 +6000,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-4024",
-            "summary": "Algorithmic complexity vulnerability in the multipart_buffer_headers function in main\/rfc1867.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote attackers to cause a denial of service (CPU consumption) via crafted form data that triggers an improper order-of-growth outcome. \n Publish Date : 2015-06-09 Last Update Date : 2016-12-30",
+            "threat": 5,
+            "summary": "Algorithmic complexity vulnerability in the multipart_buffer_headers function in main\/rfc1867.c in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 allows remote attackers to cause a denial of service (CPU consumption) via crafted form data that triggers an improper order-of-growth outcome.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5183,9 +6014,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-4025",
-            "summary": "PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character in certain situations, which allows remote attackers to bypass intended extension restrictions and access files or directories with unexpected names via a crafted argument to (1) set_include_path, (2) tempnam, (3) rmdir, or (4) readlink.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243. \n Publish Date : 2015-06-09 Last Update Date : 2016-12-30",
+            "threat": 7.5,
+            "summary": "PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character in certain situations, which allows remote attackers to bypass intended extension restrictions and access files or directories with unexpected names via a crafted argument to (1) set_include_path, (2) tempnam, (3) rmdir, or (4) readlink.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5195,9 +6028,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-4026",
-            "summary": "The pcntl_exec implementation in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character, which might allow remote attackers to bypass intended extension restrictions and execute files with unexpected names via a crafted first argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243. \n Publish Date : 2015-06-09 Last Update Date : 2016-12-30",
+            "threat": 7.5,
+            "summary": "The pcntl_exec implementation in PHP before 5.4.41, 5.5.x before 5.5.25, and 5.6.x before 5.6.9 truncates a pathname upon encountering a \\x00 character, which might allow remote attackers to bypass intended extension restrictions and execute files with unexpected names via a crafted first argument.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2006-7243.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.41",
@@ -5207,9 +6042,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-4116",
-            "summary": "Use-after-free vulnerability in the spl_ptr_heap_insert function in ext\/spl\/spl_heap.c in PHP before 5.5.27 and 5.6.x before 5.6.11 allows remote attackers to execute arbitrary code by triggering a failed SplMinHeap::compare operation. \n Publish Date : 2016-05-16 Last Update Date : 2016-06-15",
+            "threat": 9.8,
+            "summary": "Use-after-free vulnerability in the spl_ptr_heap_insert function in ext\/spl\/spl_heap.c in PHP before 5.5.27 and 5.6.x before 5.6.11 allows remote attackers to execute arbitrary code by triggering a failed SplMinHeap::compare operation.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.27",
@@ -5218,9 +6055,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-4147",
-            "summary": "The SoapClient::__call method in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that __default_headers is an array, which allows remote attackers to execute arbitrary code by providing crafted serialized data with an unexpected data type, related to a \"type confusion\" issue. \n Publish Date : 2015-06-09 Last Update Date : 2016-12-30",
+            "threat": 7.5,
+            "summary": "The SoapClient::__call method in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that __default_headers is an array, which allows remote attackers to execute arbitrary code by providing crafted serialized data with an unexpected data type, related to a \"type confusion\" issue.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5230,9 +6069,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-4148",
-            "summary": "The do_soap_call function in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that the uri property is a string, which allows remote attackers to obtain sensitive information by providing crafted serialized data with an int data type, related to a \"type confusion\" issue. \n Publish Date : 2015-06-09 Last Update Date : 2016-12-30",
+            "threat": 5,
+            "summary": "The do_soap_call function in ext\/soap\/soap.c in PHP before 5.4.39, 5.5.x before 5.5.23, and 5.6.x before 5.6.7 does not verify that the uri property is a string, which allows remote attackers to obtain sensitive information by providing crafted serialized data with an int data type, related to a \"type confusion\" issue.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2015-06-09T18:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.39",
@@ -5242,9 +6083,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-4598",
-            "summary": "PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to read or write to arbitrary files via crafted input to an application that calls (1) a DOMDocument save method or (2) the GD imagepsloadfont function, as demonstrated by a filename\\0.html attack that bypasses an intended configuration in which client users may write to only .html files. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 6.5,
+            "summary": "PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 does not ensure that pathnames lack %00 sequences, which might allow remote attackers to read or write to arbitrary files via crafted input to an application that calls (1) a DOMDocument save method or (2) the GD imagepsloadfont function, as demonstrated by a filename\\0.html attack that bypasses an intended configuration in which client users may write to only .html files.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.42",
@@ -5254,9 +6097,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-4599",
-            "summary": "The SoapFault::__toString method in ext\/soap\/soap.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to obtain sensitive information, cause a denial of service (application crash), or possibly execute arbitrary code via an unexpected data type, related to a \"type confusion\" issue. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "The SoapFault::__toString method in ext\/soap\/soap.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to obtain sensitive information, cause a denial of service (application crash), or possibly execute arbitrary code via an unexpected data type, related to a \"type confusion\" issue.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5266,9 +6111,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-4600",
-            "summary": "The SoapClient implementation in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an unexpected data type, related to \"type confusion\" issues in the (1) SoapClient::__getLastRequest, (2) SoapClient::__getLastResponse, (3) SoapClient::__getLastRequestHeaders, (4) SoapClient::__getLastResponseHeaders, (5) SoapClient::__getCookies, and (6) SoapClient::__setCookie methods. \n Publish Date : 2016-05-16 Last Update Date : 2016-10-11",
+            "threat": 9.8,
+            "summary": "The SoapClient implementation in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an unexpected data type, related to \"type confusion\" issues in the (1) SoapClient::__getLastRequest, (2) SoapClient::__getLastResponse, (3) SoapClient::__getLastRequestHeaders, (4) SoapClient::__getLastResponseHeaders, (5) SoapClient::__getCookies, and (6) SoapClient::__setCookie methods.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5278,9 +6125,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-4601",
-            "summary": "PHP before 5.6.7 might allow remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an unexpected data type, related to \"type confusion\" issues in (1) ext\/soap\/php_encoding.c, (2) ext\/soap\/php_http.c, and (3) ext\/soap\/soap.c, a different issue than CVE-2015-4600. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "PHP before 5.6.7 might allow remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an unexpected data type, related to \"type confusion\" issues in (1) ext\/soap\/php_encoding.c, (2) ext\/soap\/php_http.c, and (3) ext\/soap\/soap.c, a different issue than CVE-2015-4600.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.7"
@@ -5288,9 +6137,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-4602",
-            "summary": "The __PHP_Incomplete_Class function in ext\/standard\/incomplete_class.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an unexpected data type, related to a \"type confusion\" issue. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 9.8,
+            "summary": "The __PHP_Incomplete_Class function in ext\/standard\/incomplete_class.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via an unexpected data type, related to a \"type confusion\" issue.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5300,9 +6151,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-4603",
-            "summary": "The exception::getTraceAsString function in Zend\/zend_exceptions.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to execute arbitrary code via an unexpected data type, related to a \"type confusion\" issue. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 9.8,
+            "summary": "The exception::getTraceAsString function in Zend\/zend_exceptions.c in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8 allows remote attackers to execute arbitrary code via an unexpected data type, related to a \"type confusion\" issue.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5312,9 +6165,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-4604",
-            "summary": "The mget function in softmagic.c in file 5.x, as used in the Fileinfo component in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, does not properly maintain a certain pointer relationship, which allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted string that is mishandled by a \"Python script text executable\" rule. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 7.5,
+            "summary": "The mget function in softmagic.c in file 5.x, as used in the Fileinfo component in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, does not properly maintain a certain pointer relationship, which allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted string that is mishandled by a \"Python script text executable\" rule.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5324,9 +6179,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-4605",
-            "summary": "The mcopy function in softmagic.c in file 5.x, as used in the Fileinfo component in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, does not properly restrict a certain offset value, which allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted string that is mishandled by a \"Python script text executable\" rule. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 7.5,
+            "summary": "The mcopy function in softmagic.c in file 5.x, as used in the Fileinfo component in PHP before 5.4.40, 5.5.x before 5.5.24, and 5.6.x before 5.6.8, does not properly restrict a certain offset value, which allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted string that is mishandled by a \"Python script text executable\" rule.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.40",
@@ -5336,9 +6193,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-4642",
-            "summary": "The escapeshellarg function in ext\/standard\/exec.c in PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 on Windows allows remote attackers to execute arbitrary OS commands via a crafted string to an application that accepts command-line arguments for a call to the PHP system function. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 9.8,
+            "summary": "The escapeshellarg function in ext\/standard\/exec.c in PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 on Windows allows remote attackers to execute arbitrary OS commands via a crafted string to an application that accepts command-line arguments for a call to the PHP system function.",
+            "lastModifiedDate": "2017-09-22T01:29:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.42",
@@ -5348,9 +6207,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-4643",
-            "summary": "Integer overflow in the ftp_genlist function in ext\/ftp\/ftp.c in PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 allows remote FTP servers to execute arbitrary code via a long reply to a LIST command, leading to a heap-based buffer overflow.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-4022. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 9.8,
+            "summary": "Integer overflow in the ftp_genlist function in ext\/ftp\/ftp.c in PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 allows remote FTP servers to execute arbitrary code via a long reply to a LIST command, leading to a heap-based buffer overflow.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-4022.",
+            "lastModifiedDate": "2019-05-10T16:42:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.42",
@@ -5360,9 +6221,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-4644",
-            "summary": "The php_pgsql_meta_data function in pgsql.c in the PostgreSQL (aka pgsql) extension in PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 does not validate token extraction for table names, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted name.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-1352. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 7.5,
+            "summary": "The php_pgsql_meta_data function in pgsql.c in the PostgreSQL (aka pgsql) extension in PHP before 5.4.42, 5.5.x before 5.5.26, and 5.6.x before 5.6.10 does not validate token extraction for table names, which might allow remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted name.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-1352.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.42",
@@ -5372,9 +6235,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-5589",
-            "summary": "The phar_convert_to_other function in ext\/phar\/phar_object.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 does not validate a file pointer before a close operation, which allows remote attackers to cause a denial of service (segmentation fault) or possibly have unspecified other impact via a crafted TAR archive that is mishandled in a Phar::convertToData call. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "The phar_convert_to_other function in ext\/phar\/phar_object.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 does not validate a file pointer before a close operation, which allows remote attackers to cause a denial of service (segmentation fault) or possibly have unspecified other impact via a crafted TAR archive that is mishandled in a Phar::convertToData call.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.43",
@@ -5384,9 +6249,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-5590",
-            "summary": "Stack-based buffer overflow in the phar_fix_filepath function in ext\/phar\/phar.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large length value, as demonstrated by mishandling of an e-mail attachment by the imap PHP extension. \n Publish Date : 2016-01-19 Last Update Date : 2016-11-28",
+            "threat": 7.3,
+            "summary": "Stack-based buffer overflow in the phar_fix_filepath function in ext\/phar\/phar.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large length value, as demonstrated by mishandling of an e-mail attachment by the imap PHP extension.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.43",
@@ -5396,9 +6263,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-6527",
-            "summary": "The php_str_replace_in_subject function in ext\/standard\/string.c in PHP 7.x before 7.0.0 allows remote attackers to execute arbitrary code via a crafted value in the third argument to the str_ireplace function. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-21",
+            "threat": 7.3,
+            "summary": "The php_str_replace_in_subject function in ext\/standard\/string.c in PHP 7.x before 7.0.0 allows remote attackers to execute arbitrary code via a crafted value in the third argument to the str_ireplace function.",
+            "lastModifiedDate": "2016-01-22T00:24:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.1"
@@ -5406,9 +6275,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-6831",
-            "summary": "Multiple use-after-free vulnerabilities in SPL in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allow remote attackers to execute arbitrary code via vectors involving (1) ArrayObject, (2) SplObjectStorage, and (3) SplDoublyLinkedList, which are mishandled during unserialization. \n Publish Date : 2016-01-19 Last Update Date : 2016-11-29",
+            "threat": 7.3,
+            "summary": "Multiple use-after-free vulnerabilities in SPL in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allow remote attackers to execute arbitrary code via vectors involving (1) ArrayObject, (2) SplObjectStorage, and (3) SplDoublyLinkedList, which are mishandled during unserialization.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5418,9 +6289,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-6832",
-            "summary": "Use-after-free vulnerability in the SPL unserialize implementation in ext\/spl\/spl_array.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to execute arbitrary code via crafted serialized data that triggers misuse of an array field. \n Publish Date : 2016-01-19 Last Update Date : 2016-11-29",
+            "threat": 7.3,
+            "summary": "Use-after-free vulnerability in the SPL unserialize implementation in ext\/spl\/spl_array.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to execute arbitrary code via crafted serialized data that triggers misuse of an array field.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5430,9 +6303,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-6833",
-            "summary": "Directory traversal vulnerability in the PharData class in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to write to arbitrary files via a .. (dot dot) in a ZIP archive entry that is mishandled during an extractTo call. \n Publish Date : 2016-01-19 Last Update Date : 2016-11-29",
+            "threat": 7.5,
+            "summary": "Directory traversal vulnerability in the PharData class in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to write to arbitrary files via a .. (dot dot) in a ZIP archive entry that is mishandled during an extractTo call.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5442,9 +6317,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-6834",
-            "summary": "Multiple use-after-free vulnerabilities in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 allow remote attackers to execute arbitrary code via vectors related to (1) the Serializable interface, (2) the SplObjectStorage class, and (3) the SplDoublyLinkedList class, which are mishandled during unserialization. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 9.8,
+            "summary": "Multiple use-after-free vulnerabilities in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 allow remote attackers to execute arbitrary code via vectors related to (1) the Serializable interface, (2) the SplObjectStorage class, and (3) the SplDoublyLinkedList class, which are mishandled during unserialization.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.45",
@@ -5454,9 +6331,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-6835",
-            "summary": "The session deserializer in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 mishandles multiple php_var_unserialize calls, which allow remote attackers to execute arbitrary code or cause a denial of service (use-after-free) via crafted session content. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 9.8,
+            "summary": "The session deserializer in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 mishandles multiple php_var_unserialize calls, which allow remote attackers to execute arbitrary code or cause a denial of service (use-after-free) via crafted session content.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.45",
@@ -5466,9 +6345,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-6836",
-            "summary": "The SoapClient __call method in ext\/soap\/soap.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 does not properly manage headers, which allows remote attackers to execute arbitrary code via crafted serialized data that triggers a \"type confusion\" in the serialize_function_call function. \n Publish Date : 2016-01-19 Last Update Date : 2016-11-29",
+            "threat": 7.3,
+            "summary": "The SoapClient __call method in ext\/soap\/soap.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13 does not properly manage headers, which allows remote attackers to execute arbitrary code via crafted serialized data that triggers a \"type confusion\" in the serialize_function_call function.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.45",
@@ -5478,9 +6359,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-6837",
-            "summary": "The xsl_ext_function_php function in ext\/xsl\/xsltprocessor.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13, when libxml2 before 2.9.2 is used, does not consider the possibility of a NULL valuePop return value before proceeding with a free operation during initial error checking, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted XML document, a different vulnerability than CVE-2015-6838. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 7.5,
+            "summary": "The xsl_ext_function_php function in ext\/xsl\/xsltprocessor.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13, when libxml2 before 2.9.2 is used, does not consider the possibility of a NULL valuePop return value before proceeding with a free operation during initial error checking, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted XML document, a different vulnerability than CVE-2015-6838.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.45",
@@ -5490,9 +6373,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-6838",
-            "summary": "The xsl_ext_function_php function in ext\/xsl\/xsltprocessor.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13, when libxml2 before 2.9.2 is used, does not consider the possibility of a NULL valuePop return value before proceeding with a free operation after the principal argument loop, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted XML document, a different vulnerability than CVE-2015-6837. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-29",
+            "threat": 7.5,
+            "summary": "The xsl_ext_function_php function in ext\/xsl\/xsltprocessor.c in PHP before 5.4.45, 5.5.x before 5.5.29, and 5.6.x before 5.6.13, when libxml2 before 2.9.2 is used, does not consider the possibility of a NULL valuePop return value before proceeding with a free operation after the principal argument loop, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted XML document, a different vulnerability than CVE-2015-6837.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.45",
@@ -5502,9 +6387,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2015-7803",
-            "summary": "The phar_get_entry_data function in ext\/phar\/util.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a .phar file with a crafted TAR archive entry in which the Link indicator references a file that does not exist. \n Publish Date : 2015-12-11 Last Update Date : 2016-12-07",
+            "threat": 6.8,
+            "summary": "The phar_get_entry_data function in ext\/phar\/util.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a .phar file with a crafted TAR archive entry in which the Link indicator references a file that does not exist.",
+            "lastModifiedDate": "2016-12-07T18:25:00+0000",
+            "publishedDate": "2015-12-11T12:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.30",
@@ -5513,9 +6400,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2015-7804",
-            "summary": "Off-by-one error in the phar_parse_zipfile function in ext\/phar\/zip.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (uninitialized pointer dereference and application crash) by including the \/ filename in a .zip PHAR archive. \n Publish Date : 2015-12-11 Last Update Date : 2016-12-07",
+            "threat": 6.8,
+            "summary": "Off-by-one error in the phar_parse_zipfile function in ext\/phar\/zip.c in PHP before 5.5.30 and 5.6.x before 5.6.14 allows remote attackers to cause a denial of service (uninitialized pointer dereference and application crash) by including the \/ filename in a .zip PHAR archive.",
+            "lastModifiedDate": "2016-12-07T18:25:00+0000",
+            "publishedDate": "2015-12-11T12:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.30",
@@ -5524,19 +6413,25 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-8383",
+            "threat": 7.5,
             "summary": "PCRE before 8.38 mishandles certain repeated conditional groups, which allows remote attackers to cause a denial of service (buffer overflow) or possibly have unspecified other impact via a crafted regular expression, as demonstrated by a JavaScript RegExp object encountered by Konqueror.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2015-12-02T01:59:00+0000",
             "fixVersions": {
                 "base": [
+                    "5.5.32",
+                    "5.6.18",
                     "7.0.3"
                 ]
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-8616",
-            "summary": "Use-after-free vulnerability in the Collator::sortWithSortKeys function in ext\/intl\/collator\/collator_sort.c in PHP 7.x before 7.0.1 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact by leveraging the relationships between a key buffer and a destroyed array. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-21",
+            "threat": 8.6,
+            "summary": "Use-after-free vulnerability in the Collator::sortWithSortKeys function in ext\/intl\/collator\/collator_sort.c in PHP 7.x before 7.0.1 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact by leveraging the relationships between a key buffer and a destroyed array.",
+            "lastModifiedDate": "2016-01-22T00:25:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.1"
@@ -5544,19 +6439,24 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-8617",
-            "summary": "Format string vulnerability in the zend_throw_or_error function in Zend\/zend_execute_API.c in PHP 7.x before 7.0.1 allows remote attackers to execute arbitrary code via format string specifiers in a string that is misused as a class name, leading to incorrect error handling. \n Publish Date : 2016-01-19 Last Update Date : 2016-01-21",
+            "threat": 9.8,
+            "summary": "Format string vulnerability in the zend_throw_or_error function in Zend\/zend_execute_API.c in PHP 7.x before 7.0.1 allows remote attackers to execute arbitrary code via format string specifiers in a string that is misused as a class name, leading to incorrect error handling.",
+            "lastModifiedDate": "2017-09-10T01:29:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
+                    "7.0.1",
                     "7.0.2"
                 ]
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-8835",
-            "summary": "The make_http_soap_request function in ext\/soap\/php_http.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 does not properly retrieve keys, which allows remote attackers to cause a denial of service (NULL pointer dereference, type confusion, and application crash) or possibly execute arbitrary code via crafted serialized data representing a numerically indexed _cookies array, related to the SoapClient::__call method in ext\/soap\/soap.c. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-30",
+            "threat": 9.8,
+            "summary": "The make_http_soap_request function in ext\/soap\/php_http.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 does not properly retrieve keys, which allows remote attackers to cause a denial of service (NULL pointer dereference, type confusion, and application crash) or possibly execute arbitrary code via crafted serialized data representing a numerically indexed _cookies array, related to the SoapClient::__call method in ext\/soap\/soap.c.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5566,9 +6466,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2015-8838",
-            "summary": "ext\/mysqlnd\/mysqlnd.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 uses a client SSL option to mean that SSL is optional, which allows man-in-the-middle attackers to spoof servers via a cleartext-downgrade attack, a related issue to CVE-2015-3152. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-30",
+            "threat": 5.9,
+            "summary": "ext\/mysqlnd\/mysqlnd.c in PHP before 5.4.43, 5.5.x before 5.5.27, and 5.6.x before 5.6.11 uses a client SSL option to mean that SSL is optional, which allows man-in-the-middle attackers to spoof servers via a cleartext-downgrade attack, a related issue to CVE-2015-3152.",
+            "lastModifiedDate": "2016-12-01T03:01:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.43",
@@ -5578,9 +6480,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-8865",
-            "summary": "The file_check_mem function in funcs.c in file before 5.23, as used in the Fileinfo component in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5, mishandles continuation-level jumps, which allows context-dependent attackers to cause a denial of service (buffer overflow and application crash) or possibly execute arbitrary code via a crafted magic file. \n Publish Date : 2016-05-20 Last Update Date : 2017-06-30",
+            "threat": 7.3,
+            "summary": "The file_check_mem function in funcs.c in file before 5.23, as used in the Fileinfo component in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5, mishandles continuation-level jumps, which allows context-dependent attackers to cause a denial of service (buffer overflow and application crash) or possibly execute arbitrary code via a crafted magic file.",
+            "lastModifiedDate": "2018-06-30T01:29:00+0000",
+            "publishedDate": "2016-05-20T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.34",
@@ -5590,9 +6494,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2015-8866",
-            "summary": "ext\/libxml\/libxml.c in PHP before 5.5.22 and 5.6.x before 5.6.6, when PHP-FPM is used, does not isolate each thread from libxml_disable_entity_loader changes in other threads, which allows remote attackers to conduct XML External Entity (XXE) and XML Entity Expansion (XEE) attacks via a crafted XML document, a related issue to CVE-2015-5161. \n Publish Date : 2016-05-21 Last Update Date : 2016-11-30",
+            "threat": 9.6,
+            "summary": "ext\/libxml\/libxml.c in PHP before 5.5.22 and 5.6.x before 5.6.6, when PHP-FPM is used, does not isolate each thread from libxml_disable_entity_loader changes in other threads, which allows remote attackers to conduct XML External Entity (XXE) and XML Entity Expansion (XEE) attacks via a crafted XML document, a related issue to CVE-2015-5161.",
+            "lastModifiedDate": "2019-02-14T18:49:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.22",
@@ -5601,9 +6507,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-8867",
-            "summary": "The openssl_random_pseudo_bytes function in ext\/openssl\/openssl.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 incorrectly relies on the deprecated RAND_pseudo_bytes function, which makes it easier for remote attackers to defeat cryptographic protection mechanisms via unspecified vectors. \n Publish Date : 2016-05-21 Last Update Date : 2016-11-30",
+            "threat": 7.5,
+            "summary": "The openssl_random_pseudo_bytes function in ext\/openssl\/openssl.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 incorrectly relies on the deprecated RAND_pseudo_bytes function, which makes it easier for remote attackers to defeat cryptographic protection mechanisms via unspecified vectors.",
+            "lastModifiedDate": "2019-02-14T18:53:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5613,9 +6521,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-8873",
-            "summary": "Stack consumption vulnerability in Zend\/zend_exceptions.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to cause a denial of service (segmentation fault) via recursive method calls. \n Publish Date : 2016-05-16 Last Update Date : 2016-06-15",
+            "threat": 7.5,
+            "summary": "Stack consumption vulnerability in Zend\/zend_exceptions.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 allows remote attackers to cause a denial of service (segmentation fault) via recursive method calls.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5625,19 +6535,25 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-8874",
-            "summary": "Stack consumption vulnerability in GD in PHP before 5.6.12 allows remote attackers to cause a denial of service via a crafted imagefilltoborder call. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-30",
+            "threat": 7.5,
+            "summary": "Stack consumption vulnerability in GD in PHP before 5.6.12 allows remote attackers to cause a denial of service via a crafted imagefilltoborder call.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
-                    "5.6.12"
+                    "5.5.37",
+                    "5.6.12",
+                    "7.0.0"
                 ]
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2015-8876",
-            "summary": "Zend\/zend_exceptions.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 does not validate certain Exception objects, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger unintended method execution via crafted serialized data. \n Publish Date : 2016-05-21 Last Update Date : 2016-05-24",
+            "threat": 9.8,
+            "summary": "Zend\/zend_exceptions.c in PHP before 5.4.44, 5.5.x before 5.5.28, and 5.6.x before 5.6.12 does not validate certain Exception objects, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or trigger unintended method execution via crafted serialized data.",
+            "lastModifiedDate": "2019-02-14T18:48:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5647,9 +6563,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-8877",
-            "summary": "The gdImageScaleTwoPass function in gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.2.0, as used in PHP before 5.6.12, uses inconsistent allocate and free approaches, which allows remote attackers to cause a denial of service (memory consumption) via a crafted call, as demonstrated by a call to the PHP imagescale function. \n Publish Date : 2016-05-21 Last Update Date : 2016-11-30",
+            "threat": 7.5,
+            "summary": "The gdImageScaleTwoPass function in gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.2.0, as used in PHP before 5.6.12, uses inconsistent allocate and free approaches, which allows remote attackers to cause a denial of service (memory consumption) via a crafted call, as demonstrated by a call to the PHP imagescale function.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.12"
@@ -5657,9 +6575,11 @@
             }
         },
         {
-            "threat": "7.1",
             "cveid": "CVE-2015-8878",
-            "summary": "main\/php_open_temporary_file.c in PHP before 5.5.28 and 5.6.x before 5.6.12 does not ensure thread safety, which allows remote attackers to cause a denial of service (race condition and heap memory corruption) by leveraging an application that performs many temporary-file accesses. \n Publish Date : 2016-05-21 Last Update Date : 2016-05-24",
+            "threat": 5.9,
+            "summary": "main\/php_open_temporary_file.c in PHP before 5.5.28 and 5.6.x before 5.6.12 does not ensure thread safety, which allows remote attackers to cause a denial of service (race condition and heap memory corruption) by leveraging an application that performs many temporary-file accesses.",
+            "lastModifiedDate": "2019-02-14T18:47:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.28",
@@ -5668,9 +6588,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2015-8879",
-            "summary": "The odbc_bindcols function in ext\/odbc\/php_odbc.c in PHP before 5.6.12 mishandles driver behavior for SQL_WVARCHAR columns, which allows remote attackers to cause a denial of service (application crash) in opportunistic circumstances by leveraging use of the odbc_fetch_array function to access a certain type of Microsoft SQL Server table. \n Publish Date : 2016-05-21 Last Update Date : 2016-05-24",
+            "threat": 7.5,
+            "summary": "The odbc_bindcols function in ext\/odbc\/php_odbc.c in PHP before 5.6.12 mishandles driver behavior for SQL_WVARCHAR columns, which allows remote attackers to cause a denial of service (application crash) in opportunistic circumstances by leveraging use of the odbc_fetch_array function to access a certain type of Microsoft SQL Server table.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.12"
@@ -5678,9 +6600,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2015-8880",
-            "summary": "Double free vulnerability in the format printer in PHP 7.x before 7.0.1 allows remote attackers to have an unspecified impact by triggering an error. \n Publish Date : 2016-05-21 Last Update Date : 2016-05-24",
+            "threat": 9.8,
+            "summary": "Double free vulnerability in the format printer in PHP 7.x before 7.0.1 allows remote attackers to have an unspecified impact by triggering an error.",
+            "lastModifiedDate": "2016-05-24T14:14:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.1"
@@ -5688,9 +6612,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2015-8935",
-            "summary": "The sapi_header_op function in main\/SAPI.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 supports deprecated line folding without considering browser compatibility, which allows remote attackers to conduct cross-site scripting (XSS) attacks against Internet Explorer by leveraging (1) %0A%20 or (2) %0D%0A%20 mishandling in the header function. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 6.1,
+            "summary": "The sapi_header_op function in main\/SAPI.c in PHP before 5.4.38, 5.5.x before 5.5.22, and 5.6.x before 5.6.6 supports deprecated line folding without considering browser compatibility, which allows remote attackers to conduct cross-site scripting (XSS) attacks against Internet Explorer by leveraging (1) %0A%20 or (2) %0D%0A%20 mishandling in the header function.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.38",
@@ -5700,9 +6626,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2015-8994",
-            "summary": "An issue was discovered in PHP 5.x and 7.x, when the configuration uses apache2handler\/mod_php or php-fpm with OpCache enabled. With 5.x after 5.6.28 or 7.x after 7.0.13, the issue is resolved in a non-default configuration with the opcache.validate_permission=1 setting. The vulnerability details are as follows. In PHP SAPIs where PHP interpreters share a common parent process, Zend OpCache creates a shared memory object owned by the common parent during initialization. Child PHP processes inherit the SHM descriptor, using it to cache and retrieve compiled script bytecode (\"opcode\" in PHP jargon). Cache keys vary depending on configuration, but filename is a central key component, and compiled opcode can generally be run if a script's filename is known or can be guessed. Many common shared-hosting configurations change EUID in child processes to enforce privilege separation among hosted users (for example using mod_ruid2 for the Apache HTTP Server, or php-fpm user settings). In these scenarios, the default Zend OpCache behavior defeats script file permissions by sharing a single SHM cache among all child PHP processes. PHP scripts often contain sensitive information: Think of CMS configurations where reading or running another user's script usually means gaining privileges to the CMS database. \n Publish Date : 2017-03-02 Last Update Date : 2017-03-16",
+            "threat": 7.5,
+            "summary": "An issue was discovered in PHP 5.x and 7.x, when the configuration uses apache2handler\/mod_php or php-fpm with OpCache enabled. With 5.x after 5.6.28 or 7.x after 7.0.13, the issue is resolved in a non-default configuration with the opcache.validate_permission=1 setting. The vulnerability details are as follows. In PHP SAPIs where PHP interpreters share a common parent process, Zend OpCache creates a shared memory object owned by the common parent during initialization. Child PHP processes inherit the SHM descriptor, using it to cache and retrieve compiled script bytecode (\"opcode\" in PHP jargon). Cache keys vary depending on configuration, but filename is a central key component, and compiled opcode can generally be run if a script's filename is known or can be guessed. Many common shared-hosting configurations change EUID in child processes to enforce privilege separation among hosted users (for example using mod_ruid2 for the Apache HTTP Server, or php-fpm user settings). In these scenarios, the default Zend OpCache behavior defeats script file permissions by sharing a single SHM cache among all child PHP processes. PHP scripts often contain sensitive information: Think of CMS configurations where reading or running another user's script usually means gaining privileges to the CMS database.",
+            "lastModifiedDate": "2017-03-16T14:40:00+0000",
+            "publishedDate": "2017-03-02T06:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -5717,9 +6645,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2016-1903",
-            "summary": "The gdImageRotateInterpolated function in ext\/gd\/libgd\/gd_interpolation.c in PHP before 5.5.31, 5.6.x before 5.6.17, and 7.x before 7.0.2 allows remote attackers to obtain sensitive information or cause a denial of service (out-of-bounds read and application crash) via a large bgd_color argument to the imagerotate function. \n Publish Date : 2016-01-19 Last Update Date : 2016-12-07",
+            "threat": 9.1,
+            "summary": "The gdImageRotateInterpolated function in ext\/gd\/libgd\/gd_interpolation.c in PHP before 5.5.31, 5.6.x before 5.6.17, and 7.x before 7.0.2 allows remote attackers to obtain sensitive information or cause a denial of service (out-of-bounds read and application crash) via a large bgd_color argument to the imagerotate function.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.31",
@@ -5729,9 +6659,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-1904",
-            "summary": "Multiple integer overflows in ext\/standard\/exec.c in PHP 7.x before 7.0.2 allow remote attackers to cause a denial of service or possibly have unspecified other impact via a long string to the (1) php_escape_shell_cmd or (2) php_escape_shell_arg function, leading to a heap-based buffer overflow. \n Publish Date : 2016-01-19 Last Update Date : 2016-12-07",
+            "threat": 7.3,
+            "summary": "Multiple integer overflows in ext\/standard\/exec.c in PHP 7.x before 7.0.2 allow remote attackers to cause a denial of service or possibly have unspecified other impact via a long string to the (1) php_escape_shell_cmd or (2) php_escape_shell_arg function, leading to a heap-based buffer overflow.",
+            "lastModifiedDate": "2016-12-07T18:33:00+0000",
+            "publishedDate": "2016-01-19T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.2"
@@ -5739,9 +6671,11 @@
             }
         },
         {
-            "threat": "10.0",
             "cveid": "CVE-2016-2554",
-            "summary": "Stack-based buffer overflow in ext\/phar\/tar.c in PHP before 5.5.32, 5.6.x before 5.6.18, and 7.x before 7.0.3 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted TAR archive. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-30",
+            "threat": 9.8,
+            "summary": "Stack-based buffer overflow in ext\/phar\/tar.c in PHP before 5.5.32, 5.6.x before 5.6.18, and 7.x before 7.0.3 allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a crafted TAR archive.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.32",
@@ -5751,9 +6685,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-3078",
-            "summary": "Multiple integer overflows in php_zip.c in the zip extension in PHP before 7.0.6 allow remote attackers to cause a denial of service (heap-based buffer overflow and application crash) or possibly have unspecified other impact via a crafted call to (1) getFromIndex or (2) getFromName in the ZipArchive class. \n Publish Date : 2016-08-07 Last Update Date : 2016-08-09",
+            "threat": 9.8,
+            "summary": "Multiple integer overflows in php_zip.c in the zip extension in PHP before 7.0.6 allow remote attackers to cause a denial of service (heap-based buffer overflow and application crash) or possibly have unspecified other impact via a crafted call to (1) getFromIndex or (2) getFromName in the ZipArchive class.",
+            "lastModifiedDate": "2017-09-07T01:29:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.6"
@@ -5761,9 +6697,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-3132",
-            "summary": "Double free vulnerability in the SplDoublyLinkedList::offsetSet function in ext\/spl\/spl_dllist.c in PHP 7.x before 7.0.6 allows remote attackers to execute arbitrary code via a crafted index. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "Double free vulnerability in the SplDoublyLinkedList::offsetSet function in ext\/spl\/spl_dllist.c in PHP 7.x before 7.0.6 allows remote attackers to execute arbitrary code via a crafted index.",
+            "lastModifiedDate": "2016-11-28T20:06:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.6"
@@ -5771,9 +6709,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-3141",
-            "summary": "Use-after-free vulnerability in wddx.c in the WDDX extension in PHP before 5.5.33 and 5.6.x before 5.6.19 allows remote attackers to cause a denial of service (memory corruption and application crash) or possibly have unspecified other impact by triggering a wddx_deserialize call on XML data containing a crafted var element. \n Publish Date : 2016-03-31 Last Update Date : 2016-12-02",
+            "threat": 9.8,
+            "summary": "Use-after-free vulnerability in wddx.c in the WDDX extension in PHP before 5.5.33 and 5.6.x before 5.6.19 allows remote attackers to cause a denial of service (memory corruption and application crash) or possibly have unspecified other impact by triggering a wddx_deserialize call on XML data containing a crafted var element.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-03-31T16:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.33",
@@ -5782,9 +6722,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2016-3142",
-            "summary": "The phar_parse_zipfile function in zip.c in the PHAR extension in PHP before 5.5.33 and 5.6.x before 5.6.19 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (out-of-bounds read and application crash) by placing a PK\\x05\\x06 signature at an invalid location. \n Publish Date : 2016-03-31 Last Update Date : 2016-12-02",
+            "threat": 8.2,
+            "summary": "The phar_parse_zipfile function in zip.c in the PHAR extension in PHP before 5.5.33 and 5.6.x before 5.6.19 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (out-of-bounds read and application crash) by placing a PK\\x05\\x06 signature at an invalid location.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-03-31T16:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.33",
@@ -5793,9 +6735,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2016-3185",
-            "summary": "The make_http_soap_request function in ext\/soap\/php_http.c in PHP before 5.4.44, 5.5.x before 5.5.28, 5.6.x before 5.6.12, and 7.x before 7.0.4 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (type confusion and application crash) via crafted serialized _cookies data, related to the SoapClient::__call method in ext\/soap\/soap.c. \n Publish Date : 2016-05-16 Last Update Date : 2016-11-30",
+            "threat": 7.1,
+            "summary": "The make_http_soap_request function in ext\/soap\/php_http.c in PHP before 5.4.44, 5.5.x before 5.5.28, 5.6.x before 5.6.12, and 7.x before 7.0.4 allows remote attackers to obtain sensitive information from process memory or cause a denial of service (type confusion and application crash) via crafted serialized _cookies data, related to the SoapClient::__call method in ext\/soap\/soap.c.",
+            "lastModifiedDate": "2016-12-01T03:09:00+0000",
+            "publishedDate": "2016-05-16T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.44",
@@ -5806,9 +6750,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-4070",
-            "summary": "** DISPUTED ** Integer overflow in the php_raw_url_encode function in ext\/standard\/url.c in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allows remote attackers to cause a denial of service (application crash) via a long string to the rawurlencode function. NOTE: the vendor says \"Not sure if this qualifies as security issue (probably not).\" \n Publish Date : 2016-05-20 Last Update Date : 2017-02-16",
+            "threat": 7.5,
+            "summary": "** DISPUTED ** Integer overflow in the php_raw_url_encode function in ext\/standard\/url.c in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allows remote attackers to cause a denial of service (application crash) via a long string to the rawurlencode function. NOTE: the vendor says \"Not sure if this qualifies as security issue (probably not).\"",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-20T11:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.34",
@@ -5818,9 +6764,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4071",
-            "summary": "Format string vulnerability in the php_snmp_error function in ext\/snmp\/snmp.c in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allows remote attackers to execute arbitrary code via format string specifiers in an SNMP::get call. \n Publish Date : 2016-05-20 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "Format string vulnerability in the php_snmp_error function in ext\/snmp\/snmp.c in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allows remote attackers to execute arbitrary code via format string specifiers in an SNMP::get call.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-20T11:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.34",
@@ -5830,9 +6778,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4072",
-            "summary": "The Phar extension in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allows remote attackers to execute arbitrary code via a crafted filename, as demonstrated by mishandling of \\0 characters by the phar_analyze_path function in ext\/phar\/phar.c. \n Publish Date : 2016-05-20 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The Phar extension in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allows remote attackers to execute arbitrary code via a crafted filename, as demonstrated by mishandling of \\0 characters by the phar_analyze_path function in ext\/phar\/phar.c.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-20T11:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.34",
@@ -5842,9 +6792,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4073",
-            "summary": "Multiple integer overflows in the mbfl_strcut function in ext\/mbstring\/libmbfl\/mbfl\/mbfilter.c in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allow remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted mb_strcut call. \n Publish Date : 2016-05-20 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "Multiple integer overflows in the mbfl_strcut function in ext\/mbstring\/libmbfl\/mbfl\/mbfilter.c in PHP before 5.5.34, 5.6.x before 5.6.20, and 7.x before 7.0.5 allow remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted mb_strcut call.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-20T11:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.34",
@@ -5854,9 +6806,11 @@
             }
         },
         {
-            "threat": "8.3",
             "cveid": "CVE-2016-4342",
-            "summary": "ext\/phar\/phar_object.c in PHP before 5.5.32, 5.6.x before 5.6.18, and 7.x before 7.0.3 mishandles zero-length uncompressed data, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted (1) TAR, (2) ZIP, or (3) PHAR archive. \n Publish Date : 2016-05-21 Last Update Date : 2017-02-16",
+            "threat": 8.8,
+            "summary": "ext\/phar\/phar_object.c in PHP before 5.5.32, 5.6.x before 5.6.18, and 7.x before 7.0.3 mishandles zero-length uncompressed data, which allows remote attackers to cause a denial of service (heap memory corruption) or possibly have unspecified other impact via a crafted (1) TAR, (2) ZIP, or (3) PHAR archive.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.32",
@@ -5866,9 +6820,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-4343",
-            "summary": "The phar_make_dirstream function in ext\/phar\/dirstream.c in PHP before 5.6.18 and 7.x before 7.0.3 mishandles zero-size .[email\u00a0protected]\/* <![CDATA[ *\/!function(t,e,r,n,c,a,p){try{t=document.currentScript||function(){for(t=document.getElementsByTagName('script'),e=t.length;e--;)if(t[e].getAttribute('data-cfhash'))return t[e]}();if(t&&(c=t.previousSibling)){p=t.parentNode;if(a=c.getAttribute('data-cfemail')){for(e='',r='0x'+a.substr(0,2)|0,n=2;a.length-n;n+=2)e+='%'+('0'+('0x'+a.substr(n,2)^r).toString(16)).slice(-2);p.replaceChild(document.createTextNode(decodeURIComponent(e)),c)}p.removeChild(t)}}catch(u){}}()\/* ]]> *\/ files, which allows remote attackers to cause a denial of service (uninitialized pointer dereference) or possibly have unspecified other impact via a crafted TAR archive. \n Publish Date : 2016-05-21 Last Update Date : 2017-02-16",
+            "threat": 8.8,
+            "summary": "The phar_make_dirstream function in ext\/phar\/dirstream.c in PHP before 5.6.18 and 7.x before 7.0.3 mishandles zero-size .\/.\/@LongLink files, which allows remote attackers to cause a denial of service (uninitialized pointer dereference) or possibly have unspecified other impact via a crafted TAR archive.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.18",
@@ -5877,9 +6833,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4344",
-            "summary": "Integer overflow in the xml_utf8_encode function in ext\/xml\/xml.c in PHP before 7.0.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a long argument to the utf8_encode function, leading to a heap-based buffer overflow. \n Publish Date : 2016-05-21 Last Update Date : 2016-05-24",
+            "threat": 9.8,
+            "summary": "Integer overflow in the xml_utf8_encode function in ext\/xml\/xml.c in PHP before 7.0.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a long argument to the utf8_encode function, leading to a heap-based buffer overflow.",
+            "lastModifiedDate": "2016-05-24T15:23:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.4"
@@ -5887,9 +6845,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4345",
-            "summary": "Integer overflow in the php_filter_encode_url function in ext\/filter\/sanitizing_filters.c in PHP before 7.0.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a long string, leading to a heap-based buffer overflow. \n Publish Date : 2016-05-21 Last Update Date : 2016-05-24",
+            "threat": 9.8,
+            "summary": "Integer overflow in the php_filter_encode_url function in ext\/filter\/sanitizing_filters.c in PHP before 7.0.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a long string, leading to a heap-based buffer overflow.",
+            "lastModifiedDate": "2016-05-24T14:24:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.4"
@@ -5897,9 +6857,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4346",
-            "summary": "Integer overflow in the str_pad function in ext\/standard\/string.c in PHP before 7.0.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a long string, leading to a heap-based buffer overflow. \n Publish Date : 2016-05-21 Last Update Date : 2016-11-30",
+            "threat": 9.8,
+            "summary": "Integer overflow in the str_pad function in ext\/standard\/string.c in PHP before 7.0.4 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a long string, leading to a heap-based buffer overflow.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.4"
@@ -5907,9 +6869,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4473",
-            "summary": "\/ext\/phar\/phar_object.c in PHP 7.0.7 and 5.6.x allows remote attackers to execute arbitrary code.  NOTE: Introduced as part of an incomplete fix to CVE-2015-6833. \n Publish Date : 2017-06-08 Last Update Date : 2017-06-16",
+            "threat": 9.8,
+            "summary": "\/ext\/phar\/phar_object.c in PHP 7.0.7 and 5.6.x allows remote attackers to execute arbitrary code.  NOTE: Introduced as part of an incomplete fix to CVE-2015-6833.",
+            "lastModifiedDate": "2017-06-16T12:47:00+0000",
+            "publishedDate": "2017-06-08T20:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.23",
@@ -5918,9 +6882,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4537",
-            "summary": "The bcpowmod function in ext\/bcmath\/bcmath.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 accepts a negative integer for the scale argument, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via a crafted call. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The bcpowmod function in ext\/bcmath\/bcmath.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 accepts a negative integer for the scale argument, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via a crafted call.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.35",
@@ -5930,9 +6896,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4538",
-            "summary": "The bcpowmod function in ext\/bcmath\/bcmath.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 modifies certain data structures without considering whether they are copies of the _zero_, _one_, or _two_ global variable, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via a crafted call. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The bcpowmod function in ext\/bcmath\/bcmath.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 modifies certain data structures without considering whether they are copies of the _zero_, _one_, or _two_ global variable, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via a crafted call.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.34",
@@ -5942,9 +6910,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4539",
-            "summary": "The xml_parse_into_struct function in ext\/xml\/xml.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 allows remote attackers to cause a denial of service (buffer under-read and segmentation fault) or possibly have unspecified other impact via crafted XML data in the second argument, leading to a parser level of zero. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The xml_parse_into_struct function in ext\/xml\/xml.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 allows remote attackers to cause a denial of service (buffer under-read and segmentation fault) or possibly have unspecified other impact via crafted XML data in the second argument, leading to a parser level of zero.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.35",
@@ -5954,9 +6924,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4540",
-            "summary": "The grapheme_stripos function in ext\/intl\/grapheme\/grapheme_string.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a negative offset. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The grapheme_stripos function in ext\/intl\/grapheme\/grapheme_string.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a negative offset.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.35",
@@ -5966,9 +6938,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4541",
-            "summary": "The grapheme_strpos function in ext\/intl\/grapheme\/grapheme_string.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a negative offset. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The grapheme_strpos function in ext\/intl\/grapheme\/grapheme_string.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a negative offset.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.35",
@@ -5978,9 +6952,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4542",
-            "summary": "The exif_process_IFD_TAG function in ext\/exif\/exif.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 does not properly construct spprintf arguments, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via crafted header data. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The exif_process_IFD_TAG function in ext\/exif\/exif.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 does not properly construct spprintf arguments, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via crafted header data.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.35",
@@ -5990,9 +6966,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4543",
-            "summary": "The exif_process_IFD_in_JPEG function in ext\/exif\/exif.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 does not validate IFD sizes, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via crafted header data. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The exif_process_IFD_in_JPEG function in ext\/exif\/exif.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 does not validate IFD sizes, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via crafted header data.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.35",
@@ -6002,9 +6980,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-4544",
-            "summary": "The exif_process_TIFF_in_JPEG function in ext\/exif\/exif.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 does not validate TIFF start data, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via crafted header data. \n Publish Date : 2016-05-21 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The exif_process_TIFF_in_JPEG function in ext\/exif\/exif.c in PHP before 5.5.35, 5.6.x before 5.6.21, and 7.x before 7.0.6 does not validate TIFF start data, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via crafted header data.",
+            "lastModifiedDate": "2018-10-30T16:27:00+0000",
+            "publishedDate": "2016-05-22T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.35",
@@ -6014,9 +6994,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5093",
-            "summary": "The get_icu_value_internal function in ext\/intl\/locale\/locale_methods.c in PHP before 5.5.36, 5.6.x before 5.6.22, and 7.x before 7.0.7 does not ensure the presence of a '\\0' character, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a crafted locale_get_primary_language call. \n Publish Date : 2016-08-07 Last Update Date : 2017-01-17",
+            "threat": 8.6,
+            "summary": "The get_icu_value_internal function in ext\/intl\/locale\/locale_methods.c in PHP before 5.5.36, 5.6.x before 5.6.22, and 7.x before 7.0.7 does not ensure the presence of a '\\0' character, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a crafted locale_get_primary_language call.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.36",
@@ -6026,9 +7008,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5094",
-            "summary": "Integer overflow in the php_html_entities function in ext\/standard\/html.c in PHP before 5.5.36 and 5.6.x before 5.6.22 allows remote attackers to cause a denial of service or possibly have unspecified other impact by triggering a large output string from the htmlspecialchars function. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 8.6,
+            "summary": "Integer overflow in the php_html_entities function in ext\/standard\/html.c in PHP before 5.5.36 and 5.6.x before 5.6.22 allows remote attackers to cause a denial of service or possibly have unspecified other impact by triggering a large output string from the htmlspecialchars function.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.37",
@@ -6037,9 +7021,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5095",
-            "summary": "Integer overflow in the php_escape_html_entities_ex function in ext\/standard\/html.c in PHP before 5.5.36 and 5.6.x before 5.6.22 allows remote attackers to cause a denial of service or possibly have unspecified other impact by triggering a large output string from a FILTER_SANITIZE_FULL_SPECIAL_CHARS filter_var call.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2016-5094. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 8.6,
+            "summary": "Integer overflow in the php_escape_html_entities_ex function in ext\/standard\/html.c in PHP before 5.5.36 and 5.6.x before 5.6.22 allows remote attackers to cause a denial of service or possibly have unspecified other impact by triggering a large output string from a FILTER_SANITIZE_FULL_SPECIAL_CHARS filter_var call.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2016-5094.",
+            "lastModifiedDate": "2016-11-28T20:22:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.36",
@@ -6048,9 +7034,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5096",
-            "summary": "Integer overflow in the fread function in ext\/standard\/file.c in PHP before 5.5.36 and 5.6.x before 5.6.22 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large integer in the second argument. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 8.6,
+            "summary": "Integer overflow in the fread function in ext\/standard\/file.c in PHP before 5.5.36 and 5.6.x before 5.6.22 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large integer in the second argument.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.36",
@@ -6059,9 +7047,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2016-5114",
-            "summary": "sapi\/fpm\/fpm\/fpm_log.c in PHP before 5.5.31, 5.6.x before 5.6.17, and 7.x before 7.0.2 misinterprets the semantics of the snprintf return value, which allows attackers to obtain sensitive information from process memory or cause a denial of service (out-of-bounds read and buffer overflow) via a long string, as demonstrated by a long URI in a configuration with custom REQUEST_URI logging. \n Publish Date : 2016-08-07 Last Update Date : 2016-08-23",
+            "threat": 9.1,
+            "summary": "sapi\/fpm\/fpm\/fpm_log.c in PHP before 5.5.31, 5.6.x before 5.6.17, and 7.x before 7.0.2 misinterprets the semantics of the snprintf return value, which allows attackers to obtain sensitive information from process memory or cause a denial of service (out-of-bounds read and buffer overflow) via a long string, as demonstrated by a long URI in a configuration with custom REQUEST_URI logging.",
+            "lastModifiedDate": "2018-01-05T02:30:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.31",
@@ -6071,9 +7061,11 @@
             }
         },
         {
-            "threat": "5.1",
             "cveid": "CVE-2016-5385",
-            "summary": "PHP through 7.0.8 does not attempt to address RFC 3875 section 4.1.18 namespace conflicts and therefore does not protect applications from the presence of untrusted client data in the HTTP_PROXY environment variable, which might allow remote attackers to redirect an application's outbound HTTP traffic to an arbitrary proxy server via a crafted Proxy header in an HTTP request, as demonstrated by (1) an application that makes a getenv('HTTP_PROXY') call or (2) a CGI configuration of PHP, aka an \"httpoxy\" issue. \n Publish Date : 2016-07-18 Last Update Date : 2017-06-30",
+            "threat": 8.1,
+            "summary": "PHP through 7.0.8 does not attempt to address RFC 3875 section 4.1.18 namespace conflicts and therefore does not protect applications from the presence of untrusted client data in the HTTP_PROXY environment variable, which might allow remote attackers to redirect an application's outbound HTTP traffic to an arbitrary proxy server via a crafted Proxy header in an HTTP request, as demonstrated by (1) an application that makes a getenv('HTTP_PROXY') call or (2) a CGI configuration of PHP, aka an \"httpoxy\" issue.",
+            "lastModifiedDate": "2019-03-04T14:47:00+0000",
+            "publishedDate": "2016-07-19T02:00:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6083,9 +7075,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-5399",
-            "summary": "The bzread function in ext\/bz2\/bz2.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (out-of-bounds write) or execute arbitrary code via a crafted bz2 archive. \n Publish Date : 2017-04-21 Last Update Date : 2017-04-27",
+            "threat": 7.8,
+            "summary": "The bzread function in ext\/bz2\/bz2.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (out-of-bounds write) or execute arbitrary code via a crafted bz2 archive.",
+            "lastModifiedDate": "2018-10-09T20:00:00+0000",
+            "publishedDate": "2017-04-21T20:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6095,19 +7089,24 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-5766",
+            "threat": 8.8,
             "summary": "Integer overflow in the _gd2GetHeader function in gd_gd2.c in the GD Graphics Library (aka libgd) before 2.2.3, as used in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8, allows remote attackers to cause a denial of service (heap-based buffer overflow and application crash) or possibly have unspecified other impact via crafted chunk dimensions in an image.",
+            "lastModifiedDate": "2019-04-22T17:48:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
+                    "5.6.23",
                     "7.0.8"
                 ]
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5768",
-            "summary": "Double free vulnerability in the _php_mb_regex_ereg_replace_exec function in php_mbregex.c in the mbstring extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 allows remote attackers to execute arbitrary code or cause a denial of service (application crash) by leveraging a callback exception. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "Double free vulnerability in the _php_mb_regex_ereg_replace_exec function in php_mbregex.c in the mbstring extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 allows remote attackers to execute arbitrary code or cause a denial of service (application crash) by leveraging a callback exception.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.37",
@@ -6117,9 +7116,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5769",
-            "summary": "Multiple integer overflows in mcrypt.c in the mcrypt extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 allow remote attackers to cause a denial of service (heap-based buffer overflow and application crash) or possibly have unspecified other impact via a crafted length value, related to the (1) mcrypt_generic and (2) mdecrypt_generic functions. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "Multiple integer overflows in mcrypt.c in the mcrypt extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 allow remote attackers to cause a denial of service (heap-based buffer overflow and application crash) or possibly have unspecified other impact via a crafted length value, related to the (1) mcrypt_generic and (2) mdecrypt_generic functions.",
+            "lastModifiedDate": "2016-11-28T20:29:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.37",
@@ -6129,9 +7130,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5770",
-            "summary": "Integer overflow in the SplFileObject::fread function in spl_directory.c in the SPL extension in PHP before 5.5.37 and 5.6.x before 5.6.23 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large integer argument, a related issue to CVE-2016-5096. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "Integer overflow in the SplFileObject::fread function in spl_directory.c in the SPL extension in PHP before 5.5.37 and 5.6.x before 5.6.23 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a large integer argument, a related issue to CVE-2016-5096.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.37",
@@ -6140,9 +7143,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5771",
-            "summary": "spl_array.c in the SPL extension in PHP before 5.5.37 and 5.6.x before 5.6.23 improperly interacts with the unserialize implementation and garbage collection, which allows remote attackers to execute arbitrary code or cause a denial of service (use-after-free and application crash) via crafted serialized data. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "spl_array.c in the SPL extension in PHP before 5.5.37 and 5.6.x before 5.6.23 improperly interacts with the unserialize implementation and garbage collection, which allows remote attackers to execute arbitrary code or cause a denial of service (use-after-free and application crash) via crafted serialized data.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.37",
@@ -6151,9 +7156,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5772",
-            "summary": "Double free vulnerability in the php_wddx_process_data function in wddx.c in the WDDX extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via crafted XML data that is mishandled in a wddx_deserialize call. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "Double free vulnerability in the php_wddx_process_data function in wddx.c in the WDDX extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 allows remote attackers to cause a denial of service (application crash) or possibly execute arbitrary code via crafted XML data that is mishandled in a wddx_deserialize call.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.37",
@@ -6163,9 +7170,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-5773",
-            "summary": "php_zip.c in the zip extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 improperly interacts with the unserialize implementation and garbage collection, which allows remote attackers to execute arbitrary code or cause a denial of service (use-after-free and application crash) via crafted serialized data containing a ZipArchive object. \n Publish Date : 2016-08-07 Last Update Date : 2016-11-28",
+            "threat": 9.8,
+            "summary": "php_zip.c in the zip extension in PHP before 5.5.37, 5.6.x before 5.6.23, and 7.x before 7.0.8 improperly interacts with the unserialize implementation and garbage collection, which allows remote attackers to execute arbitrary code or cause a denial of service (use-after-free and application crash) via crafted serialized data containing a ZipArchive object.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-08-07T10:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.37",
@@ -6175,9 +7184,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-6174",
-            "summary": "applications\/core\/modules\/front\/system\/content.php in Invision Power Services IPS Community Suite (aka Invision Power Board, IPB, or Power Board) before 4.1.13, when used with PHP before 5.4.24 or 5.5.x before 5.5.8, allows remote attackers to execute arbitrary code via the content_class parameter. \n Publish Date : 2016-07-12 Last Update Date : 2017-03-20",
+            "threat": 8.1,
+            "summary": "applications\/core\/modules\/front\/system\/content.php in Invision Power Services IPS Community Suite (aka Invision Power Board, IPB, or Power Board) before 4.1.13, when used with PHP before 5.4.24 or 5.5.x before 5.5.8, allows remote attackers to execute arbitrary code via the content_class parameter.",
+            "lastModifiedDate": "2017-03-21T01:59:00+0000",
+            "publishedDate": "2016-07-12T19:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.4.24",
@@ -6186,9 +7197,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-6288",
-            "summary": "The php_url_parse_ex function in ext\/standard\/url.c in PHP before 5.5.38 allows remote attackers to cause a denial of service (buffer over-read) or possibly have unspecified other impact via vectors involving the smart_str data type. \n Publish Date : 2016-07-25 Last Update Date : 2016-09-26",
+            "threat": 9.8,
+            "summary": "The php_url_parse_ex function in ext\/standard\/url.c in PHP before 5.5.38 allows remote attackers to cause a denial of service (buffer over-read) or possibly have unspecified other impact via vectors involving the smart_str data type.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38"
@@ -6196,9 +7209,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-6289",
-            "summary": "Integer overflow in the virtual_file_ex function in TSRM\/tsrm_virtual_cwd.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (stack-based buffer overflow) or possibly have unspecified other impact via a crafted extract operation on a ZIP archive. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 7.8,
+            "summary": "Integer overflow in the virtual_file_ex function in TSRM\/tsrm_virtual_cwd.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (stack-based buffer overflow) or possibly have unspecified other impact via a crafted extract operation on a ZIP archive.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6208,9 +7223,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-6290",
-            "summary": "ext\/session\/session.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 does not properly maintain a certain hash data structure, which allows remote attackers to cause a denial of service (use-after-free) or possibly have unspecified other impact via vectors related to session deserialization. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "ext\/session\/session.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 does not properly maintain a certain hash data structure, which allows remote attackers to cause a denial of service (use-after-free) or possibly have unspecified other impact via vectors related to session deserialization.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6220,9 +7237,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-6291",
-            "summary": "The exif_process_IFD_in_MAKERNOTE function in ext\/exif\/exif.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (out-of-bounds array access and memory corruption), obtain sensitive information from process memory, or possibly have unspecified other impact via a crafted JPEG image. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The exif_process_IFD_in_MAKERNOTE function in ext\/exif\/exif.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (out-of-bounds array access and memory corruption), obtain sensitive information from process memory, or possibly have unspecified other impact via a crafted JPEG image.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6232,9 +7251,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2016-6292",
-            "summary": "The exif_process_user_comment function in ext\/exif\/exif.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted JPEG image. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 6.5,
+            "summary": "The exif_process_user_comment function in ext\/exif\/exif.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via a crafted JPEG image.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6244,9 +7265,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-6294",
-            "summary": "The locale_accept_from_http function in ext\/intl\/locale\/locale_methods.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 does not properly restrict calls to the ICU uloc_acceptLanguageFromHTTP function, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a call with a long argument. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The locale_accept_from_http function in ext\/intl\/locale\/locale_methods.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 does not properly restrict calls to the ICU uloc_acceptLanguageFromHTTP function, which allows remote attackers to cause a denial of service (out-of-bounds read) or possibly have unspecified other impact via a call with a long argument.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6256,9 +7279,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-6295",
-            "summary": "ext\/snmp\/snmp.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 improperly interacts with the unserialize implementation and garbage collection, which allows remote attackers to cause a denial of service (use-after-free and application crash) or possibly have unspecified other impact via crafted serialized data, a related issue to CVE-2016-5773. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "ext\/snmp\/snmp.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 improperly interacts with the unserialize implementation and garbage collection, which allows remote attackers to cause a denial of service (use-after-free and application crash) or possibly have unspecified other impact via crafted serialized data, a related issue to CVE-2016-5773.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6268,9 +7293,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-6296",
-            "summary": "Integer signedness error in the simplestring_addn function in simplestring.c in xmlrpc-epi through 0.54.2, as used in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9, allows remote attackers to cause a denial of service (heap-based buffer overflow) or possibly have unspecified other impact via a long first argument to the PHP xmlrpc_encode_request function. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "Integer signedness error in the simplestring_addn function in simplestring.c in xmlrpc-epi through 0.54.2, as used in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9, allows remote attackers to cause a denial of service (heap-based buffer overflow) or possibly have unspecified other impact via a long first argument to the PHP xmlrpc_encode_request function.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6280,9 +7307,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-6297",
-            "summary": "Integer overflow in the php_stream_zip_opener function in ext\/zip\/zip_stream.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (stack-based buffer overflow) or possibly have unspecified other impact via a crafted zip:\/\/ URL. \n Publish Date : 2016-07-25 Last Update Date : 2017-06-30",
+            "threat": 8.8,
+            "summary": "Integer overflow in the php_stream_zip_opener function in ext\/zip\/zip_stream.c in PHP before 5.5.38, 5.6.x before 5.6.24, and 7.x before 7.0.9 allows remote attackers to cause a denial of service (stack-based buffer overflow) or possibly have unspecified other impact via a crafted zip:\/\/ URL.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-07-25T14:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.5.38",
@@ -6292,9 +7321,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7124",
-            "summary": "ext\/standard\/var_unserializer.c in PHP before 5.6.25 and 7.x before 7.0.10 mishandles certain invalid objects, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data that leads to a (1) __destruct call or (2) magic method call. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "ext\/standard\/var_unserializer.c in PHP before 5.6.25 and 7.x before 7.0.10 mishandles certain invalid objects, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data that leads to a (1) __destruct call or (2) magic method call.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6303,9 +7334,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7125",
-            "summary": "ext\/session\/session.c in PHP before 5.6.25 and 7.x before 7.0.10 skips invalid session names in a way that triggers incorrect parsing, which allows remote attackers to inject arbitrary-type session data by leveraging control of a session name, as demonstrated by object injection. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 7.5,
+            "summary": "ext\/session\/session.c in PHP before 5.6.25 and 7.x before 7.0.10 skips invalid session names in a way that triggers incorrect parsing, which allows remote attackers to inject arbitrary-type session data by leveraging control of a session name, as demonstrated by object injection.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6314,9 +7347,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7126",
-            "summary": "The imagetruecolortopalette function in ext\/gd\/gd.c in PHP before 5.6.25 and 7.x before 7.0.10 does not properly validate the number of colors, which allows remote attackers to cause a denial of service (select_colors allocation error and out-of-bounds write) or possibly have unspecified other impact via a large value in the third argument. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The imagetruecolortopalette function in ext\/gd\/gd.c in PHP before 5.6.25 and 7.x before 7.0.10 does not properly validate the number of colors, which allows remote attackers to cause a denial of service (select_colors allocation error and out-of-bounds write) or possibly have unspecified other impact via a large value in the third argument.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6325,9 +7360,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7127",
-            "summary": "The imagegammacorrect function in ext\/gd\/gd.c in PHP before 5.6.25 and 7.x before 7.0.10 does not properly validate gamma values, which allows remote attackers to cause a denial of service (out-of-bounds write) or possibly have unspecified other impact by providing different signs for the second and third arguments. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The imagegammacorrect function in ext\/gd\/gd.c in PHP before 5.6.25 and 7.x before 7.0.10 does not properly validate gamma values, which allows remote attackers to cause a denial of service (out-of-bounds write) or possibly have unspecified other impact by providing different signs for the second and third arguments.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6336,9 +7373,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7128",
-            "summary": "The exif_process_IFD_in_TIFF function in ext\/exif\/exif.c in PHP before 5.6.25 and 7.x before 7.0.10 mishandles the case of a thumbnail offset that exceeds the file size, which allows remote attackers to obtain sensitive information from process memory via a crafted TIFF image. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 5.3,
+            "summary": "The exif_process_IFD_in_TIFF function in ext\/exif\/exif.c in PHP before 5.6.25 and 7.x before 7.0.10 mishandles the case of a thumbnail offset that exceeds the file size, which allows remote attackers to obtain sensitive information from process memory via a crafted TIFF image.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6347,9 +7386,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7129",
-            "summary": "The php_wddx_process_data function in ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (segmentation fault) or possibly have unspecified other impact via an invalid ISO 8601 time value, as demonstrated by a wddx_deserialize call that mishandles a dateTime element in a wddxPacket XML document. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The php_wddx_process_data function in ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (segmentation fault) or possibly have unspecified other impact via an invalid ISO 8601 time value, as demonstrated by a wddx_deserialize call that mishandles a dateTime element in a wddxPacket XML document.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6358,9 +7399,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7130",
-            "summary": "The php_wddx_pop_element function in ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or possibly have unspecified other impact via an invalid base64 binary value, as demonstrated by a wddx_deserialize call that mishandles a binary element in a wddxPacket XML document. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 7.5,
+            "summary": "The php_wddx_pop_element function in ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or possibly have unspecified other impact via an invalid base64 binary value, as demonstrated by a wddx_deserialize call that mishandles a binary element in a wddxPacket XML document.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6369,9 +7412,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7131",
-            "summary": "ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or possibly have unspecified other impact via a malformed wddxPacket XML document that is mishandled in a wddx_deserialize call, as demonstrated by a tag that lacks a < (less than) character. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 7.5,
+            "summary": "ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or possibly have unspecified other impact via a malformed wddxPacket XML document that is mishandled in a wddx_deserialize call, as demonstrated by a tag that lacks a < (less than) character.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6380,9 +7425,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7132",
-            "summary": "ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or possibly have unspecified other impact via an invalid wddxPacket XML document that is mishandled in a wddx_deserialize call, as demonstrated by a stray element inside a boolean element, leading to incorrect pop processing. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 7.5,
+            "summary": "ext\/wddx\/wddx.c in PHP before 5.6.25 and 7.x before 7.0.10 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) or possibly have unspecified other impact via an invalid wddxPacket XML document that is mishandled in a wddx_deserialize call, as demonstrated by a stray element inside a boolean element, leading to incorrect pop processing.",
+            "lastModifiedDate": "2018-01-05T02:31:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.25",
@@ -6391,9 +7438,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-7133",
-            "summary": "Zend\/zend_alloc.c in PHP 7.x before 7.0.10, when open_basedir is enabled, mishandles huge realloc operations, which allows remote attackers to cause a denial of service (integer overflow) or possibly have unspecified other impact via a long pathname. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 8.1,
+            "summary": "Zend\/zend_alloc.c in PHP 7.x before 7.0.10, when open_basedir is enabled, mishandles huge realloc operations, which allows remote attackers to cause a denial of service (integer overflow) or possibly have unspecified other impact via a long pathname.",
+            "lastModifiedDate": "2017-07-01T01:30:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.10"
@@ -6401,9 +7450,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7134",
-            "summary": "ext\/curl\/interface.c in PHP 7.x before 7.0.10 does not work around a libcurl integer overflow, which allows remote attackers to cause a denial of service (allocation error and heap-based buffer overflow) or possibly have unspecified other impact via a long string that is mishandled in a curl_escape call. \n Publish Date : 2016-09-11 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "ext\/curl\/interface.c in PHP 7.x before 7.0.10 does not work around a libcurl integer overflow, which allows remote attackers to cause a denial of service (allocation error and heap-based buffer overflow) or possibly have unspecified other impact via a long string that is mishandled in a curl_escape call.",
+            "lastModifiedDate": "2017-08-16T01:29:00+0000",
+            "publishedDate": "2016-09-12T01:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.10"
@@ -6411,9 +7462,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7411",
-            "summary": "ext\/standard\/var_unserializer.re in PHP before 5.6.26 mishandles object-deserialization failures, which allows remote attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact via an unserialize call that references a partially constructed object. \n Publish Date : 2016-09-17 Last Update Date : 2017-07-29",
+            "threat": 9.8,
+            "summary": "ext\/standard\/var_unserializer.re in PHP before 5.6.26 mishandles object-deserialization failures, which allows remote attackers to cause a denial of service (memory corruption) or possibly have unspecified other impact via an unserialize call that references a partially constructed object.",
+            "lastModifiedDate": "2017-07-30T01:29:00+0000",
+            "publishedDate": "2016-09-17T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.26"
@@ -6421,9 +7474,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2016-7412",
-            "summary": "ext\/mysqlnd\/mysqlnd_wireprotocol.c in PHP before 5.6.26 and 7.x before 7.0.11 does not verify that a BIT field has the UNSIGNED_FLAG flag, which allows remote MySQL servers to cause a denial of service (heap-based buffer overflow) or possibly have unspecified other impact via crafted field metadata. \n Publish Date : 2016-09-17 Last Update Date : 2017-07-29",
+            "threat": 8.1,
+            "summary": "ext\/mysqlnd\/mysqlnd_wireprotocol.c in PHP before 5.6.26 and 7.x before 7.0.11 does not verify that a BIT field has the UNSIGNED_FLAG flag, which allows remote MySQL servers to cause a denial of service (heap-based buffer overflow) or possibly have unspecified other impact via crafted field metadata.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2016-09-17T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.26",
@@ -6432,9 +7487,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7413",
-            "summary": "Use-after-free vulnerability in the wddx_stack_destroy function in ext\/wddx\/wddx.c in PHP before 5.6.26 and 7.x before 7.0.11 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a wddxPacket XML document that lacks an end-tag for a recordset field element, leading to mishandling in a wddx_deserialize call. \n Publish Date : 2016-09-17 Last Update Date : 2017-07-29",
+            "threat": 9.8,
+            "summary": "Use-after-free vulnerability in the wddx_stack_destroy function in ext\/wddx\/wddx.c in PHP before 5.6.26 and 7.x before 7.0.11 allows remote attackers to cause a denial of service or possibly have unspecified other impact via a wddxPacket XML document that lacks an end-tag for a recordset field element, leading to mishandling in a wddx_deserialize call.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2016-09-17T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.26",
@@ -6443,9 +7500,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7414",
-            "summary": "The ZIP signature-verification feature in PHP before 5.6.26 and 7.x before 7.0.11 does not ensure that the uncompressed_filesize field is large enough, which allows remote attackers to cause a denial of service (out-of-bounds memory access) or possibly have unspecified other impact via a crafted PHAR archive, related to ext\/phar\/util.c and ext\/phar\/zip.c. \n Publish Date : 2016-09-17 Last Update Date : 2017-07-29",
+            "threat": 9.8,
+            "summary": "The ZIP signature-verification feature in PHP before 5.6.26 and 7.x before 7.0.11 does not ensure that the uncompressed_filesize field is large enough, which allows remote attackers to cause a denial of service (out-of-bounds memory access) or possibly have unspecified other impact via a crafted PHAR archive, related to ext\/phar\/util.c and ext\/phar\/zip.c.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2016-09-17T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.26",
@@ -6454,9 +7513,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7416",
-            "summary": "ext\/intl\/msgformat\/msgformat_format.c in PHP before 5.6.26 and 7.x before 7.0.11 does not properly restrict the locale length provided to the Locale class in the ICU library, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a MessageFormatter::formatMessage call with a long first argument. \n Publish Date : 2016-09-17 Last Update Date : 2017-07-29",
+            "threat": 7.5,
+            "summary": "ext\/intl\/msgformat\/msgformat_format.c in PHP before 5.6.26 and 7.x before 7.0.11 does not properly restrict the locale length provided to the Locale class in the ICU library, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact via a MessageFormatter::formatMessage call with a long first argument.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2016-09-17T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.26",
@@ -6465,9 +7526,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7417",
-            "summary": "ext\/spl\/spl_array.c in PHP before 5.6.26 and 7.x before 7.0.11 proceeds with SplArray unserialization without validating a return value and data type, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data. \n Publish Date : 2016-09-17 Last Update Date : 2017-07-29",
+            "threat": 9.8,
+            "summary": "ext\/spl\/spl_array.c in PHP before 5.6.26 and 7.x before 7.0.11 proceeds with SplArray unserialization without validating a return value and data type, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2016-09-17T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.26",
@@ -6476,9 +7539,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7418",
-            "summary": "The php_wddx_push_element function in ext\/wddx\/wddx.c in PHP before 5.6.26 and 7.x before 7.0.11 allows remote attackers to cause a denial of service (invalid pointer access and out-of-bounds read) or possibly have unspecified other impact via an incorrect boolean element in a wddxPacket XML document, leading to mishandling in a wddx_deserialize call. \n Publish Date : 2016-09-17 Last Update Date : 2017-07-29",
+            "threat": 7.5,
+            "summary": "The php_wddx_push_element function in ext\/wddx\/wddx.c in PHP before 5.6.26 and 7.x before 7.0.11 allows remote attackers to cause a denial of service (invalid pointer access and out-of-bounds read) or possibly have unspecified other impact via an incorrect boolean element in a wddxPacket XML document, leading to mishandling in a wddx_deserialize call.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2016-09-17T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.26",
@@ -6487,9 +7552,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-7478",
-            "summary": "Zend\/zend_exceptions.c in PHP, possibly 5.x before 5.6.28 and 7.x before 7.0.13, allows remote attackers to cause a denial of service (infinite loop) via a crafted Exception object in serialized data, a related issue to CVE-2015-8876. \n Publish Date : 2017-01-11 Last Update Date : 2017-01-27",
+            "threat": 7.5,
+            "summary": "Zend\/zend_exceptions.c in PHP, possibly 5.x before 5.6.28 and 7.x before 7.0.13, allows remote attackers to cause a denial of service (infinite loop) via a crafted Exception object in serialized data, a related issue to CVE-2015-8876.",
+            "lastModifiedDate": "2018-01-14T02:29:00+0000",
+            "publishedDate": "2017-01-11T06:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -6504,9 +7571,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7479",
-            "summary": "In all versions of PHP 7, during the unserialization process, resizing the 'properties' hash table of a serialized object may lead to use-after-free. A remote attacker may exploit this bug to gain arbitrary code execution. \n Publish Date : 2017-01-11 Last Update Date : 2017-07-25",
+            "threat": 9.8,
+            "summary": "In all versions of PHP 7, during the unserialization process, resizing the 'properties' hash table of a serialized object may lead to use-after-free. A remote attacker may exploit this bug to gain arbitrary code execution.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-12T00:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.15",
@@ -6515,9 +7584,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-7480",
-            "summary": "The SplObjectStorage unserialize implementation in ext\/spl\/spl_observer.c in PHP before 7.0.12 does not verify that a key is an object, which allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized memory access) via crafted serialized data. \n Publish Date : 2017-01-11 Last Update Date : 2017-01-12",
+            "threat": 9.8,
+            "summary": "The SplObjectStorage unserialize implementation in ext\/spl\/spl_observer.c in PHP before 7.0.12 does not verify that a key is an object, which allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized memory access) via crafted serialized data.",
+            "lastModifiedDate": "2018-01-14T02:29:00+0000",
+            "publishedDate": "2017-01-11T07:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.12"
@@ -6525,9 +7596,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-9137",
-            "summary": "Use-after-free vulnerability in the CURLFile implementation in ext\/curl\/curl_file.c in PHP before 5.6.27 and 7.x before 7.0.12 allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data that is mishandled during __wakeup processing. \n Publish Date : 2017-01-04 Last Update Date : 2017-01-10",
+            "threat": 9.8,
+            "summary": "Use-after-free vulnerability in the CURLFile implementation in ext\/curl\/curl_file.c in PHP before 5.6.27 and 7.x before 7.0.12 allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data that is mishandled during __wakeup processing.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2017-01-04T20:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.27",
@@ -6536,9 +7609,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-9138",
-            "summary": "PHP through 5.6.27 and 7.x through 7.0.12 mishandles property modification during __wakeup processing, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data, as demonstrated by Exception::__toString with DateInterval::__wakeup. \n Publish Date : 2017-01-04 Last Update Date : 2017-01-06",
+            "threat": 9.8,
+            "summary": "PHP through 5.6.27 and 7.x through 7.0.12 mishandles property modification during __wakeup processing, which allows remote attackers to cause a denial of service or possibly have unspecified other impact via crafted serialized data, as demonstrated by Exception::__toString with DateInterval::__wakeup.",
+            "lastModifiedDate": "2017-01-07T03:00:00+0000",
+            "publishedDate": "2017-01-04T20:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.28",
@@ -6547,19 +7622,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-9933",
+            "threat": 7.5,
             "summary": "Stack consumption vulnerability in the gdImageFillToBorder function in gd.c in the GD Graphics Library (aka libgd) before 2.2.2, as used in PHP before 5.6.28 and 7.x before 7.0.13, allows remote attackers to cause a denial of service (segmentation violation) via a crafted imagefilltoborder call that triggers use of a negative color value.",
-            "fixVersions": {
-                "base": [
-                    "7.0.13"
-                ]
-            }
-        },
-        {
-            "threat": "5.0",
-            "cveid": "CVE-2016-9934",
-            "summary": "ext\/wddx\/wddx.c in PHP before 5.6.28 and 7.x before 7.0.13 allows remote attackers to cause a denial of service (NULL pointer dereference) via crafted serialized data in a wddxPacket XML document, as demonstrated by a PDORow string. \n Publish Date : 2017-01-04 Last Update Date : 2017-01-17",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-04T20:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.28",
@@ -6568,9 +7635,24 @@
             }
         },
         {
-            "threat": "7.5",
+            "cveid": "CVE-2016-9934",
+            "threat": 7.5,
+            "summary": "ext\/wddx\/wddx.c in PHP before 5.6.28 and 7.x before 7.0.13 allows remote attackers to cause a denial of service (NULL pointer dereference) via crafted serialized data in a wddxPacket XML document, as demonstrated by a PDORow string.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-04T20:59:00+0000",
+            "fixVersions": {
+                "base": [
+                    "5.6.28",
+                    "7.0.13"
+                ]
+            }
+        },
+        {
             "cveid": "CVE-2016-9935",
-            "summary": "The php_wddx_push_element function in ext\/wddx\/wddx.c in PHP before 5.6.29 and 7.x before 7.0.14 allows remote attackers to cause a denial of service (out-of-bounds read and memory corruption) or possibly have unspecified other impact via an empty boolean element in a wddxPacket XML document. \n Publish Date : 2017-01-04 Last Update Date : 2017-06-30",
+            "threat": 9.8,
+            "summary": "The php_wddx_push_element function in ext\/wddx\/wddx.c in PHP before 5.6.29 and 7.x before 7.0.14 allows remote attackers to cause a denial of service (out-of-bounds read and memory corruption) or possibly have unspecified other impact via an empty boolean element in a wddxPacket XML document.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-04T20:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.29",
@@ -6579,19 +7661,24 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-9936",
-            "summary": "The unserialize implementation in ext\/standard\/var.c in PHP 7.x before 7.0.14 allows remote attackers to cause a denial of service (use-after-free) or possibly have unspecified other impact via crafted serialized data.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-6834. \n Publish Date : 2017-01-04 Last Update Date : 2017-01-17",
+            "threat": 9.8,
+            "summary": "The unserialize implementation in ext\/standard\/var.c in PHP 7.x before 7.0.14 allows remote attackers to cause a denial of service (use-after-free) or possibly have unspecified other impact via crafted serialized data.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2015-6834.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-04T20:59:00+0000",
             "fixVersions": {
                 "base": [
-                    "7.0.14"
+                    "7.0.14",
+                    "7.1.0"
                 ]
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-10158",
-            "summary": "The exif_convert_any_to_int function in ext\/exif\/exif.c in PHP before 5.6.30, 7.0.x before 7.0.15, and 7.1.x before 7.1.1 allows remote attackers to cause a denial of service (application crash) via crafted EXIF data that triggers an attempt to divide the minimum representable negative integer by -1. \n Publish Date : 2017-01-24 Last Update Date : 2017-07-25",
+            "threat": 7.5,
+            "summary": "The exif_convert_any_to_int function in ext\/exif\/exif.c in PHP before 5.6.30, 7.0.x before 7.0.15, and 7.1.x before 7.1.1 allows remote attackers to cause a denial of service (application crash) via crafted EXIF data that triggers an attempt to divide the minimum representable negative integer by -1.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-24T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.30",
@@ -6601,9 +7688,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-10159",
-            "summary": "Integer overflow in the phar_parse_pharfile function in ext\/phar\/phar.c in PHP before 5.6.30 and 7.0.x before 7.0.15 allows remote attackers to cause a denial of service (memory consumption or application crash) via a truncated manifest entry in a PHAR archive. \n Publish Date : 2017-01-24 Last Update Date : 2017-07-25",
+            "threat": 7.5,
+            "summary": "Integer overflow in the phar_parse_pharfile function in ext\/phar\/phar.c in PHP before 5.6.30 and 7.0.x before 7.0.15 allows remote attackers to cause a denial of service (memory consumption or application crash) via a truncated manifest entry in a PHAR archive.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-24T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.30",
@@ -6612,9 +7701,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2016-10160",
-            "summary": "Off-by-one error in the phar_parse_pharfile function in ext\/phar\/phar.c in PHP before 5.6.30 and 7.0.x before 7.0.15 allows remote attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via a crafted PHAR archive with an alias mismatch. \n Publish Date : 2017-01-24 Last Update Date : 2017-07-25",
+            "threat": 9.8,
+            "summary": "Off-by-one error in the phar_parse_pharfile function in ext\/phar\/phar.c in PHP before 5.6.30 and 7.0.x before 7.0.15 allows remote attackers to cause a denial of service (memory corruption) or possibly execute arbitrary code via a crafted PHAR archive with an alias mismatch.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-24T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.30",
@@ -6623,9 +7714,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-10161",
-            "summary": "The object_common1 function in ext\/standard\/var_unserializer.c in PHP before 5.6.30, 7.0.x before 7.0.15, and 7.1.x before 7.1.1 allows remote attackers to cause a denial of service (buffer over-read and application crash) via crafted serialized data that is mishandled in a finish_nested_data call. \n Publish Date : 2017-01-24 Last Update Date : 2017-07-25",
+            "threat": 7.5,
+            "summary": "The object_common1 function in ext\/standard\/var_unserializer.c in PHP before 5.6.30, 7.0.x before 7.0.15, and 7.1.x before 7.1.1 allows remote attackers to cause a denial of service (buffer over-read and application crash) via crafted serialized data that is mishandled in a finish_nested_data call.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-24T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.30",
@@ -6635,9 +7728,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-10162",
-            "summary": "The php_wddx_pop_element function in ext\/wddx\/wddx.c in PHP 7.0.x before 7.0.15 and 7.1.x before 7.1.1 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via an inapplicable class name in a wddxPacket XML document, leading to mishandling in a wddx_deserialize call. \n Publish Date : 2017-01-24 Last Update Date : 2017-07-25",
+            "threat": 7.5,
+            "summary": "The php_wddx_pop_element function in ext\/wddx\/wddx.c in PHP 7.0.x before 7.0.15 and 7.1.x before 7.1.1 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via an inapplicable class name in a wddxPacket XML document, leading to mishandling in a wddx_deserialize call.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-24T21:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.15",
@@ -6646,11 +7741,14 @@
             }
         },
         {
-            "threat": "9.8",
             "cveid": "CVE-2016-10166",
+            "threat": 9.8,
             "summary": "Integer underflow in the _gdContributionsAlloc function in gd_interpolation.c in the GD Graphics Library (aka libgd) before 2.2.4 allows remote attackers to have unspecified impact via vectors related to decrementing the u variable.",
+            "lastModifiedDate": "2017-11-04T01:29:00+0000",
+            "publishedDate": "2017-03-15T15:59:00+0000",
             "fixVersions": {
                 "base": [
+                    "5.6.40",
                     "7.1.26",
                     "7.2.14",
                     "7.3.1"
@@ -6658,9 +7756,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2016-10397",
-            "summary": "In PHP before 5.6.28 and 7.x before 7.0.13, incorrect handling of various URI components in the URL parser could be used by attackers to bypass hostname-specific URL checks, as demonstrated by evil.example.com:[email\u00a0protected]\/* <![CDATA[ *\/!function(t,e,r,n,c,a,p){try{t=document.currentScript||function(){for(t=document.getElementsByTagName('script'),e=t.length;e--;)if(t[e].getAttribute('data-cfhash'))return t[e]}();if(t&&(c=t.previousSibling)){p=t.parentNode;if(a=c.getAttribute('data-cfemail')){for(e='',r='0x'+a.substr(0,2)|0,n=2;a.length-n;n+=2)e+='%'+('0'+('0x'+a.substr(n,2)^r).toString(16)).slice(-2);p.replaceChild(document.createTextNode(decodeURIComponent(e)),c)}p.removeChild(t)}}catch(u){}}()\/* ]]> *\/\/ and evil.example.com:[email\u00a0protected]\/* <![CDATA[ *\/!function(t,e,r,n,c,a,p){try{t=document.currentScript||function(){for(t=document.getElementsByTagName('script'),e=t.length;e--;)if(t[e].getAttribute('data-cfhash'))return t[e]}();if(t&&(c=t.previousSibling)){p=t.parentNode;if(a=c.getAttribute('data-cfemail')){for(e='',r='0x'+a.substr(0,2)|0,n=2;a.length-n;n+=2)e+='%'+('0'+('0x'+a.substr(n,2)^r).toString(16)).slice(-2);p.replaceChild(document.createTextNode(decodeURIComponent(e)),c)}p.removeChild(t)}}catch(u){}}()\/* ]]> *\/\/ inputs to the parse_url function (implemented in the php_url_parse_ex function in ext\/standard\/url.c). \n Publish Date : 2017-07-10 Last Update Date : 2017-07-17",
+            "threat": 7.5,
+            "summary": "In PHP before 5.6.28 and 7.x before 7.0.13, incorrect handling of various URI components in the URL parser could be used by attackers to bypass hostname-specific URL checks, as demonstrated by evil.example.com:80#@good.example.com\/ and evil.example.com:80?@good.example.com\/ inputs to the parse_url function (implemented in the php_url_parse_ex function in ext\/standard\/url.c).",
+            "lastModifiedDate": "2018-01-14T02:29:00+0000",
+            "publishedDate": "2017-07-10T14:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.28",
@@ -6669,9 +7769,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-5340",
-            "summary": "Zend\/zend_hash.c in PHP before 7.0.15 and 7.1.x before 7.1.1 mishandles certain cases that require large array allocations, which allows remote attackers to execute arbitrary code or cause a denial of service (integer overflow, uninitialized memory access, and use of arbitrary destructor function pointers) via crafted serialized data. \n Publish Date : 2017-01-11 Last Update Date : 2017-07-25",
+            "threat": 9.8,
+            "summary": "Zend\/zend_hash.c in PHP before 7.0.15 and 7.1.x before 7.1.1 mishandles certain cases that require large array allocations, which allows remote attackers to execute arbitrary code or cause a denial of service (integer overflow, uninitialized memory access, and use of arbitrary destructor function pointers) via crafted serialized data.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-01-11T06:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.15"
@@ -6679,9 +7781,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-6441",
-            "summary": "** DISPUTED ** The _zval_get_long_func_ex in Zend\/zend_operators.c in PHP 7.1.2 allows attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted use of \"declare(ticks=\" in a PHP script. NOTE: the vendor disputes the classification of this as a vulnerability, stating \"Please do not request CVEs for ordinary bugs. CVEs are relevant for security issues only.\" \n Publish Date : 2017-04-03 Last Update Date : 2017-04-10",
+            "threat": 7.5,
+            "summary": "** DISPUTED ** The _zval_get_long_func_ex in Zend\/zend_operators.c in PHP 7.1.2 allows attackers to cause a denial of service (NULL pointer dereference and application crash) via crafted use of \"declare(ticks=\" in a PHP script. NOTE: the vendor disputes the classification of this as a vulnerability, stating \"Please do not request CVEs for ordinary bugs. CVEs are relevant for security issues only.\"",
+            "lastModifiedDate": "2017-04-10T16:12:00+0000",
+            "publishedDate": "2017-04-03T05:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.3"
@@ -6689,9 +7793,11 @@
             }
         },
         {
-            "threat": "5.8",
             "cveid": "CVE-2017-7272",
-            "summary": "PHP through 7.1.3 enables potential SSRF in applications that accept an fsockopen hostname argument with an expectation that the port number is constrained. Because a :port syntax is recognized, fsockopen will use the port number that is specified in the hostname argument, instead of the port number in the second argument of the function. \n Publish Date : 2017-03-27 Last Update Date : 2017-07-11",
+            "threat": 7.4,
+            "summary": "PHP through 7.1.11 enables potential SSRF in applications that accept an fsockopen or pfsockopen hostname argument with an expectation that the port number is constrained. Because a :port syntax is recognized, fsockopen will use the port number that is specified in the hostname argument, instead of the port number in the second argument of the function.",
+            "lastModifiedDate": "2018-02-26T02:29:00+0000",
+            "publishedDate": "2017-03-27T17:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.4"
@@ -6699,9 +7805,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2017-7890",
-            "summary": "The GIF decoding function gdImageCreateFromGifCtx in gd_gif_in.c in the GD Graphics Library (aka libgd), as used in PHP before 5.6.31 and 7.x before 7.1.7, does not zero colorMap arrays before use. A specially crafted GIF image could use the uninitialized tables to read ~700 bytes from the top of the stack, potentially disclosing sensitive information. \n Publish Date : 2017-08-02 Last Update Date : 2017-08-15",
+            "threat": 6.5,
+            "summary": "The GIF decoding function gdImageCreateFromGifCtx in gd_gif_in.c in the GD Graphics Library (aka libgd), as used in PHP before 5.6.31 and 7.x before 7.1.7, does not zero colorMap arrays before use. A specially crafted GIF image could use the uninitialized tables to read ~700 bytes from the top of the stack, potentially disclosing sensitive information.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-08-02T19:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.31",
@@ -6711,9 +7819,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-7963",
-            "summary": "** DISPUTED ** The GNU Multiple Precision Arithmetic Library (GMP) interfaces for PHP through 7.1.4 allow attackers to cause a denial of service (memory consumption and application crash) via operations on long strings. NOTE: the vendor disputes this, stating \"There is no security issue here, because GMP safely aborts in case of an OOM condition. The only attack vector here is denial of service. However, if you allow attacker-controlled, unbounded allocations you have a DoS vector regardless of GMP's OOM behavior.\" \n Publish Date : 2017-04-19 Last Update Date : 2017-04-28",
+            "threat": 7.5,
+            "summary": "** DISPUTED ** The GNU Multiple Precision Arithmetic Library (GMP) interfaces for PHP through 7.1.4 allow attackers to cause a denial of service (memory consumption and application crash) via operations on long strings. NOTE: the vendor disputes this, stating \"There is no security issue here, because GMP safely aborts in case of an OOM condition. The only attack vector here is denial of service. However, if you allow attacker-controlled, unbounded allocations you have a DoS vector regardless of GMP's OOM behavior.\"",
+            "lastModifiedDate": "2019-10-03T00:03:00+0000",
+            "publishedDate": "2017-04-19T15:59:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.5"
@@ -6721,9 +7831,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-8923",
-            "summary": "The zend_string_extend function in Zend\/zend_string.h in PHP through 7.1.5 does not prevent changes to string objects that result in a negative length, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact by leveraging a script's use of .= with a long string. \n Publish Date : 2017-05-12 Last Update Date : 2017-05-24",
+            "threat": 9.8,
+            "summary": "The zend_string_extend function in Zend\/zend_string.h in PHP through 7.1.5 does not prevent changes to string objects that result in a negative length, which allows remote attackers to cause a denial of service (application crash) or possibly have unspecified other impact by leveraging a script's use of .= with a long string.",
+            "lastModifiedDate": "2019-04-16T14:27:00+0000",
+            "publishedDate": "2017-05-12T20:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6731,9 +7843,11 @@
             }
         },
         {
-            "threat": "4.4",
             "cveid": "CVE-2017-9067",
-            "summary": "In MODX Revolution before 2.5.7, when PHP 5.3.3 is used, an attacker is able to include and execute arbitrary files on the web server due to insufficient validation of the action parameter to setup\/index.php, aka directory traversal. \n Publish Date : 2017-05-18 Last Update Date : 2017-05-31",
+            "threat": 7,
+            "summary": "In MODX Revolution before 2.5.7, when PHP 5.3.3 is used, an attacker is able to include and execute arbitrary files on the web server due to insufficient validation of the action parameter to setup\/index.php, aka directory traversal.",
+            "lastModifiedDate": "2017-05-31T15:07:00+0000",
+            "publishedDate": "2017-05-18T16:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.4"
@@ -6741,9 +7855,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-9119",
-            "summary": "The i_zval_ptr_dtor function in Zend\/zend_variables.h in PHP 7.1.5 allows attackers to cause a denial of service (memory consumption and application crash) or possibly have unspecified other impact by triggering crafted operations on array data structures. \n Publish Date : 2017-05-21 Last Update Date : 2017-06-01",
+            "threat": 9.8,
+            "summary": "The i_zval_ptr_dtor function in Zend\/zend_variables.h in PHP 7.1.5 allows attackers to cause a denial of service (memory consumption and application crash) or possibly have unspecified other impact by triggering crafted operations on array data structures.",
+            "lastModifiedDate": "2019-03-19T19:40:00+0000",
+            "publishedDate": "2017-05-21T19:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6751,9 +7867,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-9224",
-            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A stack out-of-bounds read occurs in match_at() during regular expression searching. A logical error involving order of validation and access in match_at() could result in an out-of-bounds read from a stack buffer. \n Publish Date : 2017-05-24 Last Update Date : 2017-06-02",
+            "threat": 9.8,
+            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A stack out-of-bounds read occurs in match_at() during regular expression searching. A logical error involving order of validation and access in match_at() could result in an out-of-bounds read from a stack buffer.",
+            "lastModifiedDate": "2018-10-31T10:30:00+0000",
+            "publishedDate": "2017-05-24T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6761,9 +7879,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-9225",
-            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A stack out-of-bounds write in onigenc_unicode_get_case_fold_codes_by_str() occurs during regular expression compilation. Code point 0xFFFFFFFF is not properly handled in unicode_unfold_key(). A malformed regular expression could result in 4 bytes being written off the end of a stack buffer of expand_case_fold_string() during the call to onigenc_unicode_get_case_fold_codes_by_str(), a typical stack buffer overflow. \n Publish Date : 2017-05-24 Last Update Date : 2017-06-02",
+            "threat": 9.8,
+            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A stack out-of-bounds write in onigenc_unicode_get_case_fold_codes_by_str() occurs during regular expression compilation. Code point 0xFFFFFFFF is not properly handled in unicode_unfold_key(). A malformed regular expression could result in 4 bytes being written off the end of a stack buffer of expand_case_fold_string() during the call to onigenc_unicode_get_case_fold_codes_by_str(), a typical stack buffer overflow.",
+            "lastModifiedDate": "2017-06-02T14:14:00+0000",
+            "publishedDate": "2017-05-24T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6771,9 +7891,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-9226",
-            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A heap out-of-bounds write or read occurs in next_state_val() during regular expression compilation. Octal numbers larger than 0xff are not handled correctly in fetch_token() and fetch_token_in_cc(). A malformed regular expression containing an octal number in the form of '\\700' would produce an invalid code point value larger than 0xff in next_state_val(), resulting in an out-of-bounds write memory corruption. \n Publish Date : 2017-05-24 Last Update Date : 2017-06-02",
+            "threat": 9.8,
+            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A heap out-of-bounds write or read occurs in next_state_val() during regular expression compilation. Octal numbers larger than 0xff are not handled correctly in fetch_token() and fetch_token_in_cc(). A malformed regular expression containing an octal number in the form of '\\700' would produce an invalid code point value larger than 0xff in next_state_val(), resulting in an out-of-bounds write memory corruption.",
+            "lastModifiedDate": "2018-10-31T10:30:00+0000",
+            "publishedDate": "2017-05-24T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6781,9 +7903,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-9227",
-            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A stack out-of-bounds read occurs in mbc_enc_len() during regular expression searching. Invalid handling of reg->dmin in forward_search_range() could result in an invalid pointer dereference, as an out-of-bounds read from a stack buffer. \n Publish Date : 2017-05-24 Last Update Date : 2017-06-02",
+            "threat": 9.8,
+            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A stack out-of-bounds read occurs in mbc_enc_len() during regular expression searching. Invalid handling of reg->dmin in forward_search_range() could result in an invalid pointer dereference, as an out-of-bounds read from a stack buffer.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-05-24T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6791,9 +7915,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-9228",
-            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A heap out-of-bounds write occurs in bitset_set_range() during regular expression compilation due to an uninitialized variable from an incorrect state transition. An incorrect state transition in parse_char_class() could create an execution path that leaves a critical local variable uninitialized until it's used as an index, resulting in an out-of-bounds write memory corruption. \n Publish Date : 2017-05-24 Last Update Date : 2017-06-02",
+            "threat": 9.8,
+            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A heap out-of-bounds write occurs in bitset_set_range() during regular expression compilation due to an uninitialized variable from an incorrect state transition. An incorrect state transition in parse_char_class() could create an execution path that leaves a critical local variable uninitialized until it's used as an index, resulting in an out-of-bounds write memory corruption.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-05-24T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6801,9 +7927,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-9229",
-            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A SIGSEGV occurs in left_adjust_char_head() during regular expression compilation. Invalid handling of reg->dmax in forward_search_range() could result in an invalid pointer dereference, normally as an immediate denial-of-service condition. \n Publish Date : 2017-05-24 Last Update Date : 2017-06-02",
+            "threat": 7.5,
+            "summary": "An issue was discovered in Oniguruma 6.2.0, as used in Oniguruma-mod in Ruby through 2.4.1 and mbstring in PHP through 7.1.5. A SIGSEGV occurs in left_adjust_char_head() during regular expression compilation. Invalid handling of reg->dmax in forward_search_range() could result in an invalid pointer dereference, normally as an immediate denial-of-service condition.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-05-24T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.6"
@@ -6811,9 +7939,11 @@
             }
         },
         {
-            "threat": "7.8",
             "cveid": "CVE-2017-11142",
-            "summary": "In PHP before 5.6.31, 7.x before 7.0.17, and 7.1.x before 7.1.3, remote attackers could cause a CPU consumption denial of service attack by injecting long form variables, related to main\/php_variables.c. \n Publish Date : 2017-07-10 Last Update Date : 2017-07-18",
+            "threat": 7.5,
+            "summary": "In PHP before 5.6.31, 7.x before 7.0.17, and 7.1.x before 7.1.3, remote attackers could cause a CPU consumption denial of service attack by injecting long form variables, related to main\/php_variables.c.",
+            "lastModifiedDate": "2018-01-14T02:29:00+0000",
+            "publishedDate": "2017-07-10T14:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.31",
@@ -6823,19 +7953,25 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-11143",
-            "summary": "In PHP before 5.6.31, an invalid free in the WDDX deserialization of boolean parameters could be used by attackers able to inject XML for deserialization to crash the PHP interpreter, related to an invalid free for an empty boolean element in ext\/wddx\/wddx.c. \n Publish Date : 2017-07-10 Last Update Date : 2017-07-17",
+            "threat": 7.5,
+            "summary": "In PHP before 5.6.31, an invalid free in the WDDX deserialization of boolean parameters could be used by attackers able to inject XML for deserialization to crash the PHP interpreter, related to an invalid free for an empty boolean element in ext\/wddx\/wddx.c.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-07-10T14:29:00+0000",
             "fixVersions": {
                 "base": [
-                    "5.6.31"
+                    "5.6.31",
+                    "7.0.22",
+                    "7.1.8"
                 ]
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-11144",
-            "summary": "In PHP before 5.6.31, 7.x before 7.0.21, and 7.1.x before 7.1.7, the openssl extension PEM sealing code did not check the return value of the OpenSSL sealing function, which could lead to a crash of the PHP interpreter, related to an interpretation conflict for a negative number in ext\/openssl\/openssl.c, and an OpenSSL documentation omission. \n Publish Date : 2017-07-10 Last Update Date : 2017-07-14",
+            "threat": 7.5,
+            "summary": "In PHP before 5.6.31, 7.x before 7.0.21, and 7.1.x before 7.1.7, the openssl extension PEM sealing code did not check the return value of the OpenSSL sealing function, which could lead to a crash of the PHP interpreter, related to an interpretation conflict for a negative number in ext\/openssl\/openssl.c, and an OpenSSL documentation omission.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-07-10T14:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.31",
@@ -6845,9 +7981,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-11145",
-            "summary": "In PHP before 5.6.31, 7.x before 7.0.21, and 7.1.x before 7.1.7, an error in the date extension's timelib_meridian parsing code could be used by attackers able to supply date strings to leak information from the interpreter, related to ext\/date\/lib\/parse_date.c out-of-bounds reads affecting the php_parse_date function. NOTE: the correct fix is in the e8b7698f5ee757ce2c8bd10a192a491a498f891c commit, not the bd77ac90d3bdf31ce2a5251ad92e9e75 gist. \n Publish Date : 2017-07-10 Last Update Date : 2017-07-23",
+            "threat": 7.5,
+            "summary": "In PHP before 5.6.31, 7.x before 7.0.21, and 7.1.x before 7.1.7, an error in the date extension's timelib_meridian parsing code could be used by attackers able to supply date strings to leak information from the interpreter, related to ext\/date\/lib\/parse_date.c out-of-bounds reads affecting the php_parse_date function. NOTE: the correct fix is in the e8b7698f5ee757ce2c8bd10a192a491a498f891c commit, not the bd77ac90d3bdf31ce2a5251ad92e9e75 gist.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-07-10T14:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.31",
@@ -6857,9 +7995,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2017-11147",
-            "summary": "In PHP before 5.6.30 and 7.x before 7.0.15, the PHAR archive handler could be used by attackers supplying malicious archive files to crash the PHP interpreter or potentially disclose information due to a buffer over-read in the phar_parse_pharfile function in ext\/phar\/phar.c. \n Publish Date : 2017-07-10 Last Update Date : 2017-07-18",
+            "threat": 9.1,
+            "summary": "In PHP before 5.6.30 and 7.x before 7.0.15, the PHAR archive handler could be used by attackers supplying malicious archive files to crash the PHP interpreter or potentially disclose information due to a buffer over-read in the phar_parse_pharfile function in ext\/phar\/phar.c.",
+            "lastModifiedDate": "2019-10-03T00:03:00+0000",
+            "publishedDate": "2017-07-10T14:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.30",
@@ -6868,9 +8008,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-11362",
-            "summary": "In PHP 7.x before 7.0.21 and 7.1.x before 7.1.7, ext\/intl\/msgformat\/msgformat_parse.c does not restrict the locale length, which allows remote attackers to cause a denial of service (stack-based buffer overflow and application crash) or possibly have unspecified other impact within International Components for Unicode (ICU) for C\/C++ via a long first argument to the msgfmt_parse_message function. \n Publish Date : 2017-07-17 Last Update Date : 2017-07-21",
+            "threat": 9.8,
+            "summary": "In PHP 7.x before 7.0.21 and 7.1.x before 7.1.7, ext\/intl\/msgformat\/msgformat_parse.c does not restrict the locale length, which allows remote attackers to cause a denial of service (stack-based buffer overflow and application crash) or possibly have unspecified other impact within International Components for Unicode (ICU) for C\/C++ via a long first argument to the msgfmt_parse_message function.",
+            "lastModifiedDate": "2019-05-22T16:29:00+0000",
+            "publishedDate": "2017-07-17T13:18:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.21",
@@ -6879,9 +8021,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2017-11628",
-            "summary": "In PHP before 5.6.31, 7.x before 7.0.21, and 7.1.x before 7.1.7, a stack-based buffer overflow in the zend_ini_do_op() function in Zend\/zend_ini_parser.c could cause a denial of service or potentially allow executing code. NOTE: this is only relevant for PHP applications that accept untrusted input (instead of the system's php.ini file) for the parse_ini_string or parse_ini_file function, e.g., a web application for syntax validation of php.ini directives. \n Publish Date : 2017-07-25 Last Update Date : 2017-08-10",
+            "threat": 7.8,
+            "summary": "In PHP before 5.6.31, 7.x before 7.0.21, and 7.1.x before 7.1.7, a stack-based buffer overflow in the zend_ini_do_op() function in Zend\/zend_ini_parser.c could cause a denial of service or potentially allow executing code. NOTE: this is only relevant for PHP applications that accept untrusted input (instead of the system's php.ini file) for the parse_ini_string or parse_ini_file function, e.g., a web application for syntax validation of php.ini directives.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-07-25T23:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.31",
@@ -6891,9 +8035,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-12932",
-            "summary": "ext\/standard\/var_unserializer.re in PHP 7.0.x through 7.0.22 and 7.1.x through 7.1.8 is prone to a heap use after free while unserializing untrusted data, related to improper use of the hash API for key deletion in a situation with an invalid array size. Exploitation of this issue can have an unspecified impact on the integrity of PHP. \n Publish Date : 2017-08-17 Last Update Date : 2018-05-03",
+            "threat": 9.8,
+            "summary": "ext\/standard\/var_unserializer.re in PHP 7.0.x through 7.0.22 and 7.1.x through 7.1.8 is prone to a heap use after free while unserializing untrusted data, related to improper use of the hash API for key deletion in a situation with an invalid array size. Exploitation of this issue can have an unspecified impact on the integrity of PHP.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-08-18T03:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.23",
@@ -6902,9 +8048,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2017-12933",
-            "summary": "The finish_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.6.31, 7.0.x before 7.0.21, and 7.1.x before 7.1.7 is prone to a buffer over-read while unserializing untrusted data. Exploitation of this issue can have an unspecified impact on the integrity of PHP. \n Publish Date : 2017-08-17 Last Update Date : 2018-05-03",
+            "threat": 9.8,
+            "summary": "The finish_nested_data function in ext\/standard\/var_unserializer.re in PHP before 5.6.31, 7.0.x before 7.0.21, and 7.1.x before 7.1.7 is prone to a buffer over-read while unserializing untrusted data. Exploitation of this issue can have an unspecified impact on the integrity of PHP.",
+            "lastModifiedDate": "2019-10-03T00:03:00+0000",
+            "publishedDate": "2017-08-18T03:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.31",
@@ -6914,9 +8062,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-12934",
-            "summary": "ext\/standard\/var_unserializer.re in PHP 7.0.x before 7.0.21 and 7.1.x before 7.1.7 is prone to a heap use after free while unserializing untrusted data, related to the zval_get_type function in Zend\/zend_types.h. Exploitation of this issue can have an unspecified impact on the integrity of PHP. \n Publish Date : 2017-08-17 Last Update Date : 2018-05-03",
+            "threat": 7.5,
+            "summary": "ext\/standard\/var_unserializer.re in PHP 7.0.x before 7.0.21 and 7.1.x before 7.1.7 is prone to a heap use after free while unserializing untrusted data, related to the zval_get_type function in Zend\/zend_types.h. Exploitation of this issue can have an unspecified impact on the integrity of PHP.",
+            "lastModifiedDate": "2018-05-04T01:29:00+0000",
+            "publishedDate": "2017-08-18T03:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.21",
@@ -6925,9 +8075,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2017-16642",
-            "summary": "In PHP before 5.6.32, 7.x before 7.0.25, and 7.1.x before 7.1.11, an error in the date extension's timelib_meridian handling of 'front of' and 'back of' directives could be used by attackers able to supply date strings to leak information from the interpreter, related to ext\/date\/lib\/parse_date.c out-of-bounds reads affecting the php_parse_date function. NOTE: this is a different issue than CVE-2017-11145. \n Publish Date : 2017-11-07 Last Update Date : 2018-11-24",
+            "threat": 7.5,
+            "summary": "In PHP before 5.6.32, 7.x before 7.0.25, and 7.1.x before 7.1.11, an error in the date extension's timelib_meridian handling of 'front of' and 'back of' directives could be used by attackers able to supply date strings to leak information from the interpreter, related to ext\/date\/lib\/parse_date.c out-of-bounds reads affecting the php_parse_date function. NOTE: this is a different issue than CVE-2017-11145.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2017-11-07T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -6943,14 +8095,17 @@
                     "5.5.39",
                     "5.6.32",
                     "7.0.25",
-                    "7.1.11"
+                    "7.1.11",
+                    "7.2.0"
                 ]
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2018-5711",
-            "summary": "gd_gif_in.c in the GD Graphics Library (aka libgd), as used in PHP before 5.6.33, 7.0.x before 7.0.27, 7.1.x before 7.1.13, and 7.2.x before 7.2.1, has an integer signedness error that leads to an infinite loop via a crafted GIF file, as demonstrated by a call to the imagecreatefromgif or imagecreatefromstring PHP function. This is related to GetCode_ and gdImageCreateFromGifCtx. \n Publish Date : 2018-01-16 Last Update Date : 2018-08-28",
+            "threat": 5.5,
+            "summary": "gd_gif_in.c in the GD Graphics Library (aka libgd), as used in PHP before 5.6.33, 7.0.x before 7.0.27, 7.1.x before 7.1.13, and 7.2.x before 7.2.1, has an integer signedness error that leads to an infinite loop via a crafted GIF file, as demonstrated by a call to the imagecreatefromgif or imagecreatefromstring PHP function. This is related to GetCode_ and gdImageCreateFromGifCtx.",
+            "lastModifiedDate": "2019-10-03T00:03:00+0000",
+            "publishedDate": "2018-01-16T09:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.33",
@@ -6961,9 +8116,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2018-5712",
-            "summary": "An issue was discovered in PHP before 5.6.33, 7.0.x before 7.0.27, 7.1.x before 7.1.13, and 7.2.x before 7.2.1. There is Reflected XSS on the PHAR 404 error page via the URI of a request for a .phar file. \n Publish Date : 2018-01-16 Last Update Date : 2018-05-16",
+            "threat": 6.1,
+            "summary": "An issue was discovered in PHP before 5.6.33, 7.0.x before 7.0.27, 7.1.x before 7.1.13, and 7.2.x before 7.2.1. There is Reflected XSS on the PHAR 404 error page via the URI of a request for a .phar file.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-01-16T09:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.33",
@@ -6974,9 +8131,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2018-7584",
-            "summary": "In PHP through 5.6.33, 7.0.x before 7.0.28, 7.1.x through 7.1.14, and 7.2.x through 7.2.2, there is a stack-based buffer under-read while parsing an HTTP response in the php_stream_url_wrap_http_ex function in ext\/standard\/http_fopen_wrapper.c. This subsequently results in copying a large string. \n Publish Date : 2018-03-01 Last Update Date : 2018-09-19",
+            "threat": 9.8,
+            "summary": "In PHP through 5.6.33, 7.0.x before 7.0.28, 7.1.x through 7.1.14, and 7.2.x through 7.2.2, there is a stack-based buffer under-read while parsing an HTTP response in the php_stream_url_wrap_http_ex function in ext\/standard\/http_fopen_wrapper.c. This subsequently results in copying a large string.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-03-01T19:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.3.30",
@@ -6990,9 +8149,11 @@
             }
         },
         {
-            "threat": "1.9",
             "cveid": "CVE-2018-10545",
-            "summary": "An issue was discovered in PHP before 5.6.35, 7.0.x before 7.0.29, 7.1.x before 7.1.16, and 7.2.x before 7.2.4. Dumpable FPM child processes allow bypassing opcache access controls because fpm_unix.c makes a PR_SET_DUMPABLE prctl call, allowing one user (in a multiuser environment) to obtain sensitive information from the process memory of a second user's PHP applications by running gcore on the PID of the PHP-FPM worker process. \n Publish Date : 2018-04-29 Last Update Date : 2018-12-03",
+            "threat": 4.7,
+            "summary": "An issue was discovered in PHP before 5.6.35, 7.0.x before 7.0.29, 7.1.x before 7.1.16, and 7.2.x before 7.2.4. Dumpable FPM child processes allow bypassing opcache access controls because fpm_unix.c makes a PR_SET_DUMPABLE prctl call, allowing one user (in a multiuser environment) to obtain sensitive information from the process memory of a second user's PHP applications by running gcore on the PID of the PHP-FPM worker process.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-04-29T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.35",
@@ -7003,9 +8164,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-10546",
-            "summary": "An issue was discovered in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. An infinite loop exists in ext\/iconv\/iconv.c because the iconv stream filter does not reject invalid multibyte sequences. \n Publish Date : 2018-04-29 Last Update Date : 2018-12-03",
+            "threat": 7.5,
+            "summary": "An issue was discovered in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. An infinite loop exists in ext\/iconv\/iconv.c because the iconv stream filter does not reject invalid multibyte sequences.",
+            "lastModifiedDate": "2019-10-03T00:03:00+0000",
+            "publishedDate": "2018-04-29T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.36",
@@ -7016,9 +8179,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2018-10547",
+            "threat": 6.1,
             "summary": "An issue was discovered in ext\/phar\/phar_object.c in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. There is Reflected XSS on the PHAR 403 and 404 error pages via request data of a request for a .phar file. NOTE: this vulnerability exists because of an incomplete fix for CVE-2018-5712.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-04-29T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.36",
@@ -7029,9 +8194,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-10548",
-            "summary": "An issue was discovered in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. ext\/ldap\/ldap.c allows remote LDAP servers to cause a denial of service (NULL pointer dereference and application crash) because of mishandling of the ldap_get_dn return value. \n Publish Date : 2018-04-29 Last Update Date : 2018-12-03",
+            "threat": 7.5,
+            "summary": "An issue was discovered in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. ext\/ldap\/ldap.c allows remote LDAP servers to cause a denial of service (NULL pointer dereference and application crash) because of mishandling of the ldap_get_dn return value.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-04-29T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.36",
@@ -7042,9 +8209,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2018-10549",
-            "summary": "An issue was discovered in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. exif_read_data in ext\/exif\/exif.c has an out-of-bounds read for crafted JPEG data because exif_iif_add_value mishandles the case of a MakerNote that lacks a final '\\0' character. \n Publish Date : 2018-04-29 Last Update Date : 2018-12-03",
+            "threat": 8.8,
+            "summary": "An issue was discovered in PHP before 5.6.36, 7.0.x before 7.0.30, 7.1.x before 7.1.17, and 7.2.x before 7.2.5. exif_read_data in ext\/exif\/exif.c has an out-of-bounds read for crafted JPEG data because exif_iif_add_value mishandles the case of a MakerNote that lacks a final '\\0' character.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-04-29T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.36",
@@ -7055,9 +8224,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2018-12882",
-            "summary": "exif_read_from_impl in ext\/exif\/exif.c in PHP 7.2.x through 7.2.7 allows attackers to trigger a use-after-free (in exif_read_from_file) because it closes a stream that it is not responsible for closing. The vulnerable code is reachable through the PHP exif_read_data function. \n Publish Date : 2018-06-25 Last Update Date : 2018-11-10",
+            "threat": 9.8,
+            "summary": "exif_read_from_impl in ext\/exif\/exif.c in PHP 7.2.x through 7.2.7 allows attackers to trigger a use-after-free (in exif_read_from_file) because it closes a stream that it is not responsible for closing. The vulnerable code is reachable through the PHP exif_read_data function.",
+            "lastModifiedDate": "2019-03-12T11:46:00+0000",
+            "publishedDate": "2018-06-26T03:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.2.8"
@@ -7065,9 +8236,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2018-14851",
-            "summary": "exif_process_IFD_in_MAKERNOTE in ext\/exif\/exif.c in PHP before 5.6.37, 7.0.x before 7.0.31, 7.1.x before 7.1.20, and 7.2.x before 7.2.8 allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted JPEG file. \n Publish Date : 2018-08-02 Last Update Date : 2018-12-11",
+            "threat": 5.5,
+            "summary": "exif_process_IFD_in_MAKERNOTE in ext\/exif\/exif.c in PHP before 5.6.37, 7.0.x before 7.0.31, 7.1.x before 7.1.20, and 7.2.x before 7.2.8 allows remote attackers to cause a denial of service (out-of-bounds read and application crash) via a crafted JPEG file.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-08-02T19:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.6.37",
@@ -7078,9 +8251,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-14883",
-            "summary": "An issue was discovered in PHP before 5.6.37, 7.0.x before 7.0.31, 7.1.x before 7.1.20, and 7.2.x before 7.2.8. An Integer Overflow leads to a heap-based buffer over-read in exif_thumbnail_extract of exif.c. \n Publish Date : 2018-08-03 Last Update Date : 2018-12-11",
+            "threat": 7.5,
+            "summary": "An issue was discovered in PHP before 5.6.37, 7.0.x before 7.0.31, 7.1.x before 7.1.20, and 7.2.x before 7.2.8. An Integer Overflow leads to a heap-based buffer over-read in exif_thumbnail_extract of exif.c.",
+            "lastModifiedDate": "2019-03-05T18:35:00+0000",
+            "publishedDate": "2018-08-03T13:29:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -7102,9 +8277,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-14884",
-            "summary": "An issue was discovered in PHP 7.0.x before 7.0.27, 7.1.x before 7.1.13, and 7.2.x before 7.2.1. Inappropriately parsing an HTTP response leads to a segmentation fault because http_header_value in ext\/standard\/http_fopen_wrapper.c can be a NULL value that is mishandled in an atoi call. \n Publish Date : 2018-08-03 Last Update Date : 2018-11-08",
+            "threat": 7.5,
+            "summary": "An issue was discovered in PHP 7.0.x before 7.0.27, 7.1.x before 7.1.13, and 7.2.x before 7.2.1. Inappropriately parsing an HTTP response leads to a segmentation fault because http_header_value in ext\/standard\/http_fopen_wrapper.c can be a NULL value that is mishandled in an atoi call.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-08-03T13:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.27",
@@ -7114,9 +8291,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-15132",
-            "summary": "An issue was discovered in ext\/standard\/link_win32.c in PHP before 5.6.37, 7.0.x before 7.0.31, 7.1.x before 7.1.20, and 7.2.x before 7.2.8. The linkinfo function on Windows doesn't implement the open_basedir check. This could be abused to find files on paths outside of the allowed directories. \n Publish Date : 2018-08-07 Last Update Date : 2018-11-08",
+            "threat": 7.5,
+            "summary": "An issue was discovered in ext\/standard\/link_win32.c in PHP before 5.6.37, 7.0.x before 7.0.31, 7.1.x before 7.1.20, and 7.2.x before 7.2.8. The linkinfo function on Windows doesn't implement the open_basedir check. This could be abused to find files on paths outside of the allowed directories.",
+            "lastModifiedDate": "2019-03-08T13:30:00+0000",
+            "publishedDate": "2018-08-07T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -7138,9 +8317,11 @@
             }
         },
         {
-            "threat": "4.3",
             "cveid": "CVE-2018-17082",
-            "summary": "The Apache2 component in PHP before 5.6.38, 7.0.x before 7.0.32, 7.1.x before 7.1.22, and 7.2.x before 7.2.10 allows XSS via the body of a \"Transfer-Encoding: chunked\" request, because the bucket brigade is mishandled in the php_handler function in sapi\/apache2handler\/sapi_apache2.c. \n Publish Date : 2018-09-16 Last Update Date : 2018-12-11",
+            "threat": 6.1,
+            "summary": "The Apache2 component in PHP before 5.6.38, 7.0.x before 7.0.32, 7.1.x before 7.1.22, and 7.2.x before 7.2.10 allows XSS via the body of a \"Transfer-Encoding: chunked\" request, because the bucket brigade is mishandled in the php_handler function in sapi\/apache2handler\/sapi_apache2.c.",
+            "lastModifiedDate": "2019-08-19T11:15:00+0000",
+            "publishedDate": "2018-09-16T15:29:00+0000",
             "fixVersions": {
                 "base": [
                     "4.0.8",
@@ -7162,9 +8343,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-19395",
-            "summary": "ext\/standard\/var.c in PHP 5.x through 7.1.24 on Windows allows attackers to cause a denial of service (NULL pointer dereference and application crash) because com and com_safearray_proxy return NULL in com_properties_get in ext\/com_dotnet\/com_handlers.c, as demonstrated by a serialize call on COM(\"WScript.Shell\"). \n Publish Date : 2018-11-20 Last Update Date : 2018-12-27",
+            "threat": 7.5,
+            "summary": "ext\/standard\/var.c in PHP 5.x through 7.1.24 on Windows allows attackers to cause a denial of service (NULL pointer dereference and application crash) because com and com_safearray_proxy return NULL in com_properties_get in ext\/com_dotnet\/com_handlers.c, as demonstrated by a serialize call on COM(\"WScript.Shell\").",
+            "lastModifiedDate": "2018-12-27T17:13:00+0000",
+            "publishedDate": "2018-11-20T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -7180,9 +8363,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-19396",
-            "summary": "ext\/standard\/var_unserializer.c in PHP 5.x through 7.1.24 allows attackers to cause a denial of service (application crash) via an unserialize call for the com, dotnet, or variant class. \n Publish Date : 2018-11-20 Last Update Date : 2019-01-02",
+            "threat": 7.5,
+            "summary": "ext\/standard\/var_unserializer.c in PHP 5.x through 7.1.24 allows attackers to cause a denial of service (application crash) via an unserialize call for the com, dotnet, or variant class.",
+            "lastModifiedDate": "2019-10-03T00:03:00+0000",
+            "publishedDate": "2018-11-20T21:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -7198,11 +8383,14 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2018-19518",
+            "threat": 7.5,
             "summary": "University of Washington IMAP Toolkit 2007f on UNIX, as used in imap_open() in PHP and other products, launches an rsh command (by means of the imap_rimap function in c-client\/imap4r1.c and the tcp_aopen function in osdep\/unix\/tcp_unix.c) without preventing argument injection, which might allow remote attackers to execute arbitrary OS commands if the IMAP server name is untrusted input (e.g., entered by a user of a web application) and if rsh has been replaced by a program with different argument semantics. For example, if rsh is a link to ssh (as seen on Debian and Ubuntu systems), then the attack can use an IMAP server name containing a \"-oProxyCommand\" argument.",
+            "lastModifiedDate": "2019-10-21T23:15:00+0000",
+            "publishedDate": "2018-11-25T10:29:00+0000",
             "fixVersions": {
                 "base": [
+                    "5.6.39",
                     "7.0.33",
                     "7.1.25",
                     "7.2.13",
@@ -7211,9 +8399,11 @@
             }
         },
         {
-            "threat": "5.0",
             "cveid": "CVE-2018-19935",
-            "summary": "ext\/imap\/php_imap.c in PHP 5.x and 7.x before 7.3.0 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via an empty string in the message argument to the imap_mail function. \n Publish Date : 2018-12-07 Last Update Date : 2018-12-31",
+            "threat": 7.5,
+            "summary": "ext\/imap\/php_imap.c in PHP 5.x and 7.x before 7.3.0 allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via an empty string in the message argument to the imap_mail function.",
+            "lastModifiedDate": "2019-06-18T18:15:00+0000",
+            "publishedDate": "2018-12-07T09:29:00+0000",
             "fixVersions": {
                 "base": [
                     "5.0.6",
@@ -7230,9 +8420,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2018-20783",
+            "threat": 7.5,
             "summary": "In PHP before 5.6.39, 7.x before 7.0.33, 7.1.x before 7.1.25, and 7.2.x before 7.2.13, a buffer over-read in PHAR reading functions may allow an attacker to read allocated or unallocated memory past the actual data when trying to parse a .phar file. This is related to phar_parse_pharfile in ext\/phar\/phar.c.",
+            "lastModifiedDate": "2019-05-22T15:29:00+0000",
+            "publishedDate": "2019-02-21T19:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.0.33",
@@ -7243,9 +8435,11 @@
             }
         },
         {
-            "threat": "8.8",
             "cveid": "CVE-2019-6977",
+            "threat": 8.8,
             "summary": "gdImageColorMatch in gd_color_match.c in the GD Graphics Library (aka LibGD) 2.2.5, as used in the imagecolormatch function in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1, has a heap-based buffer overflow. This can be exploited by an attacker who is able to trigger imagecolormatch calls with crafted image data.",
+            "lastModifiedDate": "2019-04-10T18:29:00+0000",
+            "publishedDate": "2019-01-27T02:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.26",
@@ -7255,9 +8449,11 @@
             }
         },
         {
-            "threat": "9.8",
             "cveid": "CVE-2019-9020",
+            "threat": 9.8,
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. Invalid input to the function xmlrpc_decode() can lead to an invalid memory access (heap out of bounds read or read after free). This is related to xml_elem_parse_buf in ext\/xmlrpc\/libxmlrpc\/xml_element.c.",
+            "lastModifiedDate": "2019-06-18T18:15:00+0000",
+            "publishedDate": "2019-02-22T23:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.26",
@@ -7267,9 +8463,11 @@
             }
         },
         {
-            "threat": "9.8",
             "cveid": "CVE-2019-9021",
+            "threat": 9.8,
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A heap-based buffer over-read in PHAR reading functions in the PHAR extension may allow an attacker to read allocated or unallocated memory past the actual data when trying to parse the file name, a different vulnerability than CVE-2018-20783. This is related to phar_detect_phar_fname_ext in ext\/phar\/phar.c.",
+            "lastModifiedDate": "2019-06-18T18:15:00+0000",
+            "publishedDate": "2019-02-22T23:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.26",
@@ -7279,9 +8477,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2019-9022",
+            "threat": 7.5,
             "summary": "An issue was discovered in PHP 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.2. dns_get_record misparses a DNS response, which can allow a hostile DNS server to cause PHP to misuse memcpy, leading to read operations going past the buffer allocated for DNS data. This affects php_parserr in ext\/standard\/dns.c for DNS_CAA and DNS_ANY queries.",
+            "lastModifiedDate": "2019-06-18T18:15:00+0000",
+            "publishedDate": "2019-02-22T23:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.26",
@@ -7291,9 +8491,11 @@
             }
         },
         {
-            "threat": "9.8",
             "cveid": "CVE-2019-9023",
+            "threat": 9.8,
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. A number of heap-based buffer over-read instances are present in mbstring regular expression functions when supplied with invalid multibyte data. These occur in ext\/mbstring\/oniguruma\/regcomp.c, ext\/mbstring\/oniguruma\/regexec.c, ext\/mbstring\/oniguruma\/regparse.c, ext\/mbstring\/oniguruma\/enc\/unicode.c, and ext\/mbstring\/oniguruma\/src\/utf32_be.c when a multibyte regular expression pattern contains invalid multibyte sequences.",
+            "lastModifiedDate": "2019-06-18T18:15:00+0000",
+            "publishedDate": "2019-02-22T23:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.26",
@@ -7303,9 +8505,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2019-9024",
+            "threat": 7.5,
             "summary": "An issue was discovered in PHP before 5.6.40, 7.x before 7.1.26, 7.2.x before 7.2.14, and 7.3.x before 7.3.1. xmlrpc_decode() can allow a hostile XMLRPC server to cause PHP to read memory outside of allocated areas in base64_decode_xmlrpc in ext\/xmlrpc\/libxmlrpc\/base64.c.",
+            "lastModifiedDate": "2019-06-18T18:15:00+0000",
+            "publishedDate": "2019-02-22T23:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.26",
@@ -7315,9 +8519,11 @@
             }
         },
         {
-            "threat": "9.8",
             "cveid": "CVE-2019-9025",
+            "threat": 9.8,
             "summary": "An issue was discovered in PHP 7.3.x before 7.3.1. An invalid multibyte string supplied as an argument to the mb_split() function in ext\/mbstring\/php_mbregex.c can cause PHP to execute memcpy() with a negative argument, which could read and write past buffers allocated for the data.",
+            "lastModifiedDate": "2019-04-17T13:57:00+0000",
+            "publishedDate": "2019-02-22T23:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.3.1"
@@ -7325,9 +8531,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2019-9637",
+            "threat": 7.5,
             "summary": "An issue was discovered in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. Due to the way rename() across filesystems is implemented, it is possible that file being renamed is briefly available with wrong permissions while the rename is ongoing, thus enabling unauthorized users to access the data.",
+            "lastModifiedDate": "2019-06-03T15:29:00+0000",
+            "publishedDate": "2019-03-09T00:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.27",
@@ -7337,9 +8545,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2019-9638",
+            "threat": 7.5,
             "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an uninitialized read in exif_process_IFD_in_MAKERNOTE because of mishandling the maker_note->offset relationship to value_len.",
+            "lastModifiedDate": "2019-06-03T15:29:00+0000",
+            "publishedDate": "2019-03-09T00:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.27",
@@ -7349,9 +8559,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2019-9639",
+            "threat": 7.5,
             "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an uninitialized read in exif_process_IFD_in_MAKERNOTE because of mishandling the data_len variable.",
+            "lastModifiedDate": "2019-06-03T15:29:00+0000",
+            "publishedDate": "2019-03-09T00:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.27",
@@ -7361,9 +8573,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2019-9640",
+            "threat": 7.5,
             "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an Invalid Read in exif_process_SOFn.",
+            "lastModifiedDate": "2019-06-03T15:29:00+0000",
+            "publishedDate": "2019-03-09T00:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.27",
@@ -7373,9 +8587,11 @@
             }
         },
         {
-            "threat": "9.8",
             "cveid": "CVE-2019-9641",
+            "threat": 9.8,
             "summary": "An issue was discovered in the EXIF component in PHP before 7.1.27, 7.2.x before 7.2.16, and 7.3.x before 7.3.3. There is an uninitialized read in exif_process_IFD_in_TIFF.",
+            "lastModifiedDate": "2019-06-18T18:15:00+0000",
+            "publishedDate": "2019-03-09T00:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.27",
@@ -7385,9 +8601,11 @@
             }
         },
         {
-            "threat": "9.1",
             "cveid": "CVE-2019-11034",
+            "threat": 9.1,
             "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.28, 7.2.x below 7.2.17 and 7.3.x below 7.3.4 can be caused to read past allocated buffer in exif_process_IFD_TAG function. This may lead to information disclosure or crash.",
+            "lastModifiedDate": "2019-06-03T15:29:00+0000",
+            "publishedDate": "2019-04-18T17:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.28",
@@ -7397,9 +8615,11 @@
             }
         },
         {
-            "threat": "9.1",
             "cveid": "CVE-2019-11035",
+            "threat": 9.1,
             "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.28, 7.2.x below 7.2.17 and 7.3.x below 7.3.4 can be caused to read past allocated buffer in exif_iif_add_value function. This may lead to information disclosure or crash.",
+            "lastModifiedDate": "2019-06-03T15:29:00+0000",
+            "publishedDate": "2019-04-18T17:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.28",
@@ -7409,9 +8629,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2019-11036",
+            "threat": 9.1,
             "summary": "When processing certain files, PHP EXIF extension in versions 7.1.x below 7.1.29, 7.2.x below 7.2.18 and 7.3.x below 7.3.5 can be caused to read past allocated buffer in exif_process_IFD_TAG function. This may lead to information disclosure or crash.",
+            "lastModifiedDate": "2019-06-05T18:29:00+0000",
+            "publishedDate": "2019-05-03T20:29:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.29",
@@ -7421,9 +8643,11 @@
             }
         },
         {
-            "threat": "6.4",
             "cveid": "CVE-2019-11040",
+            "threat": 9.1,
             "summary": "When PHP EXIF extension is parsing EXIF information from an image, e.g. via exif_read_data() function, in PHP versions 7.1.x below 7.1.30, 7.2.x below 7.2.19 and 7.3.x below 7.3.6 it is possible to supply it with data what will cause it to read past the allocated buffer. This may lead to information disclosure or crash.",
+            "lastModifiedDate": "2019-06-20T22:15:00+0000",
+            "publishedDate": "2019-06-19T00:15:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.30",
@@ -7433,9 +8657,11 @@
             }
         },
         {
-            "threat": "6.8",
             "cveid": "CVE-2019-11042",
+            "threat": 7.1,
             "summary": "When PHP EXIF extension is parsing EXIF information from an image, e.g. via exif_read_data() function, in PHP versions 7.1.x below 7.1.31, 7.2.x below 7.2.21 and 7.3.x below 7.3.8 it is possible to supply it with data what will cause it to read past the allocated buffer. This may lead to information disclosure or crash.",
+            "lastModifiedDate": "2019-11-01T07:15:00+0000",
+            "publishedDate": "2019-08-09T20:15:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.31",
@@ -7445,9 +8671,11 @@
             }
         },
         {
-            "threat": "9.8",
             "cveid": "CVE-2019-11043",
+            "threat": 9.8,
             "summary": "In PHP versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 in certain configurations of FPM setup it is possible to cause FPM module to write past allocated buffers into the space reserved for FCGI protocol data, thus opening the possibility of remote code execution.",
+            "lastModifiedDate": "2019-10-30T20:15:00+0000",
+            "publishedDate": "2019-10-28T15:15:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.33",
@@ -7457,9 +8685,11 @@
             }
         },
         {
-            "threat": "7.5",
             "cveid": "CVE-2019-13224",
+            "threat": 9.8,
             "summary": "A use-after-free in onig_new_deluxe() in regext.c in Oniguruma 6.9.2 allows attackers to potentially cause information disclosure, denial of service, or possibly code execution by providing a crafted regular expression. The attacker provides a pair of a regex pattern and a string, with a multi-byte encoding that gets handled by onig_new_deluxe(). Oniguruma issues often affect Ruby, as well as common optional libraries for PHP and Rust.",
+            "lastModifiedDate": "2019-07-17T18:15:00+0000",
+            "publishedDate": "2019-07-10T14:15:00+0000",
             "fixVersions": {
                 "base": [
                     "7.1.32",
@@ -7468,5 +8698,5 @@
             }
         }
     ],
-    "updatedAt": "2019-10-28T12:41:39+00:00"
+    "updatedAt": "2019-11-20T13:28:05+00:00"
 }

--- a/tests/Psecio/Versionscan/CheckFormatTest.php
+++ b/tests/Psecio/Versionscan/CheckFormatTest.php
@@ -29,7 +29,10 @@ class CheckFormatTest extends \PHPUnit_Framework_TestCase
             $this->assertArrayHasKey('threat', $check, 'Missing "threat" for ' . $id);
             $this->assertArrayHasKey('summary', $check, 'Missing "summary" for ' . $id);
             $this->assertArrayHasKey('fixVersions', $check, 'Missing "fixVersions" for ' . $id);
+            $this->assertArrayHasKey('lastModifiedDate', $check, 'Missing "lastModifiedDate" for ' . $id);
+            $this->assertArrayHasKey('publishedDate', $check, 'Missing "publishedDate" for ' . $id);
             $this->assertArrayHasKey('base', $check['fixVersions'], 'Missing "fixVersions[base]" for ' . $id);
+            $this->assertNotEmpty($check['fixVersions']['base'], 'Missing "fixVersions[base]" for ' . $id);
 
             // Make sure the versions are in order
             $versions = $check['fixVersions']['base'];


### PR DESCRIPTION
Using published JSON data feeds from NIST (instead of cvedetails.com) allows for more reliable parsing of CVE details and removes the dependency on `kub-at/php-simple-html-dom-parser`. Having a more reliable data source for CVE details will allow for further automation in the near future.

Since we now have a reliable way to parse CVE details, I've included a couple new attributes to the CVE check: lastModifiedDate and publishedDate. The values are not being used anywhere at the moment, but it might aid in pull-request review where CVE details have been modified. Also, the old CVE source commonly included those values in the summary.

Finally, I've changed the check.json 'threat' datatype from a string to float. I believe the float datatype is more appropriate, and the change was able to be made without having any compatibility issues with the scan logic. I believe there is a need to allow checks to be released prior to a threat value being assigned - in which case threat would be set to null.